### PR TITLE
fix: Prevent tracking duplicate note tags

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -84,7 +84,14 @@ impl Client {
 
     /// Adds a note tag for the client to track.
     pub fn add_note_tag(&mut self, tag: u64) -> Result<(), ClientError> {
-        self.store.add_note_tag(tag).map_err(|err| err.into())
+        match self.store.add_note_tag(tag).map_err(|err| err.into()) {
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                println!("tag {} is already being tracked", tag);
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Syncs the client's state with the current state of the Miden network.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,7 @@ pub enum StoreError {
     InputNoteNotFound(Digest),
     MigrationError(rusqlite_migration::Error),
     TransactionError(rusqlite::Error),
+    NoteTagAlreadyTracked(u64),
 }
 
 impl fmt::Display for StoreError {
@@ -86,6 +87,7 @@ impl fmt::Display for StoreError {
             AccountCodeDataNotFound(root) => {
                 write!(f, "account code data with root {} not found", root)
             }
+            NoteTagAlreadyTracked(tag) => write!(f, "note tag {} is already being tracked", tag),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,5 +247,14 @@ mod tests {
             client.get_note_tags().unwrap(),
             vec![TAG_VALUE_1, TAG_VALUE_2]
         );
+
+        // attempt to add the same tag again
+        client.add_note_tag(TAG_VALUE_1).unwrap();
+
+        // verify that the tag is still being tracked only once
+        assert_eq!(
+            client.get_note_tags().unwrap(),
+            vec![TAG_VALUE_1, TAG_VALUE_2]
+        );
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -419,6 +419,9 @@ impl Store {
     /// Adds a note tag to the list of tags that the client is interested in.
     pub fn add_note_tag(&mut self, tag: u64) -> Result<(), StoreError> {
         let mut tags = self.get_note_tags()?;
+        if tags.contains(&tag) {
+            return Err(StoreError::NoteTagAlreadyTracked(tag));
+        }
         tags.push(tag);
         let tags = serde_json::to_string(&tags).map_err(StoreError::InputSerializationError)?;
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -415,7 +415,8 @@ impl Store {
             .expect("state sync tags exist")
     }
 
-    /// Adds a note tag to the list of tags that the client is interested in.
+    /// Adds a note tag to the list of tags that the client is interested in. This function returns
+    /// `Ok(false)` if the tag had been added before, and `Ok(true)` if it was added succesfully.
     pub fn add_note_tag(&mut self, tag: u64) -> Result<bool, StoreError> {
         let mut tags = self.get_note_tags()?;
         if tags.contains(&tag) {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -418,10 +418,10 @@ impl Store {
     }
 
     /// Adds a note tag to the list of tags that the client is interested in.
-    pub fn add_note_tag(&mut self, tag: u64) -> Result<(), StoreError> {
+    pub fn add_note_tag(&mut self, tag: u64) -> Result<bool, StoreError> {
         let mut tags = self.get_note_tags()?;
         if tags.contains(&tag) {
-            return Err(StoreError::NoteTagAlreadyTracked(tag));
+            return Ok(false);
         }
         tags.push(tag);
         let tags = serde_json::to_string(&tags).map_err(StoreError::InputSerializationError)?;
@@ -430,7 +430,9 @@ impl Store {
         self.db
             .execute(QUERY, params![tags])
             .map_err(StoreError::QueryError)
-            .map(|_| ())
+            .map(|_| ())?;
+
+        Ok(true)
     }
 
     /// Returns the block number of the last state sync block


### PR DESCRIPTION
Closes #60 

Prevent adding a duplicate note tag to the tracking list by first checking if it's already present on the database.
<img width="564" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/62400508/97f2e701-41a1-4783-8cef-12bd65cdf4fa">
