### PR TITLE
add store function to retrieve partial mmr appropiate for notes

### DIFF
--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -6,8 +6,8 @@ use crate::errors::StoreError;
 
 use clap::error::Result;
 
-use crypto::merkle::{InOrderIndex, MmrPeaks, PartialMmr, MerklePath};
-use objects::{BlockHeader, Digest, transaction::InputNote};
+use crypto::merkle::{InOrderIndex, MerklePath, MmrPeaks, PartialMmr};
+use objects::{transaction::InputNote, BlockHeader, Digest};
 use rusqlite::{params, OptionalExtension, Transaction};
 
 type SerializedBlockHeaderData = (i64, String, String, String, String);
@@ -120,18 +120,22 @@ impl Store {
         MmrPeaks::new(0, vec![]).map_err(StoreError::MmrError)
     }
 
-    pub fn get_partial_mmr_for_notes(&self, block_num: u32, notes_to_consume: &[InputNote]) -> Result<(PartialMmr, BTreeMap<u32, Digest>), StoreError> {
-        let current_peaks = self
-                    .get_chain_mmr_peaks_by_block_num(block_num)
-                    .unwrap();
+    pub fn get_partial_mmr_for_notes(
+        &self,
+        block_num: u32,
+        notes_to_consume: &[InputNote],
+    ) -> Result<(PartialMmr, BTreeMap<u32, Digest>), StoreError> {
+        let current_peaks = self.get_chain_mmr_peaks_by_block_num(block_num).unwrap();
 
-        let notes_blocks : Result<Vec<(u32, objects::Digest)>, StoreError> = notes_to_consume.iter().map(|input_note| {
-            let note_block_num = input_note.proof().origin().block_num;
-            let block_header = self
-                .get_block_header_by_num(note_block_num)?;
+        let notes_blocks: Result<Vec<(u32, objects::Digest)>, StoreError> = notes_to_consume
+            .iter()
+            .map(|input_note| {
+                let note_block_num = input_note.proof().origin().block_num;
+                let block_header = self.get_block_header_by_num(note_block_num)?;
 
-            Ok((block_header.block_num() as u32, block_header.hash()))
-        }).collect();
+                Ok((block_header.block_num() as u32, block_header.hash()))
+            })
+            .collect();
         let notes_blocks = notes_blocks?;
 
         let mut partial_mmr = PartialMmr::from_peaks(current_peaks);

--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -120,6 +120,10 @@ impl Store {
         MmrPeaks::new(0, vec![]).map_err(StoreError::MmrError)
     }
 
+    /// Given a set of input notes we want to consume at a certain block number (all notes belong
+    /// to prior blocks), this builds a PartialMmr sufficient to prove the block inclusion of the
+    /// notes corresponding blocks and a dictionary containing the tracked node numbers along with
+    /// their hash.
     pub fn get_partial_mmr_for_notes(
         &self,
         block_num: u32,

--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -133,7 +133,7 @@ impl Store {
                 let note_block_num = input_note.proof().origin().block_num;
                 let block_header = self.get_block_header_by_num(note_block_num)?;
 
-                Ok((block_header.block_num() as u32, block_header.hash()))
+                Ok((block_header.block_num(), block_header.hash()))
             })
             .collect();
         let notes_blocks = notes_blocks?;

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -1,4 +1,3 @@
-
 use super::Store;
 use crypto::merkle::PartialMmr;
 use miden_tx::{DataStore, DataStoreError, TransactionInputs};
@@ -60,14 +59,13 @@ impl DataStore for SqliteDataStore {
         // TODO:
         //  - To build the return (partial) ChainMmr: From the block numbers in each note.origin(), get the list of block headers
         //    and construct the partial Mmr
-        let (partial_mmr, notes_blocks) = self.store.get_partial_mmr_for_notes(block_num, &list_of_notes)
+        let (partial_mmr, notes_blocks) = self
+            .store
+            .get_partial_mmr_for_notes(block_num, &list_of_notes)
             .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
 
-        let chain_mmr = ChainMmr::new(
-            partial_mmr,
-            notes_blocks
-        )
-        .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
+        let chain_mmr = ChainMmr::new(partial_mmr, notes_blocks)
+            .map_err(|_err| DataStoreError::AccountNotFound(account_id))?;
 
         let input_notes = InputNotes::new(list_of_notes)
             .map_err(|_| DataStoreError::AccountNotFound(account_id))?;


### PR DESCRIPTION
The get_transaction_inputs function was building a PartialMmr, although it wasn't inserting the markle paths corresponding to each input note. This wasn't necessary since the mint transaction does not require it, but for further transactions I made a function that builds a sufficient PartialMmr for the transaction and input notes.