### PR TITLE
feat: Add transaction execution and proving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.67"
 
 [features]
-default = ["std"]
+default = ["std", "testing"]
 std = ["crypto/std", "objects/std"]
 testing = ["objects/testing", "mock"]
 
@@ -18,9 +18,9 @@ testing = ["objects/testing", "mock"]
 clap = { version = "4.3" , features = ["derive"] }
 crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 lazy_static = "1.4.0"
+miden_node_proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "main", default-features = false }
 objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", features = ["serde"] }
 miden_lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
-miden_node_proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "main", default-features = false }
 miden_tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false, optional = true }
 rusqlite = { version = "0.29.0", features = ["bundled"] }

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -4,15 +4,10 @@ use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use crypto::{
     dsa::rpo_falcon512::KeyPair,
     utils::{bytes_to_hex_string, Serializable},
-    Felt,
 };
-use miden_client::store::AuthInfo;
-use miden_lib::{faucets, AuthScheme};
-use objects::{
-    accounts::{AccountId, AccountType},
-    assets::TokenSymbol,
-};
-use rand::Rng;
+use miden_client::client::accounts;
+
+use objects::{accounts::AccountId, assets::TokenSymbol};
 
 // ACCOUNT COMMAND
 // ================================================================================================
@@ -44,11 +39,7 @@ pub enum AccountCmd {
     #[clap(short_flag = 'n')]
     New {
         #[clap(subcommand)]
-        template: Option<AccountTemplate>,
-
-        /// Executes a transaction that records the account on-chain
-        #[clap(short, long, default_value_t = false)]
-        deploy: bool,
+        template: AccountTemplate,
     },
 }
 
@@ -73,13 +64,39 @@ pub enum AccountTemplate {
 }
 
 impl AccountCmd {
-    pub fn execute(&self, client: Client) -> Result<(), String> {
+    pub fn execute(&self, mut client: Client) -> Result<(), String> {
         match self {
             AccountCmd::List => {
                 list_accounts(client)?;
             }
-            AccountCmd::New { template, deploy } => {
-                new_account(client, template, *deploy)?;
+            AccountCmd::New { template } => {
+                let client_template = match template {
+                    AccountTemplate::BasicImmutable => accounts::AccountTemplate::BasicWallet {
+                        mutable_code: false,
+                        storage_mode: accounts::AccountStorageMode::Local,
+                    },
+                    AccountTemplate::BasicMutable => accounts::AccountTemplate::BasicWallet {
+                        mutable_code: true,
+                        storage_mode: accounts::AccountStorageMode::Local,
+                    },
+                    AccountTemplate::FungibleFaucet {
+                        token_symbol,
+                        decimals,
+                        max_supply,
+                    } => accounts::AccountTemplate::FungibleFaucet {
+                        token_symbol: TokenSymbol::new(token_symbol)
+                            .map_err(|err| format!("error: token symbol is invalid: {}", err))?,
+                        decimals: *decimals,
+                        max_supply: *max_supply,
+                        storage_mode: accounts::AccountStorageMode::Local,
+                    },
+                    AccountTemplate::NonFungibleFaucet => todo!(),
+                };
+                let new_account = client
+                    .new_account(client_template)
+                    .map_err(|err| err.to_string())?;
+
+                println!("New account created: {}", new_account.id());
             }
             AccountCmd::Show { id: None, .. } => {
                 todo!("Default accounts are not supported yet")
@@ -93,7 +110,6 @@ impl AccountCmd {
             } => {
                 let account_id: AccountId = AccountId::from_hex(v)
                     .map_err(|_| "Input number was not a valid Account Id")?;
-
                 show_account(client, account_id, *keys, *vault, *storage, *code)?;
             }
         }
@@ -130,69 +146,6 @@ fn list_accounts(client: Client) -> Result<(), String> {
     });
 
     println!("{table}");
-    Ok(())
-}
-
-// ACCOUNT NEW
-// ================================================================================================
-
-fn new_account(
-    mut client: Client,
-    template: &Option<AccountTemplate>,
-    deploy: bool,
-) -> Result<(), String> {
-    if deploy {
-        todo!("Recording the account on chain is not supported yet");
-    }
-
-    let key_pair: KeyPair =
-        KeyPair::new().map_err(|err| format!("Error generating KeyPair: {}", err))?;
-    let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 {
-        pub_key: key_pair.public_key(),
-    };
-
-    let mut rng = rand::thread_rng();
-    // we need to use an initial seed to create the wallet account
-    let init_seed: [u8; 32] = rng.gen();
-
-    // TODO: as the client takes form, make errors more structured
-    let (account, _) = match template {
-        None => todo!("Generic account creation is not supported yet"),
-        Some(AccountTemplate::BasicImmutable) => miden_lib::wallets::create_basic_wallet(
-            init_seed,
-            auth_scheme,
-            AccountType::RegularAccountImmutableCode,
-        ),
-        Some(AccountTemplate::FungibleFaucet {
-            token_symbol,
-            decimals,
-            max_supply,
-        }) => {
-            let max_supply = max_supply.to_le_bytes();
-            faucets::create_basic_fungible_faucet(
-                init_seed,
-                TokenSymbol::new(token_symbol)
-                    .expect("Hardcoded test token symbol creation should not panic"),
-                *decimals,
-                Felt::try_from(max_supply.as_slice())
-                    .map_err(|_| "Maximum supply must fit into a field element")?,
-                auth_scheme,
-            )
-        }
-        Some(AccountTemplate::BasicMutable) => miden_lib::wallets::create_basic_wallet(
-            init_seed,
-            auth_scheme,
-            AccountType::RegularAccountUpdatableCode,
-        ),
-        _ => todo!("Template not supported yet"),
-    }
-    .map_err(|err| err.to_string())?;
-
-    let auth_info = AuthInfo::RpoFalcon512(key_pair);
-    client
-        .insert_account(&account, &auth_info)
-        .map_err(|err| err.to_string())?;
-
     Ok(())
 }
 

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -1,5 +1,4 @@
 use super::{Client, Parser};
-
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::store::InputNoteFilter;
 use objects::notes::RecordedNote;

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -3,7 +3,11 @@ use comfy_table::Attribute;
 use comfy_table::Cell;
 use comfy_table::ContentArrangement;
 use comfy_table::Table;
+use miden_client::client::transactions::PaymentTransactionData;
 use miden_client::client::transactions::TransactionStub;
+use miden_client::client::transactions::TransactionTemplate;
+use objects::accounts::AccountId;
+use objects::assets::FungibleAsset;
 
 use super::Client;
 use super::Parser;
@@ -18,14 +22,66 @@ pub enum Transaction {
         #[clap(short, long, default_value_t = false)]
         pending: bool,
     },
+    /// Execute a transaction, prove and submit it to the node
+    #[clap(short_flag = 'n')]
+    New {
+        #[clap(subcommand)]
+        transaction_type: TransactionType,
+    },
+}
+
+#[derive(Clone, Debug, Parser)]
+#[clap()]
+pub enum TransactionType {
+    P2ID {
+        sender_account_id: String,
+        target_account_id: String,
+        faucet_id: String,
+        amount: u64,
+    },
+    P2IDR,
 }
 
 impl Transaction {
-    pub fn execute(&self, client: Client) -> Result<(), String> {
+    pub async fn execute(&self, mut client: Client) -> Result<(), String> {
         match self {
             Transaction::List { pending } => {
                 list_transactions(client, *pending)?;
             }
+            Transaction::New { transaction_type } => match transaction_type {
+                TransactionType::P2ID {
+                    sender_account_id,
+                    target_account_id,
+                    faucet_id,
+                    amount,
+                } => {
+                    let faucet_id =
+                        AccountId::from_hex(faucet_id).map_err(|err| err.to_string())?;
+                    let fungible_asset = FungibleAsset::new(faucet_id, *amount)
+                        .map_err(|err| err.to_string())?
+                        .into();
+                    let sender_account_id =
+                        AccountId::from_hex(sender_account_id).map_err(|err| err.to_string())?;
+                    let target_account_id =
+                        AccountId::from_hex(target_account_id).map_err(|err| err.to_string())?;
+                    let payment_transaction = PaymentTransactionData::new(
+                        fungible_asset,
+                        sender_account_id,
+                        target_account_id,
+                    );
+                    let (transaction_result, tx_script) = client
+                        .new_transaction(TransactionTemplate::PayToId(payment_transaction))
+                        .map_err(|err| err.to_string())?;
+
+                    client
+                        .send_transaction(transaction_result.into_witness(), Some(tx_script))
+                        .await
+                        .map_err(|err| err.to_string())?;
+                }
+                TransactionType::P2IDR => {
+                    todo!()
+                }
+            },
         }
         Ok(())
     }
@@ -58,6 +114,7 @@ where
             Cell::new("script hash").add_attribute(Attribute::Bold),
             Cell::new("committed").add_attribute(Attribute::Bold),
             Cell::new("block number").add_attribute(Attribute::Bold),
+            Cell::new("input notes count").add_attribute(Attribute::Bold),
         ]);
 
     for tx in executed_transactions {
@@ -69,6 +126,7 @@ where
                 .unwrap_or("-".to_string()),
             tx.committed.to_string(),
             tx.block_num.to_string(),
+            tx.input_note_nullifiers.len().to_string(),
         ]);
     }
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -2,19 +2,138 @@ use super::Client;
 
 use std::collections::BTreeMap;
 
