### PR TITLE
fix: Mock functions input & output parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ comfy-table = "7.1.0"
 [dev-dependencies]
 uuid = { version = "1.6.1", features = ["serde", "v4"] }
 mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,3 @@ comfy-table = "7.1.0"
 [dev-dependencies]
 uuid = { version = "1.6.1", features = ["serde", "v4"] }
 mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
-vm-processor = { package = "miden-processor", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,6 +375,7 @@ mod tests {
         notes::AssetPreservationStatus,
         transaction::mock_inputs,
     };
+    use vm_processor::AdviceInputs;
 
     #[tokio::test]
     async fn test_input_notes_round_trip() {
@@ -390,7 +391,7 @@ mod tests {
         .unwrap();
 
         // generate test data
-        let (_, _, _, recorded_notes) = mock_inputs(
+        let (_, _, _, recorded_notes, _) = mock_inputs(
             MockAccountType::StandardExisting,
             AssetPreservationStatus::Preserved,
         );
@@ -421,7 +422,7 @@ mod tests {
         .unwrap();
 
         // generate test data
-        let (_, _, _, recorded_notes) = mock_inputs(
+        let (_, _, _, recorded_notes, _) = mock_inputs(
             MockAccountType::StandardExisting,
             AssetPreservationStatus::Preserved,
         );
@@ -452,7 +453,8 @@ mod tests {
         .unwrap();
 
         let assembler = assembler();
-        let account = account::mock_new_account(&assembler);
+        let mut auxiliary_data = AdviceInputs::default();
+        let account = account::mock_new_account(&assembler, &mut auxiliary_data);
 
         let key_pair: KeyPair = KeyPair::new()
             .map_err(|err| format!("Error generating KeyPair: {}", err))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ mod tests {
         notes::AssetPreservationStatus,
         transaction::mock_inputs,
     };
-    use vm_processor::AdviceInputs;
+    use objects::AdviceInputs;
 
     #[tokio::test]
     async fn test_input_notes_round_trip() {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -31,12 +31,15 @@ impl MockRpcApi {
         request: impl tonic::IntoRequest<SyncStateRequest>,
     ) -> std::result::Result<tonic::Response<SyncStateResponse>, tonic::Status> {
         let request = request.into_request().into_inner();
-        let response = self
-            .sync_state_requests
-            .get(&request)
-            .expect("no response for sync state request")
-            .clone();
-        Ok(tonic::Response::new(response))
+        match self.sync_state_requests.get(&request) {
+            Some(response) => {
+                let response = response.clone();
+                Ok(tonic::Response::new(response))
+            }
+            None => Err(tonic::Status::not_found(
+                "no response for sync state request",
+            )),
+        }
     }
 }
 
@@ -47,7 +50,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
     };
 
     // generate test data
-    let (account, _, _, recorded_notes) = mock_inputs(
+    let (account, _, _, recorded_notes, _) = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
@@ -97,7 +100,7 @@ pub fn insert_mock_data(client: &mut Client) {
     };
 
     // generate test data
-    let (account, _, _, recorded_notes) = mock_inputs(
+    let (account, _, _, recorded_notes, _) = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );


### PR DESCRIPTION
Closes #53 

Minimal changes to calls to `mock_inputs` and `mock_new_account` to accomodate `miden-base` mock modifications. Add's `vm-processor` as a dev dependency.

(this PR has changes from #52 applied, it should be merged before this one)