### PR TITLE
fix: state sync panics on no data

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -31,12 +31,15 @@ impl MockRpcApi {
         request: impl tonic::IntoRequest<SyncStateRequest>,
     ) -> std::result::Result<tonic::Response<SyncStateResponse>, tonic::Status> {
         let request = request.into_request().into_inner();
-        let response = self
-            .sync_state_requests
-            .get(&request)
-            .expect("no response for sync state request")
-            .clone();
-        Ok(tonic::Response::new(response))
+        match self.sync_state_requests.get(&request) {
+            Some(response) => {
+                let response = response.clone();
+                Ok(tonic::Response::new(response))
+            }
+            None => Err(tonic::Status::not_found(
+                "no response for sync state request",
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
Current implementation `panics` when the following command is ran:
`cargo run --features testing -- sync-state -s`
And the database doesn't hold any contents to sync, the resulting output is:
```
thread 'main' panicked at /home/juan518/Coding/miden-client/src/mock.rs:37:14:
no response for sync state request
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Output with the applied fix is now:
```
rpc api error: rpc request failed: status: NotFound, message: "no response for sync state request", details: [], metadata: MetadataMap { headers: {} }
```
Whic is a `tonic::Status::not_found` error wrapped inside a `ClientError::RpcApiError(errors::RpcApiError::RequestError(err)`.