-use crypto::Word;
+use crypto::{Felt, Word};
+use miden_lib::{faucets, AuthScheme};
 use objects::{
-    accounts::{Account, AccountId, AccountStub},
+    accounts::{Account, AccountId, AccountStub, AccountType},
     assembly::ModuleAst,
-    assets::Asset,
+    assets::{Asset, TokenSymbol},
     Digest,
 };
+use rand::{rngs::ThreadRng, Rng};
 
 use crate::{errors::ClientError, store::AuthInfo};
+
+pub enum AccountTemplate {
+    BasicWallet {
+        mutable_code: bool,
+        storage_mode: AccountStorageMode,
+    },
+    FungibleFaucet {
+        token_symbol: TokenSymbol,
+        decimals: u8,
+        max_supply: u64,
+        storage_mode: AccountStorageMode,
+    },
+}
+
+pub enum AccountStorageMode {
+    Local,
+    OnChain,
+}
 
 impl Client {
     // ACCOUNT INSERTION
     // --------------------------------------------------------------------------------------------
+
+    // ACCOUNT CREATION
+    // --------------------------------------------------------------------------------------------
+
+    pub fn new_account(&mut self, template: AccountTemplate) -> Result<Account, ClientError> {
+        let mut rng = rand::thread_rng();
+
+        let account = match template {
+            AccountTemplate::BasicWallet {
+                mutable_code,
+                storage_mode,
+            } => self.new_basic_wallet(mutable_code, &mut rng, storage_mode),
+            AccountTemplate::FungibleFaucet {
+                token_symbol,
+                decimals,
+                max_supply,
+                storage_mode,
+            } => {
+                self.new_fungible_faucet(token_symbol, decimals, max_supply, &mut rng, storage_mode)
+            }
+        }?;
+
+        Ok(account)
+    }
+
+    fn new_basic_wallet(
+        &mut self,
+        mutable_code: bool,
+        rng: &mut ThreadRng,
+        account_storage_mode: AccountStorageMode,
+    ) -> Result<Account, ClientError> {
+        if let AccountStorageMode::OnChain = account_storage_mode {
+            todo!("Recording the account on chain is not supported yet");
+        }
+
+        let key_pair: objects::crypto::dsa::rpo_falcon512::KeyPair =
+            objects::crypto::dsa::rpo_falcon512::KeyPair::new().map_err(ClientError::AuthError)?;
+
+        let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 {
+            pub_key: key_pair.public_key(),
+        };
+
+        // we need to use an initial seed to create the wallet account
+        let init_seed: [u8; 32] = rng.gen();
+
+        let (account, _seed) = if !mutable_code {
+            miden_lib::wallets::create_basic_wallet(
+                init_seed,
+                auth_scheme,
+                AccountType::RegularAccountImmutableCode,
+            )
+        } else {
+            miden_lib::wallets::create_basic_wallet(
+                init_seed,
+                auth_scheme,
+                AccountType::RegularAccountUpdatableCode,
+            )
+        }
+        .map_err(ClientError::AccountError)?;
+
+        self.insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))?;
+        Ok(account)
+    }
+
+    fn new_fungible_faucet(
+        &mut self,
+        token_symbol: TokenSymbol,
+        decimals: u8,
+        max_supply: u64,
+        rng: &mut ThreadRng,
+        account_storage_mode: AccountStorageMode,
+    ) -> Result<Account, ClientError> {
+        if let AccountStorageMode::OnChain = account_storage_mode {
+            todo!("On-chain accounts are not supported yet");
+        }
+
+        let key_pair: objects::crypto::dsa::rpo_falcon512::KeyPair =
+            objects::crypto::dsa::rpo_falcon512::KeyPair::new().map_err(ClientError::AuthError)?;
+
+        let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 {
+            pub_key: key_pair.public_key(),
+        };
+
+        // we need to use an initial seed to create the wallet account
+        let init_seed: [u8; 32] = rng.gen();
+
+        let (account, _seed) = faucets::create_basic_fungible_faucet(
+            init_seed,
+            token_symbol,
+            decimals,
+            Felt::try_from(max_supply.to_le_bytes().as_slice())
+                .expect("u64 can be safely converted to a field element"),
+            auth_scheme,
+        )
+        .map_err(ClientError::AccountError)?;
+
+        self.insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))?;
+        Ok(account)
+    }
 
     /// Inserts a new account into the client's store.
     pub fn insert_account(

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,12 +6,13 @@ use miden_node_proto::{
     account_id::AccountId as ProtoAccountId, requests::SyncStateRequest,
     responses::SyncStateResponse,
 };
+use miden_tx::TransactionExecutor;
 use objects::{accounts::AccountId, Digest};
 
 use crate::{
     config::ClientConfig,
     errors::{ClientError, RpcApiError},
-    store::Store,
+    store::{mock_executor_data_store::MockDataStore, Store},
 };
 
 #[cfg(any(test, feature = "testing"))]
@@ -37,12 +38,13 @@ pub const FILTER_ID_SHIFT: u8 = 48;
 /// - Executes, proves, and submits transactions to the network as directed by the user.
 pub struct Client {
     /// Local database containing information about the accounts managed by this client.
-    store: Store,
+    pub(crate) store: Store,
     #[cfg(not(any(test, feature = "testing")))]
     /// Api client for interacting with the Miden node.
     rpc_api: miden_node_proto::rpc::api_client::ApiClient<tonic::transport::Channel>,
     #[cfg(any(test, feature = "testing"))]
     pub rpc_api: MockRpcApi,
+    pub(crate) tx_executor: TransactionExecutor<MockDataStore>,
 }
 
 impl Client {
@@ -64,6 +66,7 @@ impl Client {
             .map_err(|err| ClientError::RpcApiError(RpcApiError::ConnectionError(err)))?,
             #[cfg(any(test, feature = "testing"))]
             rpc_api: Default::default(),
+            tx_executor: TransactionExecutor::new(MockDataStore::new()),
         })
     }
 

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -177,7 +177,7 @@ impl Client {
         self.set_data_store(data_store.clone());
         self.tx_executor
             .load_account(target_account_id)
-            .map_err(ClientError::TransactionExecutorError)?;
+            .map_err(ClientError::TransactionExecutionError)?;
 
         let block_ref = data_store.block_header.block_num().as_int() as u32;
         let note_origins = data_store
@@ -204,7 +204,7 @@ impl Client {
                 vec![(target_pub_key, target_sk_pk_felt)],
                 vec![],
             )
-            .map_err(ClientError::TransactionExecutorError)?;
+            .map_err(ClientError::TransactionExecutionError)?;
 
         // Execute the transaction and get the witness
         let transaction_result = self
@@ -215,7 +215,7 @@ impl Client {
                 &note_origins,
                 Some(tx_script_target.clone()),
             )
-            .map_err(ClientError::TransactionExecutorError)?;
+            .map_err(ClientError::TransactionExecutionError)?;
 
         Ok((transaction_result, tx_script_target))
     }
