### PR TITLE
feat: Add method for exporting and importing notes

### DIFF
--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -123,7 +123,7 @@ pub fn import_note(mut client: Client, filename: PathBuf) -> Result<Digest, Stri
     let note = RecordedNote::read_from_bytes(&contents).map_err(|err| err.to_string())?;
 
     client
-        .insert_input_note(note.clone())
+        .import_input_note(note.clone())
         .map_err(|err| err.to_string())?;
     Ok(note.note().hash())
 }

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -119,7 +119,8 @@ pub fn import_note(mut client: Client, filename: PathBuf) -> Result<Digest, Stri
     let mut _file = File::open(filename)
         .and_then(|mut f| f.read_to_end(&mut contents))
         .map_err(|err| err.to_string());
-
+    // TODO: When importing a RecordedNote we want to make sure that the note actually exists in the chain (RPC call)  
+    // and start monitoring its nullifiers (ie, update the list of relevant tags in the state sync table)
     let note = RecordedNote::read_from_bytes(&contents).map_err(|err| err.to_string())?;
 
     client

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -240,7 +240,7 @@ mod tests {
         config::{ClientConfig, Endpoint},
         store::notes::InputNoteFilter,
     };
-    use std::{env::temp_dir};
+    use std::env::temp_dir;
     use uuid::Uuid;
 
     #[tokio::test]

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -119,7 +119,7 @@ pub fn import_note(mut client: Client, filename: PathBuf) -> Result<Digest, Stri
     let mut _file = File::open(filename)
         .and_then(|mut f| f.read_to_end(&mut contents))
         .map_err(|err| err.to_string());
-    // TODO: When importing a RecordedNote we want to make sure that the note actually exists in the chain (RPC call)  
+    // TODO: When importing a RecordedNote we want to make sure that the note actually exists in the chain (RPC call)
     // and start monitoring its nullifiers (ie, update the list of relevant tags in the state sync table)
     let note = RecordedNote::read_from_bytes(&contents).map_err(|err| err.to_string())?;
 

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -1,5 +1,3 @@
-
-
 use super::Client;
 
 use crate::{errors::ClientError, store::notes::InputNoteFilter};

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -1,6 +1,9 @@
+
+
 use super::Client;
 
 use crate::{errors::ClientError, store::notes::InputNoteFilter};
+
 use objects::{notes::RecordedNote, Digest};
 
 impl Client {
@@ -31,7 +34,4 @@ impl Client {
             .insert_input_note(&note)
             .map_err(|err| err.into())
     }
-
-    // TODO: add methods for retrieving note and transaction info, and for creating/executing
-    // transaction
 }

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -27,7 +27,7 @@ impl Client {
     // --------------------------------------------------------------------------------------------
 
     /// Inserts a new input note into the client's store.
-    pub fn insert_input_note(&mut self, note: RecordedNote) -> Result<(), ClientError> {
+    pub fn import_input_note(&mut self, note: RecordedNote) -> Result<(), ClientError> {
         self.store
             .insert_input_note(&note)
             .map_err(|err| err.into())

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -1,4 +1,4 @@
-use crypto::{utils::Serializable, StarkField};
+use crypto::utils::Serializable;
 use miden_lib::notes::{create_note, Script};
 use miden_node_proto::{
     requests::SubmitProvenTransactionRequest, responses::SubmitProvenTransactionResponse,
@@ -179,7 +179,7 @@ impl Client {
             .load_account(target_account_id)
             .map_err(ClientError::TransactionExecutionError)?;
 
-        let block_ref = data_store.block_header.block_num().as_int() as u32;
+        let block_ref = data_store.block_header.block_num();
         let note_origins = data_store
             .notes
             .iter()

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -142,7 +142,7 @@ pub fn insert_mock_data(client: &mut Client) {
 
     // insert notes into database
     for note in recorded_notes.into_iter() {
-        client.insert_input_note(note).unwrap();
+        client.import_input_note(note).unwrap();
     }
 
     // insert account

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -99,8 +99,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
     let chain_tip = 10;
 
     // create a block header for the response
-    let block_header: objects::BlockHeader =
-        block::mock_block_header(chain_tip.into(), None, None, &[]);
+    let block_header: objects::BlockHeader = block::mock_block_header(chain_tip, None, None, &[]);
 
     // create a state sync response
     let response = SyncStateResponse {

--- a/src/store/mock_executor_data_store.rs
+++ b/src/store/mock_executor_data_store.rs
@@ -6,7 +6,6 @@ use mock::{
     mock::notes::AssetPreservationStatus,
     mock::transaction::{mock_inputs, mock_inputs_with_existing},
 };
-use objects::AdviceInputs;
 use objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, AccountVault, StorageSlotType},
     assembly::ModuleAst,
@@ -14,8 +13,9 @@ use objects::{
     assets::{Asset, FungibleAsset},
     crypto::{dsa::rpo_falcon512::KeyPair, utils::Serializable},
     notes::{Note, NoteOrigin, NoteScript, RecordedNote},
-    BlockHeader, ChainMmr, Felt, Word,
+    BlockHeader, Felt, Word,
 };
+use objects::{transaction::ChainMmr, AdviceInputs};
 
 // MOCK DATA STORE
 // ================================================================================================

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -324,7 +324,7 @@ fn serialize_input_note(
     let recipients = serde_json::to_string(&recorded_note.note().metadata().tag())
         .map_err(StoreError::InputSerializationError)?;
     let status = String::from("committed");
-    let commit_height = recorded_note.origin().block_num.inner() as i64;
+    let commit_height = recorded_note.origin().block_num as i64;
     Ok((
         hash,
         nullifier,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,7 +39,7 @@ async fn test_input_notes_round_trip() {
 
     // insert notes into database
     for note in recorded_notes.iter().cloned() {
-        client.insert_input_note(note).unwrap();
+        client.import_input_note(note).unwrap();
     }
 
     // retrieve notes from database
@@ -69,7 +69,7 @@ async fn test_get_input_note() {
     );
 
     // insert note into database
-    client.insert_input_note(recorded_notes[0].clone()).unwrap();
+    client.import_input_note(recorded_notes[0].clone()).unwrap();
 
     // retrieve note from database
     let retrieved_note = client


### PR DESCRIPTION
In order to register notes that can be passed through a side channel, we need a method to import/export them
