### PR TITLE
Fix broken import path from miden node

### DIFF
--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -1,7 +1,7 @@
 use super::Client;
 use crypto::StarkField;
 use miden_node_proto::{
-    account_id::AccountId as ProtoAccountId, note::NoteSyncRecord, requests::SyncStateRequest,
+    account::AccountId as ProtoAccountId, note::NoteSyncRecord, requests::SyncStateRequest,
     responses::SyncStateResponse,
 };
 use objects::{accounts::AccountId, notes::NoteInclusionProof, BlockHeader, Digest};

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -10,7 +10,7 @@ use miden_node_proto::note::NoteSyncRecord;
 use miden_node_proto::requests::SubmitProvenTransactionRequest;
 use miden_node_proto::responses::SubmitProvenTransactionResponse;
 use miden_node_proto::{
-    account_id::AccountId as ProtoAccountId,
+    account::AccountId as ProtoAccountId,
     requests::SyncStateRequest,
     responses::{NullifierUpdate, SyncStateResponse},
 };


### PR DESCRIPTION
A [PR was merged](https://github.com/0xPolygonMiden/miden-node/pull/126) on miden-node which changed the path for `AccountId`. This PR fixes the 2 imports we had for it