### PR TITLE
Fix for changes in mock_inputs from miden-base

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -81,10 +81,13 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
     };
 
     // generate test data
-    let (account, _, _, recorded_notes) = mock_inputs(
+    let transaction_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
+
+    let account = transaction_inputs.account();
+    let recorded_notes = transaction_inputs.input_notes();
 
     let accounts = vec![ProtoAccountId {
         id: u64::from(account.id()),
@@ -135,8 +138,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
         nullifiers: vec![NullifierUpdate {
             nullifier: Some(
                 recorded_notes
-                    .first()
-                    .unwrap()
+                    .get_note(0)
                     .note()
                     .nullifier()
                     .inner()
@@ -179,8 +181,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
         nullifiers: vec![NullifierUpdate {
             nullifier: Some(
                 recorded_notes
-                    .first()
-                    .unwrap()
+                    .get_note(0)
                     .note()
                     .nullifier()
                     .inner()
@@ -202,7 +203,7 @@ pub fn insert_mock_data(client: &mut Client) {
     };
 
     // generate test data
-    let (_account, _, _, recorded_notes) = mock_inputs(
+    let transaction_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
@@ -212,7 +213,7 @@ pub fn insert_mock_data(client: &mut Client) {
     let (_consumed, created_notes) = mock_notes(&assembler, &AssetPreservationStatus::Preserved);
 
     // insert notes into database
-    for note in recorded_notes.into_iter() {
+    for note in transaction_inputs.input_notes().clone().into_iter() {
         client.import_input_note(note.into()).unwrap();
     }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -136,14 +136,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
             merkle_path: Some(MerklePath::default()),
         }],
         nullifiers: vec![NullifierUpdate {
-            nullifier: Some(
-                recorded_notes
-                    .get_note(0)
-                    .note()
-                    .nullifier()
-                    .inner()
-                    .into(),
-            ),
+            nullifier: Some(recorded_notes.get_note(0).note().nullifier().inner().into()),
             block_num: 7,
         }],
     };
@@ -179,14 +172,7 @@ fn generate_sync_state_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
             merkle_path: Some(MerklePath::default()),
         }],
         nullifiers: vec![NullifierUpdate {
-            nullifier: Some(
-                recorded_notes
-                    .get_note(0)
-                    .note()
-                    .nullifier()
-                    .inner()
-                    .into(),
-            ),
+            nullifier: Some(recorded_notes.get_note(0).note().nullifier().inner().into()),
             block_num: 7,
         }],
     };

--- a/src/store/mock_executor_data_store.rs
+++ b/src/store/mock_executor_data_store.rs
@@ -36,7 +36,7 @@ impl MockDataStore {
         );
         Self {
             account: transaction_data.account().clone(),
-            block_header: transaction_data.block_header().clone(),
+            block_header: *transaction_data.block_header(),
             block_chain: transaction_data.block_chain().clone(),
             input_notes: transaction_data.input_notes().clone(),
         }

--- a/src/store/mock_executor_data_store.rs
+++ b/src/store/mock_executor_data_store.rs
@@ -30,15 +30,15 @@ pub struct MockDataStore {
 
 impl MockDataStore {
     pub fn new() -> Self {
-        let (account, block_header, block_chain, consumed_notes) = mock_inputs(
+        let transaction_data = mock_inputs(
             MockAccountType::StandardExisting,
             AssetPreservationStatus::Preserved,
         );
         Self {
-            account,
-            block_header,
-            block_chain,
-            input_notes: InputNotes::new(consumed_notes).unwrap(),
+            account: transaction_data.account().clone(),
+            block_header: transaction_data.block_header().clone(),
+            block_chain: transaction_data.block_chain().clone(),
+            input_notes: transaction_data.input_notes().clone(),
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,6 +18,8 @@ use mock::mock::{
     transaction::mock_inputs,
 };
 use objects::accounts::{AccountId, AccountStub};
+use objects::transaction::InputNotes;
+
 #[tokio::test]
 async fn test_input_notes_round_trip() {
     // generate test store path
@@ -32,10 +34,11 @@ async fn test_input_notes_round_trip() {
     .unwrap();
 
     // generate test data
-    let (_, _, _, recorded_notes) = mock_inputs(
+    let transaction_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
+    let recorded_notes = transaction_inputs.input_notes();
 
     // insert notes into database
     for note in recorded_notes.iter().cloned() {
@@ -67,22 +70,23 @@ async fn test_get_input_note() {
     .unwrap();
 
     // generate test data
-    let (_, _, _, recorded_notes) = mock_inputs(
+    let transaction_inputs = mock_inputs(
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
+    let recorded_notes : InputNotes = transaction_inputs.input_notes().clone();
 
     // insert note into database
     client
-        .import_input_note(recorded_notes[0].clone().into())
+        .import_input_note(recorded_notes.get_note(0).clone().into())
         .unwrap();
 
     // retrieve note from database
     let retrieved_note = client
-        .get_input_note(recorded_notes[0].note().id())
+        .get_input_note(recorded_notes.get_note(0).note().id())
         .unwrap();
 
-    let recorded_note: InputNoteRecord = recorded_notes[0].clone().into();
+    let recorded_note: InputNoteRecord = recorded_notes.get_note(0).clone().into();
     assert_eq!(recorded_note.note_id(), retrieved_note.note_id())
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -74,7 +74,7 @@ async fn test_get_input_note() {
         MockAccountType::StandardExisting,
         AssetPreservationStatus::Preserved,
     );
-    let recorded_notes : InputNotes = transaction_inputs.input_notes().clone();
+    let recorded_notes: InputNotes = transaction_inputs.input_notes().clone();
 
     // insert note into database
     client


### PR DESCRIPTION
Apparently since [#405](https://github.com/0xPolygonMiden/miden-base/pull/405) from miden-base got merged the `mock_inputs` function now returns a TransactionInputs struct instead of a tuple. This PRs fixes the compilation errors that arised from that.