### PR TITLE
feat: Mint transaction and load accounts from Genesis files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,23 @@ edition = "2021"
 rust-version = "1.67"
 
 [features]
-default = ["std", "testing"]
+default = ["std"]
+mock = []
 std = ["crypto/std", "objects/std"]
-testing = ["objects/testing", "mock"]
+testing = ["objects/testing", "miden_lib/testing"]
+concurrent = ["miden_lib/concurrent", "objects/concurrent"]
 
 [dependencies]
 clap = { version = "4.3" , features = ["derive"] }
 crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 lazy_static = "1.4.0"
-miden_node_proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "main", default-features = false }
+miden_node_proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "igamigo-export-seed", default-features = false }
+miden_node_store = { package = "miden-node-store", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "igamigo-export-seed" }
 objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", features = ["serde"] }
 miden_lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 miden_tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false, optional = true }
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 rusqlite_migration = { version = "1.0" }
 rand = { version = "0.8.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/
 miden_lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 miden_tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
-
+mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 rusqlite_migration = { version = "1.0" }
 rand = { version = "0.8.5" }
@@ -38,4 +38,3 @@ comfy-table = "7.1.0"
 
 [dev-dependencies]
 uuid = { version = "1.6.1", features = ["serde", "v4"] }
-mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,31 +10,31 @@ edition = "2021"
 rust-version = "1.67"
 
 [features]
+concurrent = ["miden_lib/concurrent", "objects/concurrent"]
 default = ["std"]
 mock = []
 std = ["crypto/std", "objects/std"]
 testing = ["objects/testing", "miden_lib/testing"]
-concurrent = ["miden_lib/concurrent", "objects/concurrent"]
 
 [dependencies]
+assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 clap = { version = "4.3" , features = ["derive"] }
+comfy-table = "7.1.0"
 crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 lazy_static = "1.4.0"
-miden_node_proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "igamigo-export-seed", default-features = false }
-miden_node_store = { package = "miden-node-store", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "igamigo-export-seed" }
-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", features = ["serde"] }
 miden_lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+miden_node_store = { package = "miden-node-store", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "igamigo-export-seed" }
+miden_node_proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "igamigo-export-seed", default-features = false }
 miden_tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 mock = { package = "miden-mock", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }
+objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", features = ["serde"] }
+rand = { version = "0.8.5" }
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 rusqlite_migration = { version = "1.0" }
-rand = { version = "0.8.5" }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = { version = "1.0", features = ["raw_value"] }
-tonic = { version = "0.10" }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
-comfy-table = "7.1.0"
+tonic = { version = "0.10" }
 
 [dev-dependencies]
 uuid = { version = "1.6.1", features = ["serde", "v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,5 @@ tonic = { version = "0.10" }
 
 [dev-dependencies]
 uuid = { version = "1.6.1", features = ["serde", "v4"] }
+# needed for tests to run always with the mock feature
+miden_client = { package = "miden-client", path = ".", features = ["mock"] }

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -8,7 +8,6 @@ use crypto::{
 use miden_client::client::accounts;
 
 use objects::{accounts::AccountId, assets::TokenSymbol, Digest};
-use objects::{accounts::AccountId, assets::TokenSymbol, Digest};
 
 // ACCOUNT COMMAND
 // ================================================================================================
@@ -141,7 +140,6 @@ fn list_accounts(client: Client) -> Result<(), String> {
             acc.vault_root().to_string(),
             acc.storage_root().to_string(),
             acc.nonce().to_string(),
-            formatted_seed,
         ]);
     });
 

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -7,7 +7,7 @@ use crypto::{
 };
 use miden_client::client::accounts;
 
-use objects::{accounts::AccountId, assets::TokenSymbol};
+use objects::{accounts::AccountId, assets::TokenSymbol, Digest};
 
 // ACCOUNT COMMAND
 // ================================================================================================
@@ -92,11 +92,9 @@ impl AccountCmd {
                     },
                     AccountTemplate::NonFungibleFaucet => todo!(),
                 };
-                let new_account = client
+                let (_new_account, _account_seed) = client
                     .new_account(client_template)
                     .map_err(|err| err.to_string())?;
-
-                println!("New account created: {}", new_account.id());
             }
             AccountCmd::Show { id: None, .. } => {
                 todo!("Default accounts are not supported yet")
@@ -135,7 +133,7 @@ fn list_accounts(client: Client) -> Result<(), String> {
             Cell::new("nonce").add_attribute(Attribute::Bold),
         ]);
 