@@ -230,7 +230,7 @@ impl Client {
         let transaction_prover = TransactionProver::new(ProvingOptions::default());
         let proven_transaction = transaction_prover
             .prove_transaction_witness(transaction_witness)
-            .map_err(ClientError::TransactionProverError)?;
+            .map_err(ClientError::TransactionProvingError)?;
 
         self.submit_proven_transaction_request(proven_transaction.clone())
             .await?;

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -1,7 +1,54 @@
-use objects::{accounts::AccountId, notes::Note, transaction::TransactionScript, Digest};
+use crypto::{utils::Serializable, StarkField};
+use miden_lib::notes::{create_note, Script};
+use miden_node_proto::{
+    requests::SubmitProvenTransactionRequest, responses::SubmitProvenTransactionResponse,
+};
+use miden_tx::{ProvingOptions, TransactionProver};
+use objects::{
+    accounts::AccountId,
+    assembly::ProgramAst,
+    assets::Asset,
+    notes::Note,
+    transaction::{ProvenTransaction, TransactionResult, TransactionScript, TransactionWitness},
+    Digest,
+};
+use rand::Rng;
+
+use crate::{
+    errors::{self, ClientError},
+    store::{self, mock_executor_data_store::MockDataStore},
+};
 
 use super::Client;
-use crate::errors::ClientError;
+
+pub enum TransactionTemplate {
+    /// Creates a pay-to-id note directed to a specific account from a faucet
+    PayToId(PaymentTransactionData),
+    /// Creates a pay-to-id note directed to a specific account, specifying a block height at which the payment is recalled
+    PayToIdWithRecall(PaymentTransactionData, u32),
+    /// Consume all outstanding notes for an account
+    ConsumeNotes(AccountId),
+}
+
+pub struct PaymentTransactionData {
+    asset: Asset,
+    sender_account_id: AccountId,
+    target_account_id: AccountId,
+}
+
+impl PaymentTransactionData {
+    pub fn new(
+        asset: Asset,
+        sender_account_id: AccountId,
+        target_account_id: AccountId,
+    ) -> PaymentTransactionData {
+        PaymentTransactionData {
+            asset,
+            sender_account_id,
+            target_account_id,
+        }
+    }
+}
 
 pub struct TransactionStub {
     pub id: Digest,
@@ -46,11 +93,159 @@ impl TransactionStub {
 }
 
 impl Client {
+    // TRANSACTION CREATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Inserts a new transaction into the client's store.
+    fn insert_transaction(
+        &mut self,
+        transaction: &ProvenTransaction,
+        transaction_script: Option<TransactionScript>,
+    ) -> Result<(), ClientError> {
+        self.store
+            .insert_transaction(transaction, transaction_script)
+            .map_err(|err| err.into())
+    }
+
     // TRANSACTION DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
     /// Returns input notes managed by this client.
     pub fn get_transactions(&self) -> Result<Vec<TransactionStub>, ClientError> {
         self.store.get_transactions().map_err(|err| err.into())
+    }
+
+    // TRANSACTION
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates and executes a transactions specified by the template, but does not change the
+    /// local database.
+    pub fn new_transaction(
+        &mut self,
+        transaction_template: TransactionTemplate,
+    ) -> Result<(TransactionResult, TransactionScript), ClientError> {
+        match transaction_template {
+            TransactionTemplate::PayToId(PaymentTransactionData {
+                asset: fungible_asset,
+                sender_account_id,
+                target_account_id,
+            }) => {
+                // Create assets
+                let (target_pub_key, target_sk_pk_felt) =
+                    store::mock_executor_data_store::get_new_key_pair_with_advice_map();
+                let target_account =
+                    store::mock_executor_data_store::get_account_with_default_account_code(
+                        target_account_id,
+                        target_pub_key,
+                        None,
+                    );
+
+                // Create the note
+                let p2id_script = Script::P2ID {
+                    target: target_account_id,
+                };
+
+                let mut rng = rand::thread_rng();
+                let serial_numbers: [u64; 4] = rng.gen();
+
+                let note = create_note(
+                    p2id_script,
+                    vec![fungible_asset],
+                    sender_account_id,
+                    Some(target_account_id.into()),
+                    serial_numbers.map(|number| number.into()),
+                )
+                .map_err(ClientError::NoteError)?;
+
+                // TODO: Remove this as DataStore is implemented on the Client's Store
+                let data_store: MockDataStore = MockDataStore::with_existing(
+                    Some(target_account.clone()),
+                    Some(vec![note.clone()]),
+                    None,
+                );
+
+                self.set_data_store(data_store.clone());
+                self.tx_executor
+                    .load_account(target_account_id)
+                    .map_err(ClientError::TransactionExecutorError)?;
+
+                let block_ref = data_store.block_header.block_num().as_int() as u32;
+                let note_origins = data_store
+                    .notes
+                    .iter()
+                    .map(|note| note.origin().clone())
+                    .collect::<Vec<_>>();
+
+                let tx_script_code = ProgramAst::parse(
+                    "
+                    use.miden::auth::basic->auth_tx
+
+                    begin
+                        call.auth_tx::auth_tx_rpo_falcon512
+                    end
+                    ",
+                )
+                .expect("program is correctly written");
+
+                let tx_script_target = self
+                    .tx_executor
+                    .compile_tx_script(
+                        tx_script_code.clone(),
+                        vec![(target_pub_key, target_sk_pk_felt)],
+                        vec![],
+                    )
+                    .map_err(ClientError::TransactionExecutorError)?;
+
+                // Execute the transaction and get the witness
+                let transaction_result = self
+                    .tx_executor
+                    .execute_transaction(
+                        target_account_id,
+                        block_ref,
+                        &note_origins,
+                        Some(tx_script_target.clone()),
+                    )
+                    .map_err(ClientError::TransactionExecutorError)?;
+
+                Ok((transaction_result, tx_script_target))
+            }
+            TransactionTemplate::PayToIdWithRecall(_payment_data, _recall_height) => todo!(),
+            TransactionTemplate::ConsumeNotes(_) => todo!(),
+        }
+    }
+
+    /// Proves the specified transaction witness, submits it to the node, and stores the transaction in
+    /// the local database for tracking.
+    pub async fn send_transaction(
+        &mut self,
+        transaction_witness: TransactionWitness,
+        transaction_script: Option<TransactionScript>,
+    ) -> Result<(), ClientError> {
+        let transaction_prover = TransactionProver::new(ProvingOptions::default());
+        let proven_transaction = transaction_prover
+            .prove_transaction_witness(transaction_witness)
+            .map_err(ClientError::TransactionProverError)?;
+
+        self.submit_proven_transaction_request(proven_transaction.clone())
+            .await?;
+
+        self.insert_transaction(&proven_transaction, transaction_script)?;
+        Ok(())
+    }
+
+    async fn submit_proven_transaction_request(
+        &mut self,
+        proven_transaction: ProvenTransaction,
+    ) -> Result<SubmitProvenTransactionResponse, ClientError> {
+        let request = SubmitProvenTransactionRequest {
+            transaction: proven_transaction.to_bytes(),
+        };
+
+        Ok(self
+            .rpc_api
+            .submit_proven_transaction(request)
+            .await
+            .map_err(|err| ClientError::RpcApiError(errors::RpcApiError::RequestError(err)))?
+            .into_inner())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,9 +60,9 @@ pub enum StoreError {
     InputSerializationError(serde_json::Error),
     JsonDataDeserializationError(serde_json::Error),
     MigrationError(rusqlite_migration::Error),
+    NoteTagAlreadyTracked(u64),
     QueryError(rusqlite::Error),
     TransactionError(rusqlite::Error),
-    NoteTagAlreadyTracked(u64),
     TransactionScriptError(TransactionScriptError),
     VaultDataNotFound(Digest),
 }
@@ -102,16 +102,13 @@ impl fmt::Display for StoreError {
                 )
             }
             MigrationError(err) => write!(f, "failed to update the database: {err}"),
+            NoteTagAlreadyTracked(tag) => write!(f, "note tag {} is already being tracked", tag),
             QueryError(err) => write!(f, "failed to retrieve data from the database: {err}"),
             TransactionError(err) => write!(f, "failed to instantiate a new transaction: {err}"),
             TransactionScriptError(err) => {
                 write!(f, "error instantiating transaction script: {err}")
             }
             VaultDataNotFound(root) => write!(f, "account vault data for root {} not found", root),
-            AccountCodeDataNotFound(root) => {
-                write!(f, "account code data with root {} not found", root)
-            }
-            NoteTagAlreadyTracked(tag) => write!(f, "note tag {} is already being tracked", tag),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,8 @@
 use core::fmt;
-use crypto::utils::{DeserializationError, HexParseError};
+use crypto::{
+    dsa::rpo_falcon512::FalconError,
+    utils::{DeserializationError, HexParseError},
+};
 use miden_tx::{TransactionExecutorError, TransactionProverError};
 use objects::{accounts::AccountId, AccountError, Digest, NoteError, TransactionScriptError};
 use tonic::{transport::Error as TransportError, Status as TonicStatus};
@@ -10,6 +13,7 @@ use tonic::{transport::Error as TransportError, Status as TonicStatus};
 #[derive(Debug)]
 pub enum ClientError {
     AccountError(AccountError),
+    AuthError(FalconError),
     NoteError(NoteError),
     RpcApiError(RpcApiError),
     StoreError(StoreError),
@@ -21,6 +25,7 @@ impl fmt::Display for ClientError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ClientError::AccountError(err) => write!(f, "account error: {err}"),
+            ClientError::AuthError(err) => write!(f, "account auth error: {err}"),
             ClientError::NoteError(err) => write!(f, "note error: {err}"),
             ClientError::RpcApiError(err) => write!(f, "rpc api error: {err}"),
             ClientError::StoreError(err) => write!(f, "store error: {err}"),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,8 +13,8 @@ pub enum ClientError {
     NoteError(NoteError),
     RpcApiError(RpcApiError),
     StoreError(StoreError),
-    TransactionExecutorError(TransactionExecutorError),
-    TransactionProverError(TransactionProverError),
+    TransactionExecutionError(TransactionExecutorError),
+    TransactionProvingError(TransactionProverError),
 }
 
 impl fmt::Display for ClientError {
@@ -24,10 +24,10 @@ impl fmt::Display for ClientError {
             ClientError::NoteError(err) => write!(f, "note error: {err}"),
             ClientError::RpcApiError(err) => write!(f, "rpc api error: {err}"),
             ClientError::StoreError(err) => write!(f, "store error: {err}"),
-            ClientError::TransactionExecutorError(err) => {
+            ClientError::TransactionExecutionError(err) => {
                 write!(f, "transaction executor error: {err}")
             }
-            ClientError::TransactionProverError(err) => {
+            ClientError::TransactionProvingError(err) => {
                 write!(f, "transaction prover error: {err}")
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,26 @@ mod tests {
         assert_eq!(recorded_notes, retrieved_notes);
     }
 
+    // #[tokio::test]
+    // async fn test_submit_proven_tx() {
+    //     let store_path = create_test_store_path();
+
+    //     // generate test client
+    //     let mut client = Client::new(
+    //         ClientConfig::new(
+    //             store_path.into_os_string().into_string().unwrap(),
+    //             Endpoint::default(),
+    //         ),
+    //         TransactionExecutor::new(MockDataStore::default()),
+    //     )
+    //     .await
+    //     .unwrap();
+
+    //     client.new_transaction(crate::TransactionTemplate::PayToId(
+    //         crate::PaymentTransaction { faucet_id: (), sender_account_id: (), target_account_id: (), amount: () }
+    //     ));
+    // }
+
     #[tokio::test]
     async fn test_get_input_note() {
         // generate test store path
@@ -74,7 +94,7 @@ mod tests {
         .unwrap();
 
         // generate test data
-        let (_, _, _, recorded_notes, _) = mock_inputs(
+        let (_account, _, _, recorded_notes, _) = mock_inputs(
             MockAccountType::StandardExisting,
             AssetPreservationStatus::Preserved,
         );

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,16 +1,20 @@
+use crate::client::transactions::{PaymentTransactionData, TransactionTemplate};
+use crate::client::{Client, FILTER_ID_SHIFT};
+use crate::store::mock_executor_data_store::MockDataStore;
+use crate::store::AuthInfo;
 use crypto::dsa::rpo_falcon512::KeyPair;
+use miden_node_proto::requests::SubmitProvenTransactionRequest;
+use miden_node_proto::responses::SubmitProvenTransactionResponse;
 use miden_node_proto::{
     account_id::AccountId as ProtoAccountId,
     requests::SyncStateRequest,
     responses::{NullifierUpdate, SyncStateResponse},
 };
 
+use miden_tx::TransactionExecutor;
+use objects::accounts::AccountType;
+use objects::assets::FungibleAsset;
 use objects::{utils::collections::BTreeMap, StarkField};
-
-use crate::{
-    client::{Client, FILTER_ID_SHIFT},
-    store::AuthInfo,
-};
 
 /// Mock RPC API
 ///
@@ -44,6 +48,16 @@ impl MockRpcApi {
                 "no response for sync state request",
             )),
         }
+    }
+
+    pub async fn submit_proven_transaction(
+        &mut self,
+        request: impl tonic::IntoRequest<SubmitProvenTransactionRequest>,
+    ) -> std::result::Result<tonic::Response<SubmitProvenTransactionResponse>, tonic::Status> {
+        let _request = request.into_request().into_inner();
+        let response = SubmitProvenTransactionResponse {};
+
+        Ok(tonic::Response::new(response))
     }
 }
 
@@ -121,4 +135,98 @@ pub fn insert_mock_data(client: &mut Client) {
     client
         .insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))
         .unwrap();
+}
+
+pub async fn create_mock_transaction(client: &mut Client) {
+    let key_pair: KeyPair = KeyPair::new()
+        .map_err(|err| format!("Error generating KeyPair: {}", err))
+        .unwrap();
+    let auth_scheme: miden_lib::AuthScheme = miden_lib::AuthScheme::RpoFalcon512 {
+        pub_key: key_pair.public_key(),
+    };
+    let _assembler = miden_lib::assembler::assembler();
+
+    let mut rng = rand::thread_rng();
+    // we need to use an initial seed to create the wallet account
+    let init_seed: [u8; 32] = rand::Rng::gen(&mut rng);
+
+    let (sender_account, _) = miden_lib::wallets::create_basic_wallet(
+        init_seed,
+        auth_scheme,
+        AccountType::RegularAccountImmutableCode,
+    )
+    .unwrap();
+
+    client
+        .insert_account(&sender_account, &AuthInfo::RpoFalcon512(key_pair))
+        .unwrap();
+
+    let key_pair: KeyPair = KeyPair::new()
+        .map_err(|err| format!("Error generating KeyPair: {}", err))
+        .unwrap();
+    let auth_scheme: miden_lib::AuthScheme = miden_lib::AuthScheme::RpoFalcon512 {
+        pub_key: key_pair.public_key(),
+    };
+
+    let mut rng = rand::thread_rng();
+    // we need to use an initial seed to create the wallet account
+    let init_seed: [u8; 32] = rand::Rng::gen(&mut rng);
+
+    let (target_account, _) = miden_lib::wallets::create_basic_wallet(
+        init_seed,
+        auth_scheme,
+        AccountType::RegularAccountImmutableCode,
+    )
+    .unwrap();
+
+    client
+        .insert_account(&target_account, &AuthInfo::RpoFalcon512(key_pair))
+        .unwrap();
+
+    let key_pair: KeyPair = KeyPair::new()
+        .map_err(|err| format!("Error generating KeyPair: {}", err))
+        .unwrap();
+    let auth_scheme: miden_lib::AuthScheme = miden_lib::AuthScheme::RpoFalcon512 {
+        pub_key: key_pair.public_key(),
+    };
+
+    let mut rng = rand::thread_rng();
+    // we need to use an initial seed to create the wallet account
+    let init_seed: [u8; 32] = rand::Rng::gen(&mut rng);
+
+    let max_supply = 10000u64.to_le_bytes();
+
+    let (faucet, _) = miden_lib::faucets::create_basic_fungible_faucet(
+        init_seed,
+        objects::assets::TokenSymbol::new("MOCK").unwrap(),
+        4u8,
+        crypto::Felt::try_from(max_supply.as_slice()).unwrap(),
+        auth_scheme,
+    )
+    .unwrap();
+
+    client
+        .insert_account(&faucet, &AuthInfo::RpoFalcon512(key_pair))
+        .unwrap();
+
+    let asset: objects::assets::Asset = FungibleAsset::new(faucet.id(), 5u64).unwrap().into();
+    let transaction_template = TransactionTemplate::PayToId(PaymentTransactionData::new(
+        asset,
+        sender_account.id(),
+        target_account.id(),
+    ));
+    let (transaction_result, script) = client.new_transaction(transaction_template).unwrap();
+
+    client
+        .send_transaction(transaction_result.into_witness(), Some(script))
+        .await
+        .unwrap();
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl Client {
+    /// testing function to set a data store to conveniently mock data if needed
+    pub fn set_data_store(&mut self, data_store: MockDataStore) {
+        self.tx_executor = TransactionExecutor::new(data_store);
+    }
 }

--- a/src/store/mock_executor_data_store.rs
+++ b/src/store/mock_executor_data_store.rs
@@ -1,0 +1,181 @@
+use miden_lib::assembler::assembler;
+use miden_tx::{DataStore, DataStoreError};
+use mock::{
+    constants::{ACCOUNT_ID_SENDER, DEFAULT_ACCOUNT_CODE},
+    mock::account::MockAccountType,
+    mock::notes::AssetPreservationStatus,
+    mock::transaction::{mock_inputs, mock_inputs_with_existing},
+};
+use objects::AdviceInputs;
+use objects::{
+    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountVault, StorageSlotType},
+    assembly::ModuleAst,
+    assembly::ProgramAst,
+    assets::{Asset, FungibleAsset},
+    crypto::{dsa::rpo_falcon512::KeyPair, utils::Serializable},
+    notes::{Note, NoteOrigin, NoteScript, RecordedNote},
+    BlockHeader, ChainMmr, Felt, Word,
+};
+
+// MOCK DATA STORE
+// ================================================================================================
+
+#[derive(Clone)]
+pub struct MockDataStore {
+    pub account: Account,
+    pub block_header: BlockHeader,
+    pub block_chain: ChainMmr,
+    pub notes: Vec<RecordedNote>,
+    pub auxiliary_data: AdviceInputs,
+}
+
+impl MockDataStore {
+    pub fn new() -> Self {
+        let (account, block_header, block_chain, consumed_notes, auxiliary_data) = mock_inputs(
+            MockAccountType::StandardExisting,
+            AssetPreservationStatus::Preserved,
+        );
+        Self {
+            account,
+            block_header,
+            block_chain,
+            notes: consumed_notes,
+            auxiliary_data,
+        }
+    }
+
+    pub fn with_existing(
+        account: Option<Account>,
+        consumed_notes: Option<Vec<Note>>,
+        auxiliary_data: Option<AdviceInputs>,
+    ) -> Self {
+        let (account, block_header, block_chain, consumed_notes, mut auxiliary_data_inputs) =
+            mock_inputs_with_existing(
+                MockAccountType::StandardExisting,
+                AssetPreservationStatus::Preserved,
+                account,
+                consumed_notes,
+            );
+        if let Some(auxiliary_data) = auxiliary_data {
+            auxiliary_data_inputs.extend(auxiliary_data);
+        }
+        Self {
+            account,
+            block_header,
+            block_chain,
+            notes: consumed_notes,
+            auxiliary_data: auxiliary_data_inputs,
+        }
+    }
+}
+
+impl Default for MockDataStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DataStore for MockDataStore {
+    /// NOTE: This method assumes the MockDataStore was created accordingly using `with_existing()`
+    fn get_transaction_data(
+        &self,
+        _account_id: AccountId,
+        _block_num: u32,
+        notes: &[NoteOrigin],
+    ) -> Result<
+        (
+            Account,
+            BlockHeader,
+            ChainMmr,
+            Vec<RecordedNote>,
+            AdviceInputs,
+        ),
+        DataStoreError,
+    > {
+        let origins = self
+            .notes
+            .iter()
+            .map(|note| note.origin())
+            .collect::<Vec<_>>();
+        notes.iter().all(|note| origins.contains(&note));
+        Ok((
+            self.account.clone(),
+            self.block_header,
+            self.block_chain.clone(),
+            self.notes.clone(),
+            self.auxiliary_data.clone(),
+        ))
+    }
+
+    fn get_account_code(&self, _account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
+        Ok(self.account.code().module().clone())
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+pub fn get_new_key_pair_with_advice_map() -> (Word, Vec<Felt>) {
+    let keypair: KeyPair = KeyPair::new().unwrap();
+
+    let pk: Word = keypair.public_key().into();
+    let pk_sk_bytes = keypair.to_bytes();
+    let pk_sk_felts: Vec<Felt> = pk_sk_bytes
+        .iter()
+        .map(|a| Felt::new(*a as u64))
+        .collect::<Vec<Felt>>();
+
+    (pk, pk_sk_felts)
+}
+
+#[allow(dead_code)]
+pub fn get_account_with_default_account_code(
+    account_id: AccountId,
+    public_key: Word,
+    assets: Option<Asset>,
+) -> Account {
+    let account_code_src = DEFAULT_ACCOUNT_CODE;
+    let account_code_ast = ModuleAst::parse(account_code_src).unwrap();
+    let account_assembler = assembler();
+
+    let account_code = AccountCode::new(account_code_ast.clone(), &account_assembler).unwrap();
+    let account_storage = AccountStorage::new(vec![(
+        0,
+        (StorageSlotType::Value { value_arity: 0 }, public_key),
+    )])
+    .unwrap();
+
+    let account_vault = match assets {
+        Some(asset) => AccountVault::new(&[asset]).unwrap(),
+        None => AccountVault::new(&[]).unwrap(),
+    };
+
+    Account::new(
+        account_id,
+        account_vault,
+        account_storage,
+        account_code,
+        Felt::new(1),
+    )
+}
+
+#[allow(dead_code)]
+pub fn get_note_with_fungible_asset_and_script(
+    fungible_asset: FungibleAsset,
+    note_script: ProgramAst,
+) -> Note {
+    let note_assembler = assembler();
+
+    let (note_script, _) = NoteScript::new(note_script, &note_assembler).unwrap();
+    const SERIAL_NUM: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
+    let sender_id = AccountId::try_from(ACCOUNT_ID_SENDER).unwrap();
+
+    Note::new(
+        note_script.clone(),
+        &[],
+        &[fungible_asset.into()],
+        SERIAL_NUM,
+        sender_id,
+        Felt::new(1),
+    )
+    .unwrap()
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,6 +1,6 @@
+use super::errors::StoreError;
 use crate::config::ClientConfig;
 
-use super::errors::StoreError;
 use clap::error::Result;
 use crypto::hash::rpo::RpoDigest;
 use crypto::{
@@ -8,6 +8,7 @@ use crypto::{
     utils::{collections::BTreeMap, Deserializable, Serializable},
     Word,
 };
+
 use objects::accounts::AccountStub;
 use objects::notes::NoteScript;
 use objects::{
@@ -19,8 +20,10 @@ use objects::{
 };
 use rusqlite::{params, Connection, Transaction};
 
-mod migrations;
+pub(crate) mod mock_executor_data_store;
 pub mod transactions;
+
+mod migrations;
 
 // TYPES
 // ================================================================================================
@@ -248,7 +251,8 @@ impl Store {
     ) -> Result<(), StoreError> {
         let (code_root, code, module) = serialize_account_code(account_code)?;
 
-        const QUERY: &str = "INSERT INTO account_code (root, procedures, module) VALUES (?, ?, ?)";
+        const QUERY: &str =
+            "INSERT OR IGNORE INTO account_code (root, procedures, module) VALUES (?, ?, ?)";
         tx.execute(QUERY, params![code_root, code, module,])
             .map(|_| ())
             .map_err(StoreError::QueryError)
@@ -270,7 +274,7 @@ impl Store {
         account_vault: &AccountVault,
     ) -> Result<(), StoreError> {
         let (vault_root, assets) = serialize_account_vault(account_vault)?;
-        const QUERY: &str = "INSERT INTO account_vaults (root, assets) VALUES (?, ?)";
+        const QUERY: &str = "INSERT OR IGNORE INTO account_vaults (root, assets) VALUES (?, ?)";
         tx.execute(QUERY, params![vault_root, assets])
             .map(|_| ())
             .map_err(StoreError::QueryError)
@@ -903,7 +907,6 @@ pub mod tests {
         assert_eq!(actual, 1);
 
         // Second insertion does not generate a new row
-        assert!(store::Store::insert_account_code(&tx, &account_code).is_err());
         actual = tx
             .query_row("SELECT Count(*) FROM account_code", [], |row| row.get(0))
             .unwrap();

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -57,7 +57,7 @@ CREATE TABLE transactions (
     block_num UNSIGNED BIG INT,                      -- Block number for the block against which the transaction was executed.
     committed BOOLEAN NOT NULL,                      -- Status of the transaction: either pending (false) or committed (true).
     commit_height UNSIGNED BIG INT,                  -- Block number of the block at which the transaction was included in the chain.
-
+    
     FOREIGN KEY (account_id) REFERENCES accounts(id),
     PRIMARY KEY (id)
 );

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -1,3 +1,4 @@
+use crate::{client::transactions::TransactionStub, errors::StoreError};
 use crypto::{
     utils::{collections::BTreeMap, Deserializable, Serializable},
     Felt,
@@ -11,8 +12,6 @@ use objects::{
     Digest,
 };
 use rusqlite::params;
-
-use crate::{client::transactions::TransactionStub, errors::StoreError};
 
 use super::Store;
 
@@ -64,21 +63,21 @@ impl Store {
             final_account_state,
             input_notes,
             output_notes,
-            script_program,
             script_hash,
+            script_program,
             script_inputs,
-            block_ref,
+            block_num,
             committed,
             commit_height,
         ) = serialize_transaction(transaction, tx_script)?;
 
         self.db.execute(
                 "INSERT INTO transactions (id, account_id, init_account_state, final_account_state, \
-                input_notes, output_notes, script_hash, script_program, script_inputs, block_ref, committed, commit_height) \
+                input_notes, output_notes, script_hash, script_program, script_inputs, block_num, committed, commit_height) \
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 params![
                     transaction_id,
-                    { account_id },
+                    account_id,
                     init_account_state,
                     final_account_state,
                     input_notes,
@@ -86,7 +85,7 @@ impl Store {
                     script_program,
                     script_hash,
                     script_inputs,
-                    block_ref,
+                    block_num,
                     committed,
                     commit_height,
                 ],

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -98,6 +98,7 @@ pub fn serialize_transaction(
     transaction: &ProvenTransaction,
     tx_script: Option<TransactionScript>,
 ) -> Result<SerializedTransactionData, StoreError> {
+    let transaction_id: String = transaction.id().inner().into();
     let account_id: u64 = transaction.account_id().into();
     let init_account_state = &transaction.initial_account_hash().to_string();
     let final_account_state = &transaction.final_account_hash().to_string();
@@ -134,7 +135,7 @@ pub fn serialize_transaction(
     let block_num = 0u32;
 
     Ok((
-        transaction.final_account_hash().to_string(),
+        transaction_id,
         account_id as i64,
         init_account_state.to_owned(),
         final_account_state.to_owned(),


### PR DESCRIPTION
This PR adds 2 Client methods:

- `new_transaction()`,  which returns a `TransactionResult`
- `send_transaction()`, which takes a witness, proves it and sends it to the node, storing the transaction locally for tracking it further

Currently the endpoint has been mocked, as well as the `DataStore` that `TransactionExecutor` needs for running. When executing a transaction, we replace the data store with a new object that has what the transaction needs. In the future we need to make this work over our DB.

This can currently be tested by doing `cargo run --features testing --release -- mock-data` and then `cargo run --features testing --release -- transaction list`.
