### PR TITLE
Set up basic client structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "miden-client"
+version = "0.1.0"
+authors = ["miden contributors"]
+readme = "README.md"
+license = "MIT"
+repository = "https://github.com/0xPolygonMiden/miden-client"
+keywords = ["miden", "client"]
+edition = "2021"
+rust-version = "1.67"
+
+[features]
+default = ["std"]
+std = ["crypto/std", "objects/std"]
+
+[dependencies]
+clap = { version = "4.3" , features = ["derive"] }
+crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+lazy_static = "1.4.0"
+objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+rusqlite = { version = "0.29.0", features = ["bundled"] }
+rusqlite_migration = { version = "1.0" }

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -1,0 +1,53 @@
+use clap::Parser;
+use miden_client::{Client, ClientConfig};
+
+// ACCOUNT COMMAND
+// ================================================================================================
+
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "View accounts and account details")]
+pub struct AccountCmd {
+    /// List all accounts monitored by this client
+    #[clap(short = 'l', long = "list")]
+    list: bool,
+
+    /// View details of the account for the specified ID
+    #[clap(short = 'v', long = "view", value_name = "ID")]
+    view: Option<String>,
+}
+
+impl AccountCmd {
+    pub fn execute(&self) -> Result<(), String> {
+        println!("list: {}", self.list);
+        println!("view: {:?}", self.view);
+        list_accounts();
+        Ok(())
+    }
+}
+
+// LIST ACCOUNTS
+// ================================================================================================
+
+pub fn list_accounts() {
+    println!("{}", "-".repeat(240));
+    println!(
+        "{0: <18} | {1: <66} | {2: <66} | {3: <66} | {4: <15}",
+        "account id", "code root", "vault root", "storage root", "nonce",
+    );
+    println!("{}", "-".repeat(240));
+
+    let client = Client::new(ClientConfig::default()).unwrap();
+    let accounts = client.get_accounts().unwrap();
+
+    for acct in accounts {
+        println!(
+            "{0: <18} | {1: <66} | {2: <66} | {3: <66} | {4: <15}",
+            acct.id(),
+            acct.code_root(),
+            acct.vault_root(),
+            acct.storage_root(),
+            acct.nonce(),
+        );
+    }
+    println!("{}", "-".repeat(240));
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,31 @@
+use clap::Parser;
+
+mod account;
+
+/// Root CLI struct
+#[derive(Parser, Debug)]
+#[clap(
+    name = "Miden",
+    about = "Miden Client",
+    version,
+    rename_all = "kebab-case"
+)]
+pub struct Cli {
+    #[clap(subcommand)]
+    action: Command,
+}
+
+/// CLI entry point
+impl Cli {
+    pub fn execute(&self) -> Result<(), String> {
+        match &self.action {
+            Command::Account(account) => account.execute(),
+        }
+    }
+}
+
+/// CLI actions
+#[derive(Debug, Parser)]
+pub enum Command {
+    Account(account::AccountCmd),
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,50 @@
+use core::fmt;
+
+// CLIENT ERROR
+// ================================================================================================
+
+#[derive(Debug, PartialEq)]
+pub enum ClientError {
+    StoreError(StoreError),
+}
+
+impl fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ClientError::StoreError(err) => write!(f, "store error: {err}"),
+        }
+    }
+}
+
+impl From<StoreError> for ClientError {
+    fn from(err: StoreError) -> Self {
+        Self::StoreError(err)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ClientError {}
+
+// STORE ERROR
+// ================================================================================================
+
+#[derive(Debug, PartialEq)]
+pub enum StoreError {
+    ConnectionError(rusqlite::Error),
+    MigrationError(rusqlite_migration::Error),
+    QueryError(rusqlite::Error),
+}
+
+impl fmt::Display for StoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use StoreError::*;
+        match self {
+            ConnectionError(err) => write!(f, "failed to connect to the database: {err}"),
+            MigrationError(err) => write!(f, "failed to update the database: {err}"),
+            QueryError(err) => write!(f, "failed to retrieve data from the database: {err}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for StoreError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,121 @@
+use objects::{Account, AccountId, AccountStub};
+use std::path::PathBuf;
+
+mod store;
+use store::Store;
+
+pub mod errors;
+use errors::ClientError;
+
+// MIDEN CLIENT
+// ================================================================================================
+
+/// A light client for connecting to the Miden rollup network.
+///
+/// Miden client is responsible for managing a set of accounts. Specifically, the client:
+/// - Keeps track of the current and historical states of a set of accounts and related objects
+///   such as notes and transactions.
+/// - Connects to one or more Miden nodes to periodically sync with the current state of the
+///   network.
+/// - Executes, proves, and submits transactions to the network as directed by the user.
+pub struct Client {
+    /// Local database containing information about the accounts managed by this client.
+    store: Store,
+    // TODO
+    // node: connection to Miden node
+}
+
+impl Client {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a new instance of [Client] instantiated with the specified configuration options.
+    ///
+    /// # Errors
+    /// Returns an error if the client could not be instantiated.
+    pub fn new(config: ClientConfig) -> Result<Self, ClientError> {
+        Ok(Self {
+            store: Store::new((&config).into())?,
+        })
+    }
+
+    // DATA RETRIEVAL
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns summary info about the accounts managed by this client.
+    ///
+    /// TODO: replace `AccountStub` with a more relevant structure.
+    pub fn get_accounts(&self) -> Result<Vec<AccountStub>, ClientError> {
+        self.store.get_accounts().map_err(|err| err.into())
+    }
+
+    /// Returns historical states for the account with the specified ID.
+    ///
+    /// TODO: wrap `Account` in a type with additional info.
+    /// TODO: consider changing the interface to support pagination.
+    pub fn get_account_history(&self, _account_id: AccountId) -> Result<Vec<Account>, ClientError> {
+        todo!()
+    }
+
+    /// Returns detailed information about the current state of the account with the specified ID.
+    ///
+    /// TODO: wrap `Account` in a type with additional info (e.g., status).
+    /// TODO: consider adding `nonce` as another parameter to identify a specific account state.
+    pub fn get_account_details(&self, _account_id: AccountId) -> Result<Account, ClientError> {
+        todo!()
+    }
+
+    // TODO: add methods for retrieving note and transaction info, and for creating/executing
+    // transaction
+}
+
+// CLIENT CONFIG
+// ================================================================================================
+
+/// Configuration options of Miden client.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ClientConfig {
+    /// Location of the client's data file.
+    store_path: String,
+    /// Address of the Miden node to connect to.
+    node_endpoint: Endpoint,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        const STORE_FILENAME: &str = "store.sqlite3";
+
+        // get directory of the currently executing binary, or fallback to the current directory
+        let exec_dir = match std::env::current_exe() {
+            Ok(mut path) => {
+                path.pop();
+                path
+            }
+            Err(_) => PathBuf::new(),
+        };
+
+        let store_path = exec_dir.join(STORE_FILENAME);
+
+        Self {
+            store_path: store_path.into_os_string().into_string().unwrap(),
+            node_endpoint: Endpoint::default(),
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct Endpoint {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Default for Endpoint {
+    fn default() -> Self {
+        const MIDEN_NODE_PORT: u16 = 57291;
+
+        Self {
+            host: "localhost".to_string(),
+            port: MIDEN_NODE_PORT,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+
+mod cli;
+use cli::Cli;
+
+fn main() {
+    // read command-line args
+    let cli = Cli::parse();
+
+    // execute cli action
+    if let Err(error) = cli.execute() {
+        println!("{}", error);
+    }
+}

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -1,0 +1,30 @@
+use lazy_static::lazy_static;
+use rusqlite::{params, Connection};
+use rusqlite_migration::{Migrations, M};
+
+use super::StoreError;
+
+// MIGRATIONS
+// ================================================================================================
+
+lazy_static! {
+    static ref MIGRATIONS: Migrations<'static> =
+        Migrations::new(vec![M::up(include_str!("store.sql")),]);
+}
+
+// PUBLIC FUNCTIONS
+// ================================================================================================
+
+pub fn update_to_latest(conn: &mut Connection) -> Result<(), StoreError> {
+    MIGRATIONS
+        .to_latest(conn)
+        .map_err(StoreError::MigrationError)
+}
+
+pub fn insert_mock_data(conn: &Connection) {
+    conn.execute(
+        "INSERT INTO accounts (id, nonce, status) VALUES (?1, 1234, 1)",
+        params!["3972335011818762557"],
+    )
+    .unwrap();
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,0 +1,62 @@
+use super::{errors::StoreError, AccountStub, ClientConfig};
+use crypto::{hash::rpo::Rpo256, Felt};
+use rusqlite::Connection;
+
+mod migrations;
+
+// CLIENT STORE
+// ================================================================================================
+
+pub struct Store {
+    db: Connection,
+}
+
+impl Store {
+    pub fn new(config: StoreConfig) -> Result<Self, StoreError> {
+        let mut db = Connection::open(config.path).map_err(StoreError::ConnectionError)?;
+        migrations::update_to_latest(&mut db)?;
+        migrations::insert_mock_data(&db);
+
+        Ok(Self { db })
+    }
+
+    pub fn get_accounts(&self) -> Result<Vec<AccountStub>, StoreError> {
+        let mut stmt = self
+            .db
+            .prepare("SELECT id, nonce FROM accounts")
+            .map_err(StoreError::QueryError)?;
+
+        let mut rows = stmt.query([]).map_err(StoreError::QueryError)?;
+        let mut result = Vec::new();
+        while let Some(row) = rows.next().map_err(StoreError::QueryError)? {
+            // TODO: implement proper error handling and conversions
+            let id: u64 = row.get(0).unwrap();
+            let nonce: u64 = row.get(1).unwrap();
+
+            result.push(AccountStub::new(
+                id.try_into().unwrap(),
+                nonce.into(),
+                Rpo256::hash_elements(&[Felt::new(2)]),
+                Rpo256::hash_elements(&[Felt::new(3)]),
+                Rpo256::hash_elements(&[Felt::new(4)]),
+            ));
+        }
+
+        Ok(result)
+    }
+}
+
+// STORE CONFIG
+// ================================================================================================
+
+pub struct StoreConfig {
+    path: String,
+}
+
+impl From<&ClientConfig> for StoreConfig {
+    fn from(config: &ClientConfig) -> Self {
+        Self {
+            path: config.store_path.clone(),
+        }
+    }
+}

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -1,0 +1,5 @@
+CREATE TABLE accounts(
+    id INTEGER NOT NULL,
+    nonce INTEGER NOT NULL,
+    status INTEGER NOT NULL
+);


### PR DESCRIPTION
This PR sets up basic client structure. This consists of:

- Defining initial `Client` struct.
- Setting up basic database structure (via `Store` struct).
- Setting up basic CLI structure.

The idea is that we can execute a single end-to-end CLI command: "list accounts". This command retrieves a list of accounts from the sqlite database and prints them to the screen. The contents and formatting of what is printed is not important for this PR.