-    accounts.iter().for_each(|acc| {
+    accounts.iter().for_each(|(acc, _acc_seed)| {
         table.add_row(vec![
             acc.id().to_string(),
             acc.code_root().to_string(),
@@ -157,9 +155,11 @@ pub fn show_account(
     show_storage: bool,
     show_code: bool,
 ) -> Result<(), String> {
-    let account = client
-        .get_account_by_id(account_id)
+    let (account, account_seed) = client
+        .get_account_stub_by_id(account_id)
         .map_err(|err| err.to_string())?;
+
+    let formatted_seed = Digest::from(account_seed).to_string();
 
     let mut table = Table::new();
     table
@@ -171,6 +171,7 @@ pub fn show_account(
             Cell::new("vault root").add_attribute(Attribute::Bold),
             Cell::new("storage root").add_attribute(Attribute::Bold),
             Cell::new("nonce").add_attribute(Attribute::Bold),
+            Cell::new("account seed").add_attribute(Attribute::Bold),
         ]);
 
     table.add_row(vec![
@@ -179,6 +180,7 @@ pub fn show_account(
         account.vault_root().to_string(),
         account.storage_root().to_string(),
         account.nonce().to_string(),
+        formatted_seed,
     ]);
 
     println!("{table}\n");

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -262,12 +262,10 @@ mod tests {
     use miden_client::{
         client::Client,
         config::{ClientConfig, Endpoint},
-        store::notes::{InputNoteRecord},
+        store::notes::InputNoteRecord,
     };
     use mock::mock::{
-        account::MockAccountType,
-        notes::{AssetPreservationStatus},
-        transaction::mock_inputs,
+        account::MockAccountType, notes::AssetPreservationStatus, transaction::mock_inputs,
     };
     use std::env::temp_dir;
     use uuid::Uuid;

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -271,7 +271,7 @@ mod tests {
     use uuid::Uuid;
 
     #[tokio::test]
-    pub async fn import_export_recorded_note() {
+    async fn import_export_recorded_note() {
         // generate test client
         let mut path = temp_dir();
         path.push(Uuid::new_v4().to_string());

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -1,6 +1,8 @@
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::PathBuf,
+};
 
 use super::{Client, Parser};
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
@@ -8,8 +10,7 @@ use miden_client::store::notes::{InputNoteFilter, InputNoteRecord};
 
 use crypto::utils::{Deserializable, Serializable};
 
-use objects::notes::NoteId;
-use objects::Digest;
+use objects::{notes::NoteId, Digest};
 
 #[derive(Debug, Parser, Clone)]
 #[clap(about = "View input notes")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,8 +37,8 @@ pub enum Command {
     SyncState(sync_state::SyncStateCmd),
     #[clap(subcommand)]
     Transaction(transactions::Transaction),
-    #[cfg(feature = "testing")]
-    /// Insert mock data into the client
+    #[cfg(feature = "mock")]
+    /// Insert mock data into the client. This is optional because it takes a few seconds
     MockData {
         #[clap(short, long)]
         transaction: bool,
@@ -66,13 +66,13 @@ impl Cli {
             Command::InputNotes(notes) => notes.execute(client),
             Command::SyncState(tags) => tags.execute(client).await,
             Command::Transaction(transaction) => transaction.execute(client).await,
-            #[cfg(feature = "testing")]
-            Command::MockData { .. } => {
-                // let mut client = client;
-                // miden_client::mock::insert_mock_data(&mut client);
-                // if *transaction {
-                //     miden_client::mock::create_mock_transaction(&mut client).await;
-                // }
+            #[cfg(feature = "mock")]
+            Command::MockData { transaction } => {
+                let mut client = client;
+                miden_client::mock::insert_mock_data(&mut client);
+                if *transaction {
+                    miden_client::mock::create_mock_transaction(&mut client).await;
+                }
                 Ok(())
             }
             Command::LoadGenesis { genesis_path } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,12 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
 use clap::Parser;
-use miden_client::{client::Client, config::ClientConfig};
+use crypto::{dsa::rpo_falcon512::KeyPair, utils::Deserializable};
+use miden_client::{client::Client, config::ClientConfig, store::accounts::AuthInfo};
+use miden_node_store::genesis::GenesisState;
 
 mod account;
 mod input_notes;
@@ -36,6 +43,13 @@ pub enum Command {
         #[clap(short, long)]
         transaction: bool,
     },
+    //#[cfg(feature = "testing")]
+    /// Insert data from node's genesis file
+    LoadGenesis {
+        /// The directory that contains the three files generated from the node: genesis.dat, faucet.fsk and wallet.fs
+        #[clap(short, long)]
+        genesis_path: PathBuf,
+    },
 }
 
 /// CLI entry point
@@ -53,14 +67,51 @@ impl Cli {
             Command::SyncState(tags) => tags.execute(client).await,
             Command::Transaction(transaction) => transaction.execute(client).await,
             #[cfg(feature = "testing")]
-            Command::MockData { transaction } => {
-                let mut client = client;
-                miden_client::mock::insert_mock_data(&mut client);
-                if *transaction {
-                    miden_client::mock::create_mock_transaction(&mut client).await;
-                }
+            Command::MockData { .. } => {
+                // let mut client = client;
+                // miden_client::mock::insert_mock_data(&mut client);
+                // if *transaction {
+                //     miden_client::mock::create_mock_transaction(&mut client).await;
+                // }
                 Ok(())
+            }
+            Command::LoadGenesis { genesis_path } => {
+                let mut client = client;
+                load_genesis_data(&mut client, genesis_path)
             }
         }
     }
+}
+
+pub fn load_genesis_data(client: &mut Client, path: &Path) -> Result<(), String> {
+    let file_contents = fs::read(path.join("genesis.dat")).map_err(|err| err.to_string())?;
+
+    let genesis_state =
+        GenesisState::read_from_bytes(&file_contents).map_err(|err| err.to_string())?;
+
+    if genesis_state.accounts.len() != 2 {
+        return Err(format!(
+            "error: genesis state file should have 2 accounts, has {}",
+            genesis_state.accounts.len()
+        ));
+    }
+
+    for acc_and_seed in genesis_state.accounts {
+        let account = acc_and_seed.account;
+        let seed = acc_and_seed.seed;
+
+        let key_pair = if account.is_faucet() {
+            let file_contents = fs::read(path.join("faucet.fsk")).unwrap();
+            let _ = account.code().procedure_tree();
+
+            KeyPair::read_from_bytes(&file_contents).unwrap()
+        } else {
+            let file_contents = fs::read(path.join("wallet.fsk")).unwrap();
+            KeyPair::read_from_bytes(&file_contents).unwrap()
+        };
+        client
+            .insert_account(&account, seed, &AuthInfo::RpoFalcon512(key_pair))
+            .map_err(|err| err.to_string())?;
+    }
+    Ok(())
 }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -1,17 +1,11 @@
-use comfy_table::presets;
-use comfy_table::Attribute;
-use comfy_table::Cell;
-use comfy_table::ContentArrangement;
-use comfy_table::Table;
+use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 
-use miden_client::client::transactions::PaymentTransactionData;
-use miden_client::client::transactions::TransactionStub;
-use miden_client::client::transactions::TransactionTemplate;
-use objects::accounts::AccountId;
-use objects::assets::FungibleAsset;
+use miden_client::client::transactions::{
+    PaymentTransactionData, TransactionStub, TransactionTemplate,
+};
+use objects::{accounts::AccountId, assets::FungibleAsset};
 
-use super::Client;
-use super::Parser;
+use super::{Client, Parser};
 
 #[derive(Debug, Parser, Clone)]
 #[clap(about = "View transactions")]

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -36,7 +36,6 @@ pub enum TransactionType {
     },
     Mint {
         target_account_id: String,
-        tag: u64,
         faucet_id: String,
         amount: u64,
     },
@@ -79,7 +78,6 @@ impl Transaction {
                     }
                     TransactionType::Mint {
                         faucet_id,
-                        tag,
                         target_account_id,
                         amount,
                     } => {
@@ -91,7 +89,6 @@ impl Transaction {
                             .map_err(|err| err.to_string())?;
                         TransactionTemplate::MintFungibleAsset {
                             asset: fungible_asset,
-                            tag: *tag,
                             target_account_id,
                         }
                     }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -40,6 +40,12 @@ pub enum TransactionType {
         faucet_id: String,
         amount: u64,
     },
+    Mint {
+        target_account_id: String,
+        tag: u64,
+        faucet_id: String,
+        amount: u64,
+    },
     P2IDR,
 }
 
@@ -49,40 +55,62 @@ impl Transaction {
             Transaction::List { pending } => {
                 list_transactions(client, *pending)?;
             }
-            Transaction::New { transaction_type } => match transaction_type {
-                TransactionType::P2ID {
-                    sender_account_id,
-                    target_account_id,
-                    faucet_id,
-                    amount,
-                } => {
-                    let faucet_id =
-                        AccountId::from_hex(faucet_id).map_err(|err| err.to_string())?;
-                    let fungible_asset = FungibleAsset::new(faucet_id, *amount)
-                        .map_err(|err| err.to_string())?
-                        .into();
-                    let sender_account_id =
-                        AccountId::from_hex(sender_account_id).map_err(|err| err.to_string())?;
-                    let target_account_id =
-                        AccountId::from_hex(target_account_id).map_err(|err| err.to_string())?;
-                    let payment_transaction = PaymentTransactionData::new(
-                        fungible_asset,
+            Transaction::New { transaction_type } => {
+                let transaction_template = match transaction_type {
+                    TransactionType::P2ID {
                         sender_account_id,
                         target_account_id,
-                    );
-                    let transaction_execution_result = client
-                        .new_transaction(TransactionTemplate::PayToId(payment_transaction))
-                        .map_err(|err| err.to_string())?;
+                        faucet_id,
+                        amount,
+                    } => {
+                        let faucet_id =
+                            AccountId::from_hex(faucet_id).map_err(|err| err.to_string())?;
+                        let fungible_asset = FungibleAsset::new(faucet_id, *amount)
+                            .map_err(|err| err.to_string())?
+                            .into();
+                        let sender_account_id = AccountId::from_hex(sender_account_id)
+                            .map_err(|err| err.to_string())?;
+                        let target_account_id = AccountId::from_hex(target_account_id)
+                            .map_err(|err| err.to_string())?;
+                        let payment_transaction = PaymentTransactionData::new(
+                            fungible_asset,
+                            sender_account_id,
+                            target_account_id,
+                        );
 
-                    client
-                        .send_transaction(transaction_execution_result)
-                        .await
-                        .map_err(|err| err.to_string())?;
-                }
-                TransactionType::P2IDR => {
-                    todo!()
-                }
-            },
+                        TransactionTemplate::PayToId(payment_transaction)
+                    }
+                    TransactionType::P2IDR => {
+                        todo!()
+                    }
+                    TransactionType::Mint {
+                        faucet_id,
+                        tag,
+                        target_account_id,
+                        amount,
+                    } => {
+                        let faucet_id =
+                            AccountId::from_hex(faucet_id).map_err(|err| err.to_string())?;
+                        let fungible_asset = FungibleAsset::new(faucet_id, *amount)
+                            .map_err(|err| err.to_string())?;
+                        let target_account_id = AccountId::from_hex(target_account_id)
+                            .map_err(|err| err.to_string())?;
+                        TransactionTemplate::MintFungibleAsset {
+                            asset: fungible_asset,
+                            tag: *tag,
+                            target_account_id,
+                        }
+                    }
+                };
+                let transaction_execution_result = client
+                    .new_transaction(transaction_template)
+                    .map_err(|err| err.to_string())?;
+                println!("Executed transaction, proving and then submitting...");
+                client
+                    .send_transaction(transaction_execution_result)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            }
         }
         Ok(())
     }
@@ -116,6 +144,7 @@ where
             Cell::new("committed").add_attribute(Attribute::Bold),
             Cell::new("block number").add_attribute(Attribute::Bold),
             Cell::new("input notes count").add_attribute(Attribute::Bold),
+            Cell::new("output notes count").add_attribute(Attribute::Bold),
         ]);
 
     for tx in executed_transactions {
@@ -128,6 +157,7 @@ where
             tx.committed.to_string(),
             tx.block_num.to_string(),
             tx.input_note_nullifiers.len().to_string(),
+            tx.output_notes.num_notes().to_string(),
         ]);
     }
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -30,12 +30,10 @@ pub enum AccountStorageMode {
 }
 
 impl Client {
-    // ACCOUNT INSERTION
-    // --------------------------------------------------------------------------------------------
-
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 
+    /// Creates a new [Account] based on an [AccountTemplate] and saves it in the store
     pub fn new_account(
         &mut self,
         template: AccountTemplate,
@@ -152,7 +150,6 @@ impl Client {
 
     /// Returns summary info about the accounts managed by this client.
     ///
-    /// TODO: replace `AccountStub` with a more relevant structure.
     pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Word)>, ClientError> {
         self.store.get_accounts().map_err(|err| err.into())
     }
@@ -203,21 +200,5 @@ impl Client {
         self.store
             .get_account_storage(storage_root)
             .map_err(|err| err.into())
-    }
-
-    /// Returns historical states for the account with the specified ID.
-    ///
-    /// TODO: wrap `Account` in a type with additional info.
-    /// TODO: consider changing the interface to support pagination.
-    pub fn get_account_history(&self, _account_id: AccountId) -> Result<Vec<Account>, ClientError> {
-        todo!()
-    }
-
-    /// Returns detailed information about the current state of the account with the specified ID.
-    ///
-    /// TODO: wrap `Account` in a type with additional info (e.g., status).
-    /// TODO: consider adding `nonce` as another parameter to identify a specific account state.
-    pub fn get_account_details(&self, _account_id: AccountId) -> Result<Account, ClientError> {
-        todo!()
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,9 +25,9 @@ pub mod transactions;
 #[cfg(not(any(test, feature = "mock")))]
 pub struct Client {
     /// Local database containing information about the accounts managed by this client.
-    pub(crate) store: Store,
-    pub rpc_api: miden_node_proto::rpc::api_client::ApiClient<tonic::transport::Channel>,
-    pub tx_executor: TransactionExecutor<crate::store::data_store::SqliteDataStore>,
+    store: Store,
+    rpc_api: miden_node_proto::rpc::api_client::ApiClient<tonic::transport::Channel>,
+    tx_executor: TransactionExecutor<crate::store::data_store::SqliteDataStore>,
 }
 
 #[cfg(not(any(test, feature = "mock")))]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -32,7 +32,7 @@ pub struct Client {
     pub rpc_api: crate::mock::MockRpcApi,
     #[cfg(any(test, feature = "mock"))]
     pub(crate) tx_executor:
-        TransactionExecutor<crate::store::mock_executor_data_store::MockDataStore>,
+    TransactionExecutor<crate::store::mock_executor_data_store::MockDataStore>,
     #[cfg(not(any(test, feature = "mock")))]
     pub rpc_api: miden_node_proto::rpc::api_client::ApiClient<tonic::transport::Channel>,
     #[cfg(not(any(test, feature = "mock")))]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,17 +25,11 @@ pub const FILTER_ID_SHIFT: u8 = 48;
 /// - Connects to one or more Miden nodes to periodically sync with the current state of the
 ///   network.
 /// - Executes, proves, and submits transactions to the network as directed by the user.
+#[cfg(not(any(test, feature = "mock")))]
 pub struct Client {
     /// Local database containing information about the accounts managed by this client.
     pub(crate) store: Store,
-    #[cfg(any(test, feature = "mock"))]
-    pub rpc_api: crate::mock::MockRpcApi,
-    #[cfg(any(test, feature = "mock"))]
-    pub(crate) tx_executor:
-        TransactionExecutor<crate::store::mock_executor_data_store::MockDataStore>,
-    #[cfg(not(any(test, feature = "mock")))]
     pub rpc_api: miden_node_proto::rpc::api_client::ApiClient<tonic::transport::Channel>,
-    #[cfg(not(any(test, feature = "mock")))]
     pub tx_executor: TransactionExecutor<crate::store::data_store::SqliteDataStore>,
 }
 
@@ -47,29 +41,43 @@ impl Client {
     ///
     /// # Errors
     /// Returns an error if the client could not be instantiated.
+    #[cfg(not(any(test, feature = "mock")))]
     pub async fn new(config: ClientConfig) -> Result<Self, ClientError> {
-        #[cfg(not(any(test, feature = "mock")))]
-        return Ok(Self {
-            store: Store::new((&config).into())?,
-            rpc_api: miden_node_proto::rpc::api_client::ApiClient::connect(
-                config.node_endpoint.to_string(),
-            )
-            .await
-            .map_err(|err| {
-                ClientError::RpcApiError(crate::errors::RpcApiError::ConnectionError(err))
-            })?,
-            tx_executor: TransactionExecutor::new(crate::store::data_store::SqliteDataStore::new(
-                Store::new((&config).into())?,
-            )),
-        });
+        use crate::{errors::RpcApiError, store::data_store::SqliteDataStore};
+        use miden_node_proto::rpc::api_client::ApiClient;
 
-        #[cfg(any(test, feature = "mock"))]
-        return Ok(Self {
+        Ok(Self {
+            store: Store::new((&config).into())?,
+            rpc_api: ApiClient::connect(config.node_endpoint.to_string())
+                .await
+                .map_err(|err| ClientError::RpcApiError(RpcApiError::ConnectionError(err)))?,
+            tx_executor: TransactionExecutor::new(SqliteDataStore::new(Store::new(
+                (&config).into(),
+            )?)),
+        })
+    }
+}
+
+// TESTING
+// ================================================================================================
+
+#[cfg(any(test, feature = "mock"))]
+pub struct Client {
+    pub(crate) store: Store,
+    pub rpc_api: crate::mock::MockRpcApi,
+    pub(crate) tx_executor:
+        TransactionExecutor<crate::store::mock_executor_data_store::MockDataStore>,
+}
+
+#[cfg(any(test, feature = "mock"))]
+impl Client {
+    pub async fn new(config: ClientConfig) -> Result<Self, ClientError> {
+        use crate::store::mock_executor_data_store::MockDataStore;
+
+        Ok(Self {
             store: Store::new((&config).into())?,
             rpc_api: Default::default(),
-            tx_executor: TransactionExecutor::new(
-                crate::store::mock_executor_data_store::MockDataStore::new(),
-            ),
-        });
+            tx_executor: TransactionExecutor::new(MockDataStore::new()),
+        })
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,9 +14,6 @@ pub mod transactions;
 // CONSTANTS
 // ================================================================================================
 
-/// The number of bits to shift identifiers for in use of filters.
-pub const FILTER_ID_SHIFT: u8 = 48;
-
 /// A light client for connecting to the Miden rollup network.
 ///
 /// Miden client is responsible for managing a set of accounts. Specifically, the client:
@@ -33,6 +30,7 @@ pub struct Client {
     pub tx_executor: TransactionExecutor<crate::store::data_store::SqliteDataStore>,
 }
 
+#[cfg(not(any(test, feature = "mock")))]
 impl Client {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -41,7 +39,6 @@ impl Client {
     ///
     /// # Errors
     /// Returns an error if the client could not be instantiated.
-    #[cfg(not(any(test, feature = "mock")))]
     pub async fn new(config: ClientConfig) -> Result<Self, ClientError> {
         use crate::{errors::RpcApiError, store::data_store::SqliteDataStore};
         use miden_node_proto::rpc::api_client::ApiClient;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -32,7 +32,7 @@ pub struct Client {
     pub rpc_api: crate::mock::MockRpcApi,
     #[cfg(any(test, feature = "mock"))]
     pub(crate) tx_executor:
-    TransactionExecutor<crate::store::mock_executor_data_store::MockDataStore>,
+        TransactionExecutor<crate::store::mock_executor_data_store::MockDataStore>,
     #[cfg(not(any(test, feature = "mock")))]
     pub rpc_api: miden_node_proto::rpc::api_client::ApiClient<tonic::transport::Channel>,
     #[cfg(not(any(test, feature = "mock")))]

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::ClientError,
     store::notes::{InputNoteFilter, InputNoteRecord},
 };
-use objects::Digest;
+use objects::notes::NoteId;
 
 impl Client {
     // INPUT NOTE DATA RETRIEVAL
@@ -19,9 +19,9 @@ impl Client {
     }
 
     /// Returns the input note with the specified hash.
-    pub fn get_input_note(&self, hash: Digest) -> Result<InputNoteRecord, ClientError> {
+    pub fn get_input_note(&self, note_id: NoteId) -> Result<InputNoteRecord, ClientError> {
         self.store
-            .get_input_note_by_hash(hash)
+            .get_input_note_by_id(note_id)
             .map_err(|err| err.into())
     }
 

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -1,7 +1,7 @@
 use super::Client;
 use crypto::StarkField;
 use miden_node_proto::{
-    account_id::AccountId as ProtoAccountId, note::NoteSyncRecord, requests::SyncStateRequest,
+    account::AccountId as ProtoAccountId, note::NoteSyncRecord, requests::SyncStateRequest,
     responses::SyncStateResponse,
 };
 

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -1,7 +1,7 @@
 use super::Client;
 use crypto::StarkField;
 use miden_node_proto::{
-    account::AccountId as ProtoAccountId, note::NoteSyncRecord, requests::SyncStateRequest,
+    account_id::AccountId as ProtoAccountId, note::NoteSyncRecord, requests::SyncStateRequest,
     responses::SyncStateResponse,
 };
 

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -51,7 +51,6 @@ impl Client {
     /// Returns the block number the client has been synced to.
     pub async fn sync_state(&mut self) -> Result<u32, ClientError> {
         loop {
-            println!("trying to sync once");
             let response = self.single_sync_state().await?;
             if let SyncStatus::SyncedToLastBlock(v) = response {
                 return Ok(v);

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -19,7 +19,7 @@ use crate::{
     store::accounts::AuthInfo,
 };
 
-use super::{Client, sync_state::FILTER_ID_SHIFT};
+use super::{sync_state::FILTER_ID_SHIFT, Client};
 
 pub enum TransactionTemplate {
     /// Consume all outstanding notes for an account

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -19,7 +19,7 @@ use crate::{
     store::accounts::AuthInfo,
 };
 
-use super::Client;
+use super::{Client, FILTER_ID_SHIFT};
 
 pub enum TransactionTemplate {
     /// Consume all outstanding notes for an account
@@ -28,7 +28,6 @@ pub enum TransactionTemplate {
     /// Mint fungible assets using a faucet account
     MintFungibleAsset {
         asset: FungibleAsset,
-        tag: u64,
         target_account_id: AccountId,
     },
     /// Creates a pay-to-id note directed to a specific account from a faucet
@@ -130,7 +129,6 @@ impl Client {
             TransactionTemplate::ConsumeNotes(_) => todo!(),
             TransactionTemplate::MintFungibleAsset {
                 asset,
-                tag: _tag,
                 target_account_id,
             } => self.new_mint_fungible_asset_transaction(asset, target_account_id),
         }
@@ -188,7 +186,7 @@ impl Client {
                 end
             ",
                 recipient = recipient,
-                tag = Felt::new(target_id.into()),
+                tag = Felt::new(Into::<u64>::into(target_id) >> FILTER_ID_SHIFT),
                 amount = Felt::new(asset.amount()),
             )
             .as_str(),

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -19,7 +19,7 @@ use crate::{
     store::accounts::AuthInfo,
 };
 
-use super::{Client, FILTER_ID_SHIFT};
+use super::{Client, sync_state::FILTER_ID_SHIFT};
 
 pub enum TransactionTemplate {
     /// Consume all outstanding notes for an account

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,12 +1,15 @@
 use core::fmt;
-use crypto::merkle::MmrError;
-use crypto::utils::DeserializationError;
-use crypto::{dsa::rpo_falcon512::FalconError, utils::HexParseError};
+use crypto::{
+    dsa::rpo_falcon512::FalconError,
+    merkle::MmrError,
+    utils::{DeserializationError, HexParseError},
+};
 use miden_node_proto::error::ParseError;
 use miden_tx::{TransactionExecutorError, TransactionProverError};
-use objects::notes::NoteId;
-use objects::{accounts::AccountId, AccountError, Digest, NoteError, TransactionScriptError};
-use objects::{AssetError, AssetVaultError};
+use objects::{
+    accounts::AccountId, notes::NoteId, AccountError, AssetError, AssetVaultError, Digest,
+    NoteError, TransactionScriptError,
+};
 use tonic::{transport::Error as TransportError, Status as TonicStatus};
 
 // CLIENT ERROR

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,6 @@ use crypto::{dsa::rpo_falcon512::FalconError, utils::HexParseError};
 use miden_node_proto::error::ParseError;
 use miden_tx::{TransactionExecutorError, TransactionProverError};
 use objects::notes::NoteId;
-use objects::AssetError;
 use objects::{accounts::AccountId, AccountError, Digest, NoteError, TransactionScriptError};
 use objects::{AssetError, AssetVaultError};
 use tonic::{transport::Error as TransportError, Status as TonicStatus};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod config;
 pub mod errors;
 pub mod store;
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "mock"))]
 pub mod mock;
 
 #[cfg(test)]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -308,7 +308,7 @@ pub async fn create_mock_transaction(client: &mut Client) {
 
     let asset: objects::assets::Asset = FungibleAsset::new(faucet.id(), 5u64).unwrap().into();
 
-    // Test submitting a P2ID transaction
+    // Insert a P2ID transaction object
 
     let transaction_template = TransactionTemplate::PayToId(PaymentTransactionData::new(
         asset,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,6 +1,6 @@
 use crate::client::{
     transactions::{PaymentTransactionData, TransactionTemplate},
-    Client, FILTER_ID_SHIFT,
+    Client, sync_state::FILTER_ID_SHIFT,
 };
 use crypto::{dsa::rpo_falcon512::KeyPair, Felt, FieldElement, StarkField};
 use miden_lib::transaction::TransactionKernel;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,6 +1,7 @@
 use crate::client::{
+    sync_state::FILTER_ID_SHIFT,
     transactions::{PaymentTransactionData, TransactionTemplate},
-    Client, sync_state::FILTER_ID_SHIFT,
+    Client,
 };
 use crypto::{dsa::rpo_falcon512::KeyPair, Felt, FieldElement, StarkField};
 use miden_lib::transaction::TransactionKernel;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,30 +1,34 @@
-use crate::client::transactions::{PaymentTransactionData, TransactionTemplate};
-use crate::client::{Client, FILTER_ID_SHIFT};
-use crypto::{dsa::rpo_falcon512::KeyPair, StarkField};
-use crypto::{Felt, FieldElement};
-use miden_lib::transaction::TransactionKernel;
-use miden_node_proto::account_id::AccountId as ProtoAccountId;
-use miden_node_proto::block_header::BlockHeader as NodeBlockHeader;
-use miden_node_proto::merkle::MerklePath;
-use miden_node_proto::note::NoteSyncRecord;
-use miden_node_proto::requests::SubmitProvenTransactionRequest;
-use miden_node_proto::responses::SubmitProvenTransactionResponse;
-use miden_node_proto::{
-    requests::SyncStateRequest,
-    responses::{NullifierUpdate, SyncStateResponse},
+use crate::client::{
+    transactions::{PaymentTransactionData, TransactionTemplate},
+    Client, FILTER_ID_SHIFT,
 };
-use mock::constants::{generate_account_seed, AccountSeedType};
-use mock::mock::account::mock_account;
+use crypto::{dsa::rpo_falcon512::KeyPair, Felt, FieldElement, StarkField};
+use miden_lib::transaction::TransactionKernel;
+use miden_node_proto::{
+    account_id::AccountId as ProtoAccountId,
+    block_header::BlockHeader as NodeBlockHeader,
+    merkle::MerklePath,
+    note::NoteSyncRecord,
+    requests::{SubmitProvenTransactionRequest, SyncStateRequest},
+    responses::{NullifierUpdate, SubmitProvenTransactionResponse, SyncStateResponse},
+};
+use mock::{
+    constants::{generate_account_seed, AccountSeedType},
+    mock::account::mock_account,
+};
 
-use mock::mock::block;
-use mock::mock::notes::{mock_notes, AssetPreservationStatus};
-use objects::transaction::InputNotes;
-use objects::utils::collections::BTreeMap;
+use mock::mock::{
+    block,
+    notes::{mock_notes, AssetPreservationStatus},
+};
+use objects::{transaction::InputNotes, utils::collections::BTreeMap};
 
 use crate::store::accounts::AuthInfo;
 
-use objects::accounts::{AccountId, AccountType};
-use objects::assets::FungibleAsset;
+use objects::{
+    accounts::{AccountId, AccountType},
+    assets::FungibleAsset,
+};
 
 /// Mock RPC API
 ///

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -6,7 +6,7 @@ use crate::client::{
 use crypto::{dsa::rpo_falcon512::KeyPair, Felt, FieldElement, StarkField};
 use miden_lib::transaction::TransactionKernel;
 use miden_node_proto::{
-    account_id::AccountId as ProtoAccountId,
+    account::AccountId as ProtoAccountId,
     block_header::BlockHeader as NodeBlockHeader,
     merkle::MerklePath,
     note::NoteSyncRecord,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -25,7 +25,6 @@ use crate::store::accounts::AuthInfo;
 
 use objects::accounts::{AccountId, AccountType};
 use objects::assets::FungibleAsset;
-use objects::transaction::InputNotes;
 
 /// Mock RPC API
 ///

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -374,7 +374,7 @@ pub(crate) fn parse_accounts(
             (nonce as u64).into(),
             serde_json::from_str(&vault_root).map_err(StoreError::JsonDataDeserializationError)?,
             Digest::try_from(&storage_root).map_err(StoreError::HexParseError)?,
-            serde_json::from_str(&code_root).map_err(StoreError::JsonDataDeserializationError)?,
+            Digest::try_from(&code_root).map_err(StoreError::HexParseError)?,
         ),
         account_seed_word,
     ))
@@ -383,8 +383,7 @@ pub(crate) fn parse_accounts(
 /// Serialized the provided account into database compatible types.
 fn serialize_account(account: &Account) -> Result<SerializedAccountData, StoreError> {
     let id: u64 = account.id().into();
-    let code_root = serde_json::to_string(&account.code().root())
-        .map_err(StoreError::InputSerializationError)?;
+    let code_root = account.code().root().to_string();
     let storage_root = account.storage().root().to_string();
     let vault_root = serde_json::to_string(&account.vault().commitment())
         .map_err(StoreError::InputSerializationError)?;

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -3,18 +3,17 @@ use super::Store;
 use crate::errors::StoreError;
 
 use clap::error::Result;
-use crypto::dsa::rpo_falcon512::KeyPair;
-use crypto::hash::rpo::RpoDigest;
-use crypto::utils::{Deserializable, Serializable};
-use crypto::Word;
+use crypto::{
+    dsa::rpo_falcon512::KeyPair,
+    hash::rpo::RpoDigest,
+    utils::{Deserializable, Serializable},
+    Word,
+};
 use miden_lib::transaction::TransactionKernel;
-use objects::accounts::AccountStub;
-use objects::assembly::AstSerdeOptions;
-use objects::assets::AssetVault;
 use objects::{
-    accounts::{Account, AccountCode, AccountId, AccountStorage},
-    assembly::ModuleAst,
-    assets::Asset,
+    accounts::{Account, AccountCode, AccountId, AccountStorage, AccountStub},
+    assembly::{AstSerdeOptions, ModuleAst},
+    assets::{Asset, AssetVault},
     Digest,
 };
 use rusqlite::{params, Transaction};

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -274,11 +274,6 @@ impl Store {
         account: &Account,
         account_seed: Word,
     ) -> Result<(), StoreError> {
-    fn insert_account_record(
-        tx: &Transaction<'_>,
-        account: &Account,
-        account_seed: Word,
-    ) -> Result<(), StoreError> {
         let (id, code_root, storage_root, vault_root, nonce, committed) =
             serialize_account(account)?;
 

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -144,6 +144,17 @@ impl Store {
             .ok_or(StoreError::AccountDataNotFound(account_id))?
     }
 
+    /// Retrieves an account's [ModuleAst] and the code root by [AccountId]
+    pub fn get_account_code_by_account_id(
+        &self,
+        account_id: AccountId,
+    ) -> Result<(Vec<RpoDigest>, ModuleAst), StoreError> {
+        // TODO: This could be done via a single query
+        let (account, _seed) = self.get_account_stub_by_id(account_id)?;
+
+        self.get_account_code(account.code_root())
+    }
+
     // TODO: Get all parts from a single query
     /// Retrieves a full [Account] object
     pub fn get_account_by_id(&self, account_id: AccountId) -> Result<(Account, Word), StoreError> {

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -67,10 +67,6 @@ impl DataStore for SqliteDataStore {
         // TODO:
         //  - To build the return (partial) ChainMmr: From the block numbers in each note.origin(), get the list of block headers
         //    and construct the partial Mmr
-        let _previous_nodes = self
-            .store
-            .get_chain_mmr_nodes()
-            .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
 
         // build partial mmr from the nodes - partial_mmr should be on memory as part of our store
         let partial_mmr: PartialMmr = {
@@ -105,14 +101,9 @@ impl DataStore for SqliteDataStore {
     }
 
     fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
-        let (account, _seed) = self
-            .store
-            .get_account_stub_by_id(account_id)
-            .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
-
         let (_, module_ast) = self
             .store
-            .get_account_code(account.code_root())
+            .get_account_code_by_account_id(account_id)
             .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
 
         Ok(module_ast)

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -1,0 +1,120 @@
+use super::Store;
+use crypto::merkle::PartialMmr;
+use miden_tx::{DataStore, DataStoreError, TransactionInputs};
+
+use objects::{
+    accounts::AccountId,
+    assembly::ModuleAst,
+    transaction::{ChainMmr, InputNote, InputNotes},
+};
+
+// DATA STORE
+// ================================================================================================
+
+pub struct SqliteDataStore {
+    /// Local database containing information about the accounts managed by this client.
+    pub(crate) store: Store,
+}
+
+impl SqliteDataStore {
+    pub fn new(store: Store) -> Self {
+        Self { store }
+    }
+}
+
+impl DataStore for SqliteDataStore {
+    fn get_transaction_inputs(
+        &self,
+        account_id: AccountId,
+        block_num: u32,
+        notes: &[objects::notes::NoteId],
+    ) -> Result<TransactionInputs, DataStoreError> {
+        // Construct Account
+        let (account, seed) = self
+            .store
+            .get_account_by_id(account_id)
+            .map_err(|_| DataStoreError::AccountNotFound(account_id))?;
+
+        // Get header data
+
+        let block_header = self
+            .store
+            .get_block_header_by_num(block_num)
+            .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
+
+        let mut list_of_notes = vec![];
+
+        let mut notes_blocks: Vec<objects::BlockHeader> = vec![];
+        for note_id in notes {
+            let input_note_record = self
+                .store
+                .get_input_note_by_id(*note_id)
+                .map_err(|_| DataStoreError::AccountNotFound(account_id))?;
+
+            let input_note: InputNote = input_note_record
+                .try_into()
+                .map_err(|_| DataStoreError::AccountNotFound(account_id))?;
+            list_of_notes.push(input_note.clone());
+
+            let note_block_num = input_note.proof().origin().block_num;
+            let note_block = self
+                .store
+                .get_block_header_by_num(note_block_num)
+                .map_err(|_| DataStoreError::AccountNotFound(account_id))?;
+            notes_blocks.push(note_block);
+        }
+
+        // TODO:
+        //  - To build the return (partial) ChainMmr: From the block numbers in each note.origin(), get the list of block headers
+        //    and construct the partial Mmr
+        let _previous_nodes = self
+            .store
+            .get_chain_mmr_nodes()
+            .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
+
+        // build partial mmr from the nodes - partial_mmr should be on memory as part of our store
+        let partial_mmr: PartialMmr = {
+            // we are supposed to have data by this point, so reconstruct the partial mmr
+            let current_peaks = self
+                .store
+                .get_chain_mmr_peaks_by_block_num(block_num)
+                .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
+
+            PartialMmr::from_peaks(current_peaks)
+        };
+
+        let chain_mmr = ChainMmr::new(
+            partial_mmr,
+            notes_blocks
+                .iter()
+                .map(|b| (b.block_num(), b.hash()))
+                .collect(),
+        )
+        .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
+
+        let input_notes = InputNotes::new(list_of_notes)
+            .map_err(|_| DataStoreError::AccountNotFound(account_id))?;
+
+        let seed = if account.is_new() { Some(seed) } else { None };
+        let transaction_inputs =
+            TransactionInputs::new(account, seed, block_header, chain_mmr, input_notes)
+                .map_err(|err| println!("{}", err))
+                .unwrap();
+
+        Ok(transaction_inputs)
+    }
+
+    fn get_account_code(&self, account_id: AccountId) -> Result<ModuleAst, DataStoreError> {
+        let (account, _seed) = self
+            .store
+            .get_account_stub_by_id(account_id)
+            .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
+
+        let (_, module_ast) = self
+            .store
+            .get_account_code(account.code_root())
+            .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
+
+        Ok(module_ast)
+    }
+}

--- a/src/store/mock_executor_data_store.rs
+++ b/src/store/mock_executor_data_store.rs
@@ -1,24 +1,24 @@
 use assembly::{Library, LibraryPath};
-use miden_lib::transaction::memory::FAUCET_STORAGE_DATA_SLOT;
-use miden_lib::transaction::TransactionKernel;
-use miden_lib::MidenLib;
-use miden_tx::{DataStore, DataStoreError, TransactionInputs};
-use mock::constants::{
-    ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_SENDER, DEFAULT_ACCOUNT_CODE,
+use miden_lib::{
+    transaction::{memory::FAUCET_STORAGE_DATA_SLOT, TransactionKernel},
+    MidenLib,
 };
-use mock::mock::account::MockAccountType;
-use mock::mock::notes::AssetPreservationStatus;
-use mock::mock::transaction::{mock_inputs, mock_inputs_with_existing};
-use objects::assets::AssetVault;
-use objects::notes::NoteId;
-use objects::transaction::{ChainMmr, InputNotes};
+use miden_tx::{DataStore, DataStoreError, TransactionInputs};
+use mock::{
+    constants::{ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN, ACCOUNT_ID_SENDER, DEFAULT_ACCOUNT_CODE},
+    mock::{
+        account::MockAccountType,
+        notes::AssetPreservationStatus,
+        transaction::{mock_inputs, mock_inputs_with_existing},
+    },
+};
 use objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, StorageSlotType},
-    assembly::ModuleAst,
-    assembly::ProgramAst,
-    assets::{Asset, FungibleAsset},
+    assembly::{ModuleAst, ProgramAst},
+    assets::{Asset, AssetVault, FungibleAsset},
     crypto::{dsa::rpo_falcon512::KeyPair, utils::Serializable},
-    notes::{Note, NoteScript},
+    notes::{Note, NoteId, NoteScript},
+    transaction::{ChainMmr, InputNotes},
     BlockHeader, Felt, Word,
 };
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,7 +1,6 @@
 use crate::{config::StoreConfig, errors::StoreError};
 
 use clap::error::Result;
-use crypto::merkle::Mmr;
 use rusqlite::Connection;
 
 pub mod accounts;
@@ -21,7 +20,6 @@ pub mod data_store;
 
 pub struct Store {
     pub(crate) db: Connection,
-    pub(crate) mmr: Mmr,
 }
 
 impl Store {
@@ -32,9 +30,8 @@ impl Store {
     pub fn new(config: StoreConfig) -> Result<Self, StoreError> {
         let mut db = Connection::open(config.path).map_err(StoreError::ConnectionError)?;
         migrations::update_to_latest(&mut db)?;
-        let mmr = Mmr::new();
 
-        Ok(Self { db, mmr })
+        Ok(Self { db })
     }
 }
 
@@ -43,7 +40,6 @@ impl Store {
 
 #[cfg(test)]
 pub mod tests {
-    use crypto::merkle::Mmr;
     use std::env::temp_dir;
     use uuid::Uuid;
 
@@ -62,9 +58,6 @@ pub mod tests {
         let mut db = Connection::open(temp_file).unwrap();
         migrations::update_to_latest(&mut db).unwrap();
 
-        Store {
-            db,
-            mmr: Mmr::new(),
-        }
+        Store { db }
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,5 +1,4 @@
-use crate::config::StoreConfig;
-use crate::errors::StoreError;
+use crate::{config::StoreConfig, errors::StoreError};
 
 use clap::error::Result;
 use crypto::merkle::Mmr;

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -1,22 +1,20 @@
-use crate::errors::StoreError;
+use crate::errors::{ClientError, StoreError};
 
 use super::Store;
 
 use clap::error::Result;
+
 use crypto::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
-use objects::notes::{Note, NoteInclusionProof, NoteScript};
+use objects::notes::{Note, NoteAssets, NoteId, NoteInclusionProof, NoteInputs, NoteScript};
 
-use objects::{
-    accounts::AccountId,
-    notes::{NoteMetadata, RecordedNote},
-    Digest, Felt,
-};
+use objects::transaction::InputNote;
+use objects::{accounts::AccountId, notes::NoteMetadata, Digest, Felt};
 use rusqlite::params;
 
 pub(crate) const INSERT_NOTE_QUERY: &str = "\
 INSERT INTO input_notes
-    (hash, nullifier, script, vault, inputs, serial_num, sender_id, tag, num_assets, inclusion_proof, recipients, status, commit_height)
+    (note_id, nullifier, script, vault, inputs, serial_num, sender_id, tag, num_assets, inclusion_proof, recipients, status, commit_height)
  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 // TYPES
@@ -26,27 +24,27 @@ type SerializedInputNoteData = (
     String,
     String,
     Vec<u8>,
-    String,
-    String,
+    Vec<u8>,
+    Vec<u8>,
     String,
     i64,
     i64,
     i64,
-    Option<String>,
+    Option<Vec<u8>>,
     String,
     String,
-    u32,
+    i64,
 );
 
 type SerializedInputNoteParts = (
     Vec<u8>,
-    String,
-    String,
+    Vec<u8>,
+    Vec<u8>,
     String,
     u64,
     u64,
     u64,
-    Option<String>,
+    Option<Vec<u8>>,
 );
 
 // NOTE FILTER
@@ -88,6 +86,10 @@ impl InputNoteRecord {
         &self.note
     }
 
+    pub fn note_id(&self) -> NoteId {
+        self.note.id()
+    }
+
     pub fn inclusion_proof(&self) -> Option<&NoteInclusionProof> {
         self.inclusion_proof.as_ref()
     }
@@ -119,8 +121,8 @@ impl From<Note> for InputNoteRecord {
     }
 }
 
-impl From<RecordedNote> for InputNoteRecord {
-    fn from(recorded_note: RecordedNote) -> Self {
+impl From<InputNote> for InputNoteRecord {
+    fn from(recorded_note: InputNote) -> Self {
         InputNoteRecord {
             note: recorded_note.note().clone(),
             inclusion_proof: Some(recorded_note.proof().clone()),
@@ -128,10 +130,25 @@ impl From<RecordedNote> for InputNoteRecord {
     }
 }
 
-impl Store {
-    // NOTES
-    // --------------------------------------------------------------------------------------------
+impl TryInto<InputNote> for InputNoteRecord {
+    type Error = ClientError;
 
+    fn try_into(self) -> Result<InputNote, Self::Error> {
+        match self.inclusion_proof() {
+            Some(proof) => Ok(InputNote::new(self.note().clone(), proof.clone())),
+            None => Err(ClientError::NoteError(
+                objects::NoteError::invalid_origin_index(
+                    "Input Note Record contains no proof".to_string(),
+                ),
+            )),
+        }
+    }
+}
+
+// NOTES STORE METHODS
+// --------------------------------------------------------------------------------------------
+
+impl Store {
     /// Retrieves the input notes from the database
     pub fn get_input_notes(
         &self,
@@ -150,15 +167,15 @@ impl Store {
             .collect::<Result<Vec<InputNoteRecord>, _>>()
     }
 
-    /// Retrieves the input note with the specified hash from the database
-    pub fn get_input_note_by_hash(&self, hash: Digest) -> Result<InputNoteRecord, StoreError> {
-        let query_hash = &hash.to_string();
-        const QUERY: &str = "SELECT script, inputs, vault, serial_num, sender_id, tag, num_assets, inclusion_proof FROM input_notes WHERE hash = ?";
+    /// Retrieves the input note with the specified id from the database
+    pub fn get_input_note_by_id(&self, note_id: NoteId) -> Result<InputNoteRecord, StoreError> {
+        let query_id = &note_id.inner().to_string();
+        const QUERY: &str = "SELECT script, inputs, vault, serial_num, sender_id, tag, num_assets, inclusion_proof FROM input_notes WHERE note_id = ?";
 
         self.db
             .prepare(QUERY)
             .map_err(StoreError::QueryError)?
-            .query_map(params![query_hash.to_string()], parse_input_note_columns)
+            .query_map(params![query_id.to_string()], parse_input_note_columns)
             .map_err(StoreError::QueryError)?
             .map(|result| {
                 result
@@ -166,13 +183,13 @@ impl Store {
                     .and_then(parse_input_note)
             })
             .next()
-            .ok_or(StoreError::InputNoteNotFound(hash))?
+            .ok_or(StoreError::InputNoteNotFound(note_id))?
     }
 
     /// Inserts the provided input note into the database
     pub fn insert_input_note(&self, note: &InputNoteRecord) -> Result<(), StoreError> {
         let (
-            hash,
+            note_id,
             nullifier,
             script,
             vault,
@@ -191,7 +208,7 @@ impl Store {
             .execute(
                 INSERT_NOTE_QUERY,
                 params![
-                    hash,
+                    note_id,
                     nullifier,
                     script,
                     vault,
@@ -236,13 +253,13 @@ fn parse_input_note_columns(
     row: &rusqlite::Row<'_>,
 ) -> Result<SerializedInputNoteParts, rusqlite::Error> {
     let script: Vec<u8> = row.get(0)?;
-    let inputs: String = row.get(1)?;
-    let vault: String = row.get(2)?;
+    let inputs: Vec<u8> = row.get(1)?;
+    let vault: Vec<u8> = row.get(2)?;
     let serial_num: String = row.get(3)?;
     let sender_id = row.get::<usize, i64>(4)? as u64;
     let tag = row.get::<usize, i64>(5)? as u64;
     let num_assets = row.get::<usize, i64>(6)? as u64;
-    let inclusion_proof: Option<String> = row.get(7)?;
+    let inclusion_proof: Option<Vec<u8>> = row.get(7)?;
     Ok((
         script,
         inputs,
@@ -259,12 +276,14 @@ fn parse_input_note_columns(
 fn parse_input_note(
     serialized_input_note_parts: SerializedInputNoteParts,
 ) -> Result<InputNoteRecord, StoreError> {
-    let (script, inputs, vault, serial_num, sender_id, tag, num_assets, inclusion_proof) =
+    let (script, inputs, note_assets, serial_num, sender_id, tag, num_assets, inclusion_proof) =
         serialized_input_note_parts;
     let script =
         NoteScript::read_from_bytes(&script).map_err(StoreError::DataDeserializationError)?;
-    let inputs = serde_json::from_str(&inputs).map_err(StoreError::JsonDataDeserializationError)?;
-    let vault = serde_json::from_str(&vault).map_err(StoreError::JsonDataDeserializationError)?;
+    let inputs =
+        NoteInputs::read_from_bytes(&inputs).map_err(StoreError::DataDeserializationError)?;
+    let vault =
+        NoteAssets::read_from_bytes(&note_assets).map_err(StoreError::DataDeserializationError)?;
     let serial_num =
         serde_json::from_str(&serial_num).map_err(StoreError::JsonDataDeserializationError)?;
     let note_metadata = NoteMetadata::new(
@@ -274,14 +293,12 @@ fn parse_input_note(
     );
     let note = Note::from_parts(script, inputs, vault, serial_num, note_metadata);
 
-    let inclusion_proof = match inclusion_proof {
-        Some(proof) => {
-            let inclusion_proof =
-                serde_json::from_str(&proof).map_err(StoreError::JsonDataDeserializationError)?;
-            Some(inclusion_proof)
-        }
-        None => None,
-    };
+    let inclusion_proof = inclusion_proof
+        .map(|proof| {
+            NoteInclusionProof::read_from_bytes(&proof)
+                .map_err(StoreError::DataDeserializationError)
+        })
+        .transpose()?;
 
     Ok(InputNoteRecord::new(note, inclusion_proof))
 }
@@ -290,34 +307,32 @@ fn parse_input_note(
 pub(crate) fn serialize_input_note(
     note: &InputNoteRecord,
 ) -> Result<SerializedInputNoteData, StoreError> {
-    let hash = note.note().hash().to_string();
+    let note_id = note.note_id().inner().to_string();
     let nullifier = note.note().nullifier().inner().to_string();
     let script = note.note().script().to_bytes();
-    let vault =
-        serde_json::to_string(&note.note().vault()).map_err(StoreError::InputSerializationError)?;
-    let inputs = serde_json::to_string(&note.note().inputs())
-        .map_err(StoreError::InputSerializationError)?;
+    let note_assets = note.note().assets().to_bytes();
+    let inputs = note.note().inputs().to_bytes();
     let serial_num = serde_json::to_string(&note.note().serial_num())
         .map_err(StoreError::InputSerializationError)?;
     let sender_id = u64::from(note.note().metadata().sender()) as i64;
     let tag = u64::from(note.note().metadata().tag()) as i64;
     let num_assets = u64::from(note.note().metadata().num_assets()) as i64;
-    let (inclusion_proof, commit_height, status) = match note.inclusion_proof() {
+    let (inclusion_proof, status, commit_height) = match note.inclusion_proof() {
         Some(proof) => (
-            Some(serde_json::to_string(&proof).map_err(StoreError::InputSerializationError)?),
-            proof.origin().block_num,
+            Some(proof.to_bytes()),
             String::from("committed"),
+            proof.origin().block_num,
         ),
-        None => (None, 0u32, String::from("pending")),
+        None => (None, String::from("pending"), 0u32),
     };
+    //(note_id, nullifier, script, vault, inputs, serial_num, sender_id, tag, num_assets, inclusion_proof, recipients, status, commit_height)
+    let recipients = note.note().recipient().to_string();
 
-    let recipients = serde_json::to_string(&note.note().metadata().tag())
-        .map_err(StoreError::InputSerializationError)?;
     Ok((
-        hash,
+        note_id,
         nullifier,
         script,
-        vault,
+        note_assets,
         inputs,
         serial_num,
         sender_id,
@@ -326,6 +341,6 @@ pub(crate) fn serialize_input_note(
         inclusion_proof,
         recipients,
         status,
-        commit_height,
+        commit_height as i64,
     ))
 }

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -8,8 +8,7 @@ use crypto::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError
 
 use objects::notes::{Note, NoteAssets, NoteId, NoteInclusionProof, NoteInputs, NoteScript};
 
-use objects::transaction::InputNote;
-use objects::{accounts::AccountId, notes::NoteMetadata, Digest, Felt};
+use objects::{accounts::AccountId, notes::NoteMetadata, transaction::InputNote, Digest, Felt};
 use rusqlite::params;
 
 pub(crate) const INSERT_NOTE_QUERY: &str = "\

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -68,7 +68,7 @@ impl InputNoteFilter {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct InputNoteRecord {
     note: Note,
     inclusion_proof: Option<NoteInclusionProof>,

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -1,4 +1,7 @@
-use crypto::merkle::{Mmr, PartialMmr};
+use crypto::{
+    merkle::{MmrPeaks, PartialMmr},
+    utils::Serializable,
+};
 use miden_node_proto::{mmr::MmrDelta, responses::AccountHashUpdate};
 
 use objects::{notes::NoteInclusionProof, BlockHeader, Digest};
@@ -73,12 +76,18 @@ impl Store {
 
     pub fn apply_state_sync(
         &mut self,
+        current_block_num: u32,
         block_header: BlockHeader,
         nullifiers: Vec<Digest>,
         account_updates: Vec<AccountHashUpdate>,
         mmr_delta: Option<MmrDelta>,
         committed_notes: Vec<(Digest, NoteInclusionProof)>,
     ) -> Result<(), StoreError> {
+        // get current nodes on table
+        // we need to do this here because creating a sql tx borrows a mut reference
+        let _previous_nodes = self.get_chain_mmr_nodes()?;
+        let current_peaks = self.get_chain_mmr_peaks_by_block_num(current_block_num)?;
+
         let tx = self
             .db
             .transaction()
@@ -92,7 +101,7 @@ impl Store {
                 let account_id_int: u64 = account_id.clone().into();
                 const ACCOUNT_HASH_QUERY: &str = "SELECT hash FROM accounts WHERE id = ?";
 
-                if let Some(Ok(acc_stub)) = tx
+                if let Some(Ok((acc_stub, _acc_seed))) = tx
                     .prepare(ACCOUNT_HASH_QUERY)
                     .map_err(StoreError::QueryError)?
                     .query_map(params![account_id_int as i64], parse_accounts_columns)
@@ -130,44 +139,50 @@ impl Store {
         // update chain mmr nodes on the table
         // get all elements from the chain mmr table
         if let Some(mmr_delta) = mmr_delta {
-            // get current nodes on table
-            let previous_nodes = Self::get_chain_mmr_nodes(&tx)?;
-
             // build partial mmr from the nodes - partial_mmr should be on memory as part of our store
-            let leaves: Vec<Digest> = previous_nodes.values().cloned().collect();
-            let mmr: Mmr = leaves.into();
-            let mut partial_mmr: PartialMmr = mmr
-                .peaks(mmr.forest())
-                .map_err(StoreError::MmrError)?
-                .into();
+
+            let mut partial_mmr: PartialMmr = if current_block_num == 0 {
+                // first block we receive so we are good to create a blank partial mmr for this
+                MmrPeaks::new(0, vec![])
+                    .map_err(StoreError::MmrError)?
+                    .into()
+            } else {
+                PartialMmr::from_peaks(current_peaks)
+            };
 
             // apply the delta
-            let new_authentication_nodes = partial_mmr
-                .apply(mmr_delta.try_into().unwrap())
-                .map_err(StoreError::MmrError)?;
-            for (node_id, node) in new_authentication_nodes {
-                Store::insert_chain_mmr_node(&tx, node_id, node)?;
-            }
+            let mmr_delta: crypto::merkle::MmrDelta = mmr_delta.try_into().unwrap();
+
+            let new_authentication_nodes =
+                partial_mmr.apply(mmr_delta).map_err(StoreError::MmrError)?;
+
+            Store::insert_chain_mmr_nodes(&tx, new_authentication_nodes)?;
+
+            let _peaks: Vec<String> = partial_mmr
+                .peaks()
+                .peaks()
+                .iter()
+                .map(|x| x.to_string())
+                .collect();
+
+            self.mmr.add(block_header.hash());
 
             Store::insert_block_header(
                 &tx,
                 block_header,
-                partial_mmr.peaks().peaks().to_vec(),
+                partial_mmr.peaks(),
                 partial_mmr.forest() as u64,
             )?;
         }
 
         // update tracked notes
-        for (committed_note_hash, inclusion_proof) in committed_notes {
+        for (note_id, inclusion_proof) in committed_notes {
             const SPENT_QUERY: &str =
-                "UPDATE input_notes SET status = 'committed', inclusion_proof = ? WHERE hash = ?";
-            let inclusion_proof = serde_json::to_string(&inclusion_proof)
-                .map_err(StoreError::InputSerializationError)?;
-            tx.execute(
-                SPENT_QUERY,
-                params![inclusion_proof, committed_note_hash.to_string()],
-            )
-            .map_err(StoreError::QueryError)?;
+                "UPDATE input_notes SET status = 'committed', inclusion_proof = ? WHERE note_id = ?";
+
+            let inclusion_proof = Some(inclusion_proof.to_bytes());
+            tx.execute(SPENT_QUERY, params![inclusion_proof, note_id.to_string()])
+                .map_err(StoreError::QueryError)?;
         }
 
         // TODO: We would need to mark transactions as committed here as well

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -102,7 +102,6 @@ impl Store {
                 const ACCOUNT_HASH_QUERY: &str = "SELECT hash FROM accounts WHERE id = ?";
 
                 if let Some(Ok((acc_stub, _acc_seed))) = tx
-                if let Some(Ok((acc_stub, _acc_seed))) = tx
                     .prepare(ACCOUNT_HASH_QUERY)
                     .map_err(StoreError::QueryError)?
                     .query_map(params![account_id_int as i64], parse_accounts_columns)

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -85,7 +85,6 @@ impl Store {
     ) -> Result<(), StoreError> {
         // get current nodes on table
         // we need to do this here because creating a sql tx borrows a mut reference
-        let _previous_nodes = self.get_chain_mmr_nodes()?;
         let current_peaks = self.get_chain_mmr_peaks_by_block_num(current_block_num)?;
 
         let tx = self
@@ -158,21 +157,7 @@ impl Store {
 
             Store::insert_chain_mmr_nodes(&tx, new_authentication_nodes)?;
 
-            let _peaks: Vec<String> = partial_mmr
-                .peaks()
-                .peaks()
-                .iter()
-                .map(|x| x.to_string())
-                .collect();
-
-            self.mmr.add(block_header.hash());
-
-            Store::insert_block_header(
-                &tx,
-                block_header,
-                partial_mmr.peaks(),
-                partial_mmr.forest() as u64,
-            )?;
+            Store::insert_block_header(&tx, block_header, partial_mmr.peaks())?;
         }
 
         // update tracked notes

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -104,7 +104,7 @@ CREATE TABLE block_headers (
     header BLOB NOT NULL,                 -- serialized block header
     notes_root BLOB NOT NULL,             -- root of the notes Merkle tree in this block
     sub_hash BLOB NOT NULL,               -- hash of all other header fields in the block
-    chain_mmr_peaks BLOB NOT NULL,              -- serialized peaks of the chain MMR at this block
+    chain_mmr_peaks BLOB NOT NULL,        -- serialized peaks of the chain MMR at this block
     PRIMARY KEY (block_num)
 );
 

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -99,18 +99,17 @@ WHERE (
 ) = 0;
 
 -- Create block headers table
-CREATE TABLE block_headers(
+CREATE TABLE block_headers (
     block_num UNSIGNED BIG INT NOT NULL,  -- block number
     header BLOB NOT NULL,                 -- serialized block header
     notes_root BLOB NOT NULL,             -- root of the notes Merkle tree in this block
     sub_hash BLOB NOT NULL,               -- hash of all other header fields in the block
-    chain_mmr BLOB NOT NULL,              -- serialized peaks of the chain MMR at this block
-    forest UNSIGNED BIG INT NOT NULL,     -- forest of the chain MMR at this block
+    chain_mmr_peaks BLOB NOT NULL,              -- serialized peaks of the chain MMR at this block
     PRIMARY KEY (block_num)
 );
 
 -- Create chain mmr nodes
-CREATE TABLE chain_mmr_nodes(
+CREATE TABLE chain_mmr_nodes (
     id UNSIGNED BIG INT NOT NULL,   -- in-order index of the internal MMR node
     node BLOB NOT NULL,             -- internal node value (hash)
     PRIMARY KEY (id)

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -15,7 +15,7 @@ CREATE TABLE account_storage (
 
 -- Create account_vaults table
 CREATE TABLE account_vaults (
-    root BLOB NOT NULL,         -- root of the Merkle tree for the account vault.
+    root BLOB NOT NULL,         -- root of the Merkle tree for the account asset vault.
     assets BLOB NOT NULL,       -- serialized account vault assets.
     PRIMARY KEY (root)
 );
@@ -36,14 +36,16 @@ CREATE TABLE accounts (
     vault_root BLOB NOT NULL,      -- root of the account_vault Merkle tree.
     nonce BIGINT NOT NULL,         -- account nonce.
     committed BOOLEAN NOT NULL,    -- true if recorded, false if not.
-    PRIMARY KEY (id),
-    FOREIGN KEY (code_root) REFERENCES account_code(root),
-    FOREIGN KEY (storage_root) REFERENCES account_storage(root),
-    FOREIGN KEY (vault_root) REFERENCES account_vaults(root)
+    account_seed BLOB NOT NULL,    -- account seed used to generate the ID.
+    PRIMARY KEY (id)
+    --FOREIGN KEY (code_root) REFERENCES account_code(root),
+    --FOREIGN KEY (storage_root) REFERENCES account_storage(root),
+    --FOREIGN KEY (vault_root) REFERENCES account_vaults(root)
 );
 
 -- Create transactions table
 -- TODO: Script-related information is to be moved to its own table referenced by the script_hash
+
 CREATE TABLE transactions (
     id BLOB NOT NULL,                                -- Transaction ID (hash of various components)
     account_id UNSIGNED BIG INT NOT NULL,            -- ID of the account against which the transaction was executed.
@@ -64,7 +66,7 @@ CREATE TABLE transactions (
 
 -- Create input notes table
 CREATE TABLE input_notes (
-    hash BLOB NOT NULL,                                     -- the note hash
+    note_id BLOB NOT NULL,                                  -- the note id
     nullifier BLOB NOT NULL,                                -- the nullifier of the note
     script BLOB NOT NULL,                                   -- the serialized NoteScript, including script hash and ProgramAst
     vault BLOB NOT NULL,                                    -- the serialized NoteVault, including vault hash and list of assets
@@ -79,7 +81,7 @@ CREATE TABLE input_notes (
         'pending', 'committed', 'consumed'
         )),
     commit_height UNSIGNED BIG INT NOT NULL,                -- the block number at which the note was included into the chain
-    PRIMARY KEY (hash)
+    PRIMARY KEY (note_id)
 );
 
 -- Create state sync table
@@ -103,7 +105,7 @@ CREATE TABLE block_headers(
     notes_root BLOB NOT NULL,             -- root of the notes Merkle tree in this block
     sub_hash BLOB NOT NULL,               -- hash of all other header fields in the block
     chain_mmr BLOB NOT NULL,              -- serialized peaks of the chain MMR at this block
-    forest UNSIGNED BIG NOT NULL,         -- forest of the chain MMR at this block
+    forest UNSIGNED BIG INT NOT NULL,     -- forest of the chain MMR at this block
     PRIMARY KEY (block_num)
 );
 

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -346,7 +346,7 @@ fn insert_input_notes(
             sender_id,
             tag,
             num_assets,
-            _inclusion_proof,
+            inclusion_proof,
             recipients,
             status,
             commit_height,
@@ -365,6 +365,7 @@ fn insert_input_notes(
                     sender_id,
                     tag,
                     num_assets,
+                    inclusion_proof,
                     recipients,
                     status,
                     commit_height

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -1,7 +1,4 @@
-use crate::{
-    client::transactions::{TransactionExecutionResult, TransactionStub},
-    errors::StoreError,
-};
+use crate::{client::transactions::TransactionStub, errors::StoreError};
 use crypto::{
     utils::{collections::BTreeMap, Deserializable, Serializable},
     Felt,
@@ -10,8 +7,7 @@ use crypto::{
 use objects::{
     accounts::AccountId,
     assembly::{AstSerdeOptions, ProgramAst},
-    notes::Note,
-    transaction::{ProvenTransaction, TransactionScript},
+    transaction::{ExecutedTransaction, OutputNotes, ProvenTransaction, TransactionScript},
     Digest,
 };
 use rusqlite::{params, Transaction};
@@ -34,7 +30,7 @@ type SerializedTransactionData = (
     String,
     String,
     String,
-    String,
+    Vec<u8>,
     Option<Vec<u8>>,
     Option<Vec<u8>>,
     Option<String>,
@@ -106,7 +102,7 @@ impl Store {
     pub fn insert_proven_transaction_data(
         &mut self,
         proven_transaction: ProvenTransaction,
-        transaction_result: TransactionExecutionResult,
+        transaction_result: ExecutedTransaction,
     ) -> Result<(), StoreError> {
         // Create atomic transcation
 
@@ -130,7 +126,7 @@ impl Store {
             block_num,
             committed,
             commit_height,
-        ) = serialize_transaction(&proven_transaction, transaction_result.script().clone())?;
+        ) = serialize_transaction(&proven_transaction, transaction_result.tx_script().cloned())?;
 
         tx.execute(
             INSERT_TRANSACTION_QUERY,
@@ -153,9 +149,9 @@ impl Store {
         .map_err(StoreError::QueryError)?;
 
         let input_notes: Vec<InputNoteRecord> = transaction_result
-            .created_notes()
+            .input_notes()
             .iter()
-            .map(|n| n.clone().into())
+            .map(|n| n.note().clone().into())
             .collect();
 
         // Insert input notes
@@ -179,7 +175,7 @@ pub(crate) fn serialize_transaction(
 
     // TODO: Double check if saving nullifiers as input notes is enough
     let nullifiers: Vec<Digest> = transaction
-        .consumed_notes()
+        .input_notes()
         .iter()
         .map(|x| x.inner())
         .collect();
@@ -187,8 +183,8 @@ pub(crate) fn serialize_transaction(
     let input_notes =
         serde_json::to_string(&nullifiers).map_err(StoreError::InputSerializationError)?;
 
-    let output_notes = serde_json::to_string(&transaction.created_notes().to_vec())
-        .map_err(StoreError::InputSerializationError)?;
+    let output_notes = transaction.output_notes();
+    println!("output notes from the transaction {:?}", output_notes);
 
     // TODO: Scripts should be in their own tables and only identifiers should be stored here
     let mut script_program = None;
@@ -214,7 +210,7 @@ pub(crate) fn serialize_transaction(
         init_account_state.to_owned(),
         final_account_state.to_owned(),
         input_notes,
-        output_notes,
+        output_notes.to_bytes(),
         script_program,
         script_hash,
         script_inputs,
@@ -232,7 +228,7 @@ pub fn parse_transaction_columns(
     let init_account_state: String = row.get(2)?;
     let final_account_state: String = row.get(3)?;
     let input_notes: String = row.get(4)?;
-    let output_notes: String = row.get(5)?;
+    let output_notes: Vec<u8> = row.get(5)?;
     let script_hash: Option<Vec<u8>> = row.get(6)?;
     let script_program: Option<Vec<u8>> = row.get(7)?;
     let script_inputs: Option<String> = row.get(8)?;
@@ -283,10 +279,12 @@ fn parse_transaction(
     let final_account_state: Digest = final_account_state
         .try_into()
         .map_err(StoreError::HexParseError)?;
+
     let input_note_nullifiers: Vec<Digest> =
         serde_json::from_str(&input_notes).map_err(StoreError::JsonDataDeserializationError)?;
-    let output_notes: Vec<Note> =
-        serde_json::from_str(&output_notes).map_err(StoreError::JsonDataDeserializationError)?;
+
+    let output_notes: OutputNotes = OutputNotes::read_from_bytes(&output_notes)
+        .map_err(StoreError::DataDeserializationError)?;
 
     let transaction_script: Option<TransactionScript> = if script_hash.is_some() {
         let script_hash = script_hash
@@ -339,7 +337,7 @@ fn insert_input_notes(
 ) -> Result<(), StoreError> {
     for note in notes {
         let (
-            hash,
+            note_id,
             nullifier,
             script,
             vault,
@@ -348,7 +346,7 @@ fn insert_input_notes(
             sender_id,
             tag,
             num_assets,
-            inclusion_proof,
+            _inclusion_proof,
             recipients,
             status,
             commit_height,
@@ -358,7 +356,7 @@ fn insert_input_notes(
             .execute(
                 INSERT_NOTE_QUERY,
                 params![
-                    hash,
+                    note_id,
                     nullifier,
                     script,
                     vault,
@@ -367,14 +365,13 @@ fn insert_input_notes(
                     sender_id,
                     tag,
                     num_assets,
-                    inclusion_proof,
                     recipients,
                     status,
                     commit_height
                 ],
             )
-            .map_err(StoreError::QueryError)?;
+            .map_err(StoreError::QueryError)
+            .map(|_| ())?
     }
-
     Ok(())
 }

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -184,7 +184,11 @@ pub(crate) fn serialize_transaction(
         serde_json::to_string(&nullifiers).map_err(StoreError::InputSerializationError)?;
 
     let output_notes = transaction.output_notes();
-    println!("output notes from the transaction {:?}", output_notes);
+
+    // TODO: Add proper logging
+    println!("transaction id {:?}", transaction.id());
+    println!("transaction account id: {}", transaction.account_id());
+    println!("transaction output notes {:?}", output_notes);
 
     // TODO: Scripts should be in their own tables and only identifiers should be stored here
     let mut script_program = None;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,8 +16,7 @@ use crate::{
 };
 
 use assembly::ast::{AstSerdeOptions, ModuleAst};
-use crypto::{dsa::rpo_falcon512::KeyPair, Word};
-use crypto::{Felt, FieldElement};
+use crypto::{dsa::rpo_falcon512::KeyPair, Felt, FieldElement, Word};
 use miden_lib::transaction::TransactionKernel;
 use mock::{
     constants::{generate_account_seed, AccountSeedType},
@@ -27,12 +26,11 @@ use mock::{
         transaction::mock_inputs,
     },
 };
-use objects::transaction::InputNotes;
 use objects::{
     accounts::{AccountId, AccountStub},
-    assets::TokenSymbol,
+    assets::{FungibleAsset, TokenSymbol},
+    transaction::InputNotes,
 };
-use objects::{assets::FungibleAsset, transaction::InputNotes};
 
 #[tokio::test]
 async fn test_input_notes_round_trip() {
@@ -49,11 +47,10 @@ async fn test_input_notes_round_trip() {
 
     // generate test data
     let transaction_inputs = mock_inputs(
-    let transaction_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
-    let recorded_notes = transaction_inputs.input_notes();
+    let _recorded_notes = transaction_inputs.input_notes();
 
     // insert notes into database
     for note in transaction_inputs.input_notes().iter().cloned() {
@@ -92,7 +89,7 @@ async fn test_get_input_note() {
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
-    let recorded_notes: InputNotes = transaction_inputs.input_notes().clone();
+    let _recorded_notes: InputNotes = transaction_inputs.input_notes().clone();
     let recorded_notes: InputNotes = transaction_inputs.input_notes().clone();
 
     // insert note into database

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,26 +1,37 @@
 // TESTS
 // ================================================================================================
 use crate::{
-    client::Client,
+    client::{
+        accounts::{AccountStorageMode, AccountTemplate},
+        transactions::TransactionTemplate,
+        Client,
+    },
     config::{ClientConfig, Endpoint},
     store::{
         accounts::AuthInfo,
+        mock_executor_data_store::MockDataStore,
         notes::{InputNoteFilter, InputNoteRecord},
         tests::create_test_store_path,
     },
 };
 
-use crypto::dsa::rpo_falcon512::KeyPair;
-use miden_lib::assembler::assembler;
-use mock::mock::{
-    account::{self, MockAccountType},
-    notes::AssetPreservationStatus,
-    transaction::mock_inputs,
+use assembly::ast::{AstSerdeOptions, ModuleAst};
+use crypto::{dsa::rpo_falcon512::KeyPair, Word};
+use crypto::{Felt, FieldElement};
+use miden_lib::transaction::TransactionKernel;
+use mock::{
+    constants::{generate_account_seed, AccountSeedType},
+    mock::{
+        account::{self, mock_account, MockAccountType},
+        notes::AssetPreservationStatus,
+        transaction::mock_inputs,
+    },
 };
 use objects::{
     accounts::{AccountId, AccountStub},
-    AdviceInputs,
+    assets::TokenSymbol,
 };
+use objects::{assets::FungibleAsset, transaction::InputNotes};
 
 #[tokio::test]
 async fn test_input_notes_round_trip() {
@@ -36,23 +47,29 @@ async fn test_input_notes_round_trip() {
     .unwrap();
 
     // generate test data
-    let (_, _, _, recorded_notes, _) = mock_inputs(
+    let transaction_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
+    let _recorded_notes = transaction_inputs.input_notes();
 
     // insert notes into database
-    for note in recorded_notes.iter().cloned() {
+    for note in transaction_inputs.input_notes().iter().cloned() {
         client.import_input_note(note.into()).unwrap();
     }
 
     // retrieve notes from database
     let retrieved_notes = client.get_input_notes(InputNoteFilter::Committed).unwrap();
 
-    let recorded_notes: Vec<InputNoteRecord> =
-        recorded_notes.iter().map(|n| n.clone().into()).collect();
+    let recorded_notes: Vec<InputNoteRecord> = transaction_inputs
+        .input_notes()
+        .iter()
+        .map(|n| n.clone().into())
+        .collect();
     // compare notes
-    assert_eq!(recorded_notes, retrieved_notes);
+    for (recorded_note, retrieved_note) in recorded_notes.iter().zip(retrieved_notes) {
+        assert_eq!(recorded_note.note_id(), retrieved_note.note_id());
+    }
 }
 
 #[tokio::test]
@@ -69,23 +86,106 @@ async fn test_get_input_note() {
     .unwrap();
 
     // generate test data
-    let (_, _, _, recorded_notes, _) = mock_inputs(
+    let transaction_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
+    let recorded_notes: InputNotes = transaction_inputs.input_notes().clone();
 
     // insert note into database
     client
-        .import_input_note(recorded_notes[0].clone().into())
+        .import_input_note(recorded_notes.get_note(0).clone().into())
         .unwrap();
 
     // retrieve note from database
     let retrieved_note = client
-        .get_input_note(recorded_notes[0].note().hash())
+        .get_input_note(recorded_notes.get_note(0).note().id())
         .unwrap();
 
-    let recorded_note: InputNoteRecord = recorded_notes[0].clone().into();
-    assert_eq!(recorded_note, retrieved_note)
+    let recorded_note: InputNoteRecord = recorded_notes.get_note(0).clone().into();
+    assert_eq!(recorded_note.note_id(), retrieved_note.note_id())
+}
+
+#[tokio::test]
+async fn insert_basic_account() {
+    // generate test store path
+    let store_path = create_test_store_path();
+
+    // generate test client
+    let mut client = Client::new(ClientConfig::new(
+        store_path.into_os_string().into_string().unwrap(),
+        Endpoint::default(),
+    ))
+    .await
+    .unwrap();
+
+    let account_template = AccountTemplate::BasicWallet {
+        mutable_code: true,
+        storage_mode: AccountStorageMode::Local,
+    };
+
+    // Insert Account
+    let account_insert_result = client.new_account(account_template);
+    assert!(account_insert_result.is_ok());
+
+    let (account, account_seed) = account_insert_result.unwrap();
+
+    // Fetch Account
+    let fetched_account_data = client.get_account_by_id(account.id());
+    assert!(fetched_account_data.is_ok());
+
+    let (fetched_account, fetched_account_seed) = fetched_account_data.unwrap();
+    // Validate stub has matching data
+    assert_eq!(account.id(), fetched_account.id());
+    assert_eq!(account.nonce(), fetched_account.nonce());
+    assert_eq!(account.vault(), fetched_account.vault());
+    assert_eq!(account.storage().root(), fetched_account.storage().root());
+    assert_eq!(account.code().root(), fetched_account.code().root());
+
+    // Validate seed matches
+    assert_eq!(account_seed, fetched_account_seed);
+}
+
+#[tokio::test]
+async fn insert_faucet_account() {
+    // generate test store path
+    let store_path = create_test_store_path();
+
+    // generate test client
+    let mut client = Client::new(ClientConfig::new(
+        store_path.into_os_string().into_string().unwrap(),
+        Endpoint::default(),
+    ))
+    .await
+    .unwrap();
+
+    let faucet_template = AccountTemplate::FungibleFaucet {
+        token_symbol: TokenSymbol::new("TEST").unwrap(),
+        decimals: 10,
+        max_supply: 9999999999,
+        storage_mode: AccountStorageMode::Local,
+    };
+
+    // Insert Account
+    let account_insert_result = client.new_account(faucet_template);
+    assert!(account_insert_result.is_ok());
+
+    let (account, account_seed) = account_insert_result.unwrap();
+
+    // Fetch Account
+    let fetched_account_data = client.get_account_by_id(account.id());
+    assert!(fetched_account_data.is_ok());
+
+    let (fetched_account, fetched_account_seed) = fetched_account_data.unwrap();
+    // Validate stub has matching data
+    assert_eq!(account.id(), fetched_account.id());
+    assert_eq!(account.nonce(), fetched_account.nonce());
+    assert_eq!(account.vault(), fetched_account.vault());
+    assert_eq!(account.storage(), fetched_account.storage());
+    assert_eq!(account.code().root(), fetched_account.code().root());
+
+    // Validate seed matches
+    assert_eq!(account_seed, fetched_account_seed);
 }
 
 #[tokio::test]
@@ -101,20 +201,71 @@ async fn insert_same_account_twice_fails() {
     .await
     .unwrap();
 
-    let assembler = assembler();
-    let mut auxiliary_data = AdviceInputs::default();
-    let account = account::mock_new_account(&assembler, &mut auxiliary_data);
+    let assembler = TransactionKernel::assembler();
+
+    let (account_id, account_seed) =
+        generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
+    let account = account::mock_account(Some(account_id.into()), Felt::ZERO, None, &assembler);
 
     let key_pair: KeyPair = KeyPair::new()
         .map_err(|err| format!("Error generating KeyPair: {}", err))
         .unwrap();
 
     assert!(client
-        .insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))
+        .insert_account(&account, account_seed, &AuthInfo::RpoFalcon512(key_pair))
         .is_ok());
     assert!(client
-        .insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))
+        .insert_account(&account, account_seed, &AuthInfo::RpoFalcon512(key_pair))
         .is_err());
+}
+
+#[tokio::test]
+async fn test_acc_code() {
+    // generate test store path
+    let store_path = create_test_store_path();
+
+    // generate test client
+    let mut client = Client::new(ClientConfig::new(
+        store_path.into_os_string().into_string().unwrap(),
+        Endpoint::default(),
+    ))
+    .await
+    .unwrap();
+
+    let assembler = TransactionKernel::assembler();
+    let key_pair: KeyPair = KeyPair::new()
+        .map_err(|err| format!("Error generating KeyPair: {}", err))
+        .unwrap();
+
+    let (account_id, account_seed) =
+        generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
+
+    let account = account::mock_account(Some(account_id.into()), Felt::ZERO, None, &assembler);
+
+    let mut account_module = account.code().module().clone();
+
+    // this is needed due to the reconstruction not including source locations
+    account_module.clear_locations();
+    account_module.clear_imports();
+
+    let account_module_bytes = account_module.to_bytes(AstSerdeOptions {
+        serialize_imports: true,
+    });
+    let reconstructed_ast = ModuleAst::from_bytes(&account_module_bytes).unwrap();
+    assert_eq!(account_module, reconstructed_ast);
+
+    client
+        .insert_account(&account, account_seed, &AuthInfo::RpoFalcon512(key_pair))
+        .unwrap();
+    let (retrieved_acc, _) = client.get_account_by_id(account_id).unwrap();
+
+    let mut account_module = account.code().module().clone();
+    account_module.clear_locations();
+    account_module.clear_imports();
+    assert_eq!(
+        *account_module.procs(),
+        *retrieved_acc.code().module().procs()
+    );
 }
 
 #[tokio::test]
@@ -130,20 +281,22 @@ async fn test_get_account_by_id() {
     .await
     .unwrap();
 
-    let assembler = assembler();
-    let mut auxiliary_data = AdviceInputs::default();
-    let account = account::mock_new_account(&assembler, &mut auxiliary_data);
+    let assembler = TransactionKernel::assembler();
+
+    let (account_id, account_seed) =
+        generate_account_seed(AccountSeedType::RegularAccountUpdatableCodeOnChain);
+    let account = account::mock_account(Some(account_id.into()), Felt::ZERO, None, &assembler);
 
     let key_pair: KeyPair = KeyPair::new()
         .map_err(|err| format!("Error generating KeyPair: {}", err))
         .unwrap();
 
     client
-        .insert_account(&account, &AuthInfo::RpoFalcon512(key_pair))
+        .insert_account(&account, account_seed, &AuthInfo::RpoFalcon512(key_pair))
         .unwrap();
 
     // Retrieving an existing account should succeed
-    let acc_from_db = match client.get_account_by_id(account.id()) {
+    let (acc_from_db, _account_seed) = match client.get_account_stub_by_id(account.id()) {
         Ok(account) => account,
         Err(err) => panic!("Error retrieving account: {}", err),
     };
@@ -152,7 +305,7 @@ async fn test_get_account_by_id() {
     // Retrieving a non existing account should fail
     let hex = format!("0x{}", "1".repeat(16));
     let invalid_id = AccountId::from_hex(&hex).unwrap();
-    assert!(client.get_account_by_id(invalid_id).is_err());
+    assert!(client.get_account_stub_by_id(invalid_id).is_err());
 }
 
 #[tokio::test]
@@ -208,7 +361,7 @@ async fn test_sync_state() {
 
     // verify that the pending note we had is now committed
     assert_ne!(
-        client.get_input_notes(InputNoteFilter::Pending).unwrap(),
+        client.get_input_notes(InputNoteFilter::Committed).unwrap(),
         pending_notes
     );
 
@@ -261,4 +414,58 @@ async fn test_add_tag() {
         client.get_note_tags().unwrap(),
         vec![TAG_VALUE_1, TAG_VALUE_2]
     );
+}
+
+#[tokio::test]
+#[ignore = "currently fails with PhantomCallsNotAllowed"]
+async fn test_mint_transaction() {
+    const FAUCET_ID: u64 = 10347894387879516201u64;
+    const FAUCET_SEED: Word = [Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ZERO];
+
+    // generate test store path
+    let store_path = create_test_store_path();
+
+    // generate test client
+    let mut client = Client::new(ClientConfig::new(
+        store_path.into_os_string().into_string().unwrap(),
+        Endpoint::default(),
+    ))
+    .await
+    .unwrap();
+
+    let (faucet, _seed) = client
+        .new_account(AccountTemplate::FungibleFaucet {
+            token_symbol: TokenSymbol::new("TST").unwrap(),
+            decimals: 10u8,
+            max_supply: 1000u64,
+            storage_mode: AccountStorageMode::Local,
+        })
+        .unwrap();
+    let faucet = mock_account(
+        Some(FAUCET_ID),
+        Felt::new(10u64),
+        Some(faucet.code().clone()),
+        &TransactionKernel::assembler(),
+    );
+
+    let key_pair: KeyPair = KeyPair::new()
+        .map_err(|err| format!("Error generating KeyPair: {}", err))
+        .unwrap();
+    client
+        .store
+        .insert_account(&faucet, FAUCET_SEED, &AuthInfo::RpoFalcon512(key_pair))
+        .unwrap();
+    client.set_data_store(MockDataStore::with_existing(faucet.clone(), None));
+
+    // Test submitting a mint transaction
+
+    dbg!(&faucet.id());
+    println!("{:?}", faucet.account_type());
+    let transaction_template = TransactionTemplate::MintFungibleAsset {
+        asset: FungibleAsset::new(faucet.id(), 5u64).unwrap(),
+        tag: 10u64,
+        target_account_id: AccountId::from_hex("0x168187d729b31a84").unwrap(),
+    };
+
+    client.new_transaction(transaction_template).unwrap();
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -463,7 +463,6 @@ async fn test_mint_transaction() {
     println!("{:?}", faucet.account_type());
     let transaction_template = TransactionTemplate::MintFungibleAsset {
         asset: FungibleAsset::new(faucet.id(), 5u64).unwrap(),
-        tag: 10u64,
         target_account_id: AccountId::from_hex("0x168187d729b31a84").unwrap(),
     };
 


### PR DESCRIPTION
- Adds load-genesis command under the testing feature to load the 2 accounts [generated by the node binary](https://github.com/0xPolygonMiden/miden-node/blob/59984a5d4969053c55edf148c978a30b0ada23e9/README.md#generating-the-genesis-file)
- Adds `mint` subcommand to create, execute and send a mint transaction from a faucet account
- Adds `DataStore` implementation that goes to the client store to retrieve needed inputs
- Adds feature `mock` for using `mock` objects (RPC API and `DataStore`): Before this PR we had only the `testing` feature which enabled the same feature on the base repos and additionally enabled mock objects. We want to separate those in cases where we are trying to send a transaction to the node but decrease PoW costs
- Cleans up imports and some other functions/tests

Future work:
- Correctly handle output notes after submitting transactions (#83)
- Fix P2ID implementation (#84)