### PR TITLE
fix: Account id parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,10 @@ mod tests {
         notes::AssetPreservationStatus,
         transaction::mock_inputs,
     };
-    use objects::{accounts::AccountId, AdviceInputs};
+    use objects::{
+        accounts::{AccountId, AccountStub},
+        AdviceInputs,
+    };
 
     #[tokio::test]
     async fn test_input_notes_round_trip() {
@@ -465,7 +468,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_account_id_retrieval() {
+    async fn test_get_account_by_id() {
         // generate test store path
         let store_path = create_test_store_path();
 
@@ -488,11 +491,11 @@ mod tests {
         client.insert_account(&account, &key_pair).unwrap();
 
         // Retrieving an existing account should succeed
-        let actual = match client.get_account_by_id(account.id()) {
+        let acc_from_db = match client.get_account_by_id(account.id()) {
             Ok(account) => account,
             Err(err) => panic!("Error retrieving account: {}", err),
         };
-        assert_eq!(account.id(), actual.id());
+        assert_eq!(AccountStub::from(account), acc_from_db);
 
         // Retrieving a non existing account should fail
         let hex = format!("0x{}", "1".repeat(16));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,9 @@ mod tests {
         let store_path = create_test_store_path();
 
         // generate test client
-        let mut client = super::Client::new(super::ClientConfig::new(
+        let mut client = Client::new(ClientConfig::new(
             store_path.into_os_string().into_string().unwrap(),
-            super::Endpoint::default(),
+            Endpoint::default(),
         ))
         .await
         .unwrap();

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -50,7 +50,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
     };
 
     // generate test data
-    let (account, _, _, recorded_notes) = mock_inputs(
+    let (account, _, _, recorded_notes, _) = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
@@ -100,7 +100,7 @@ pub fn insert_mock_data(client: &mut Client) {
     };
 
     // generate test data
-    let (account, _, _, recorded_notes) = mock_inputs(
+    let (account, _, _, recorded_notes, _) = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -72,7 +72,7 @@ impl Store {
             .map(|result| {
                 result
                     .map_err(StoreError::ColumnParsingError)
-                    .map(|id: u64| AccountId::try_from(id).expect("account id is valid"))
+                    .map(|id: i64| AccountId::try_from(id as u64).expect("account id is valid"))
             })
             .collect::<Result<Vec<AccountId>, _>>()
     }


### PR DESCRIPTION
Closes https://github.com/0xPolygonMiden/miden-client/issues/55

Modify get_account_ids to correctly parse data retrieved from database. Added a couple of unit tests to verify it works as expected.