### PR TITLE
refactor: move account and note update to single transaction

### DIFF
--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -1,6 +1,8 @@
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 
-use miden_client::client::transactions::{PaymentTransactionData, TransactionStub, TransactionTemplate};
+use miden_client::client::transactions::{
+    PaymentTransactionData, TransactionStub, TransactionTemplate,
+};
 use objects::{accounts::AccountId, assets::FungibleAsset};
 
 use super::{Client, Parser};
@@ -105,7 +107,9 @@ impl Transaction {
                 // transaction was proven and submitted to the node correctly, persist note details and update account
                 let account_id = transaction_template.account_id();
 
-                client.persist_transaction_execution_changes(account_id, transaction_execution_result).map_err(|err| err.to_string())?;
+                client
+                    .persist_transaction_execution_changes(account_id, transaction_execution_result)
+                    .map_err(|err| err.to_string())?;
             }
         }
         Ok(())

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -100,7 +100,11 @@ impl Transaction {
                 println!("Executed transaction, proving and then submitting...");
 
                 client
-                    .send_transaction(transaction_template.account_id(), transaction_execution_result.executed_transaction().clone(), &transaction_execution_result.created_notes().clone())
+                    .send_transaction(
+                        transaction_template.account_id(),
+                        transaction_execution_result.executed_transaction().clone(),
+                        &transaction_execution_result.created_notes().clone(),
+                    )
                     .await
                     .map_err(|err| err.to_string())?;
             }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -100,15 +100,8 @@ impl Transaction {
                 println!("Executed transaction, proving and then submitting...");
 
                 client
-                    .send_transaction(transaction_execution_result.executed_transaction().clone())
+                    .send_transaction(transaction_template.account_id(), transaction_execution_result.executed_transaction().clone(), &transaction_execution_result.created_notes().clone())
                     .await
-                    .map_err(|err| err.to_string())?;
-
-                // transaction was proven and submitted to the node correctly, persist note details and update account
-                let account_id = transaction_template.account_id();
-
-                client
-                    .persist_transaction_execution_changes(account_id, transaction_execution_result)
                     .map_err(|err| err.to_string())?;
             }
         }

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -344,8 +344,12 @@ impl Client {
             .await?;
 
         // transaction was proven and submitted to the node correctly, persist note details and update account
-        self.store
-            .insert_proven_and_submitted_transaction_data(account_id, proven_transaction, transaction_execution_result, created_notes)?;
+        self.store.insert_proven_and_submitted_transaction_data(
+            account_id,
+            proven_transaction,
+            transaction_execution_result,
+            created_notes,
+        )?;
 
         Ok(())
     }

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -363,17 +363,26 @@ impl Client {
             .into_inner())
     }
 
-    pub fn persist_transaction_execution_changes(&mut self, account_id: AccountId, transaction_execution_result: TransactionExecutionResult) -> Result<(), ClientError> {
+    pub fn persist_transaction_execution_changes(
+        &mut self,
+        account_id: AccountId,
+        transaction_execution_result: TransactionExecutionResult,
+    ) -> Result<(), ClientError> {
         let account_delta = transaction_execution_result
             .executed_transaction()
             .account_delta();
-        let input_note_records = transaction_execution_result.created_notes()
+        let input_note_records = transaction_execution_result
+            .created_notes()
             .into_iter()
             .map(|note| InputNoteRecord::from(note.clone()))
             .collect::<Vec<_>>();
 
         self.store
-            .insert_proven_and_submitted_transaction_data(account_id, account_delta, &input_note_records)
+            .insert_proven_and_submitted_transaction_data(
+                account_id,
+                account_delta,
+                &input_note_records,
+            )
             .map_err(ClientError::StoreError)?;
 
         Ok(())

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -363,6 +363,8 @@ impl Client {
             .into_inner())
     }
 
+    // Persists account changes and created notes from an executed transaction. Should be used
+    // after submitting a proven transaction to a node.
     pub fn persist_transaction_execution_changes(
         &mut self,
         account_id: AccountId,

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -17,7 +17,7 @@ use rand::Rng;
 
 use crate::{
     errors::{ClientError, RpcApiError},
-    store::{accounts::AuthInfo, notes::InputNoteRecord},
+    store::accounts::AuthInfo,
 };
 
 use super::{sync_state::FILTER_ID_SHIFT, Client};
@@ -329,7 +329,9 @@ impl Client {
     /// the local database for tracking.
     pub async fn send_transaction(
         &mut self,
+        account_id: AccountId,
         transaction_execution_result: ExecutedTransaction,
+        created_notes: &[Note],
     ) -> Result<(), ClientError> {
         let transaction_prover = TransactionProver::new(ProvingOptions::default());
         let proven_transaction = transaction_prover
@@ -341,8 +343,9 @@ impl Client {
         self.submit_proven_transaction_request(proven_transaction.clone())
             .await?;
 
+        // transaction was proven and submitted to the node correctly, persist note details and update account
         self.store
-            .insert_proven_transaction_data(proven_transaction, transaction_execution_result)?;
+            .insert_proven_and_submitted_transaction_data(account_id, proven_transaction, transaction_execution_result, created_notes)?;
 
         Ok(())
     }
@@ -361,33 +364,6 @@ impl Client {
             .await
             .map_err(|err| ClientError::RpcApiError(RpcApiError::RequestError(err)))?
             .into_inner())
-    }
-
-    // Persists account changes and created notes from an executed transaction. Should be used
-    // after submitting a proven transaction to a node.
-    pub fn persist_transaction_execution_changes(
-        &mut self,
-        account_id: AccountId,
-        transaction_execution_result: TransactionExecutionResult,
-    ) -> Result<(), ClientError> {
-        let account_delta = transaction_execution_result
-            .executed_transaction()
-            .account_delta();
-        let input_note_records = transaction_execution_result
-            .created_notes()
-            .iter()
-            .map(|note| InputNoteRecord::from(note.clone()))
-            .collect::<Vec<_>>();
-
-        self.store
-            .insert_proven_and_submitted_transaction_data(
-                account_id,
-                account_delta,
-                &input_note_records,
-            )
-            .map_err(ClientError::StoreError)?;
-
-        Ok(())
     }
 
     // HELPERS

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -373,7 +373,7 @@ impl Client {
             .account_delta();
         let input_note_records = transaction_execution_result
             .created_notes()
-            .into_iter()
+            .iter()
             .map(|note| InputNoteRecord::from(note.clone()))
             .collect::<Vec<_>>();
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -326,7 +326,11 @@ pub async fn create_mock_transaction(client: &mut Client) {
     let transaction_execution_result = client.new_transaction(transaction_template).unwrap();
 
     client
-        .send_transaction(account_id, transaction_execution_result.executed_transaction().clone(), &transaction_execution_result.created_notes().clone())
+        .send_transaction(
+            account_id,
+            transaction_execution_result.executed_transaction().clone(),
+            &transaction_execution_result.created_notes().clone(),
+        )
         .await
         .unwrap();
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -321,10 +321,12 @@ pub async fn create_mock_transaction(client: &mut Client) {
         target_account.id(),
     ));
 
+    let account_id = transaction_template.account_id();
+
     let transaction_execution_result = client.new_transaction(transaction_template).unwrap();
 
     client
-        .send_transaction(transaction_execution_result.executed_transaction().clone())
+        .send_transaction(account_id, transaction_execution_result.executed_transaction().clone(), &transaction_execution_result.created_notes().clone())
         .await
         .unwrap();
 }

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -332,7 +332,10 @@ impl Store {
         .map_err(StoreError::QueryError)
     }
 
-    pub(crate) fn update_account_record(tx: &Transaction<'_>, account: &Account) -> Result<(), StoreError> {
+    pub(crate) fn update_account_record(
+        tx: &Transaction<'_>,
+        account: &Account,
+    ) -> Result<(), StoreError> {
         let (id, code_root, storage_root, vault_root, nonce, committed) =
             serialize_account(account)?;
 

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -332,7 +332,7 @@ impl Store {
         .map_err(StoreError::QueryError)
     }
 
-    fn update_account_record(tx: &Transaction<'_>, account: &Account) -> Result<(), StoreError> {
+    pub(crate) fn update_account_record(tx: &Transaction<'_>, account: &Account) -> Result<(), StoreError> {
         let (id, code_root, storage_root, vault_root, nonce, committed) =
             serialize_account(account)?;
 
@@ -357,7 +357,7 @@ impl Store {
             .map_err(StoreError::QueryError)
     }
 
-    fn insert_account_storage(
+    pub(crate) fn insert_account_storage(
         tx: &Transaction<'_>,
         account_storage: &AccountStorage,
     ) -> Result<(), StoreError> {
@@ -368,7 +368,7 @@ impl Store {
             .map_err(StoreError::QueryError)
     }
 
-    fn insert_account_asset_vault(
+    pub(crate) fn insert_account_asset_vault(
         tx: &Transaction<'_>,
         asset_vault: &AssetVault,
     ) -> Result<(), StoreError> {

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -215,7 +215,10 @@ impl Store {
     }
 
     /// Inserts the provided input note into the database
-    pub fn insert_input_note_tx(tx: &Transaction<'_>, note: &InputNoteRecord) -> Result<(), StoreError> {
+    pub fn insert_input_note_tx(
+        tx: &Transaction<'_>,
+        note: &InputNoteRecord,
+    ) -> Result<(), StoreError> {
         let (
             note_id,
             nullifier,
@@ -232,27 +235,26 @@ impl Store {
             commit_height,
         ) = serialize_input_note(note)?;
 
-        tx
-            .execute(
-                INSERT_NOTE_QUERY,
-                params![
-                    note_id,
-                    nullifier,
-                    script,
-                    vault,
-                    inputs,
-                    serial_num,
-                    sender_id,
-                    tag,
-                    num_assets,
-                    inclusion_proof,
-                    recipients,
-                    status,
-                    commit_height
-                ],
-            )
-            .map_err(StoreError::QueryError)
-            .map(|_| ())
+        tx.execute(
+            INSERT_NOTE_QUERY,
+            params![
+                note_id,
+                nullifier,
+                script,
+                vault,
+                inputs,
+                serial_num,
+                sender_id,
+                tag,
+                num_assets,
+                inclusion_proof,
+                recipients,
+                status,
+                commit_height
+            ],
+        )
+        .map_err(StoreError::QueryError)
+        .map(|_| ())
     }
 }
 

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -105,14 +105,14 @@ impl Store {
         account_id: AccountId,
         proven_transaction: ProvenTransaction,
         transaction_result: ExecutedTransaction,
-        created_notes: &[Note]
+        created_notes: &[Note],
     ) -> Result<(), StoreError> {
         let (mut account, _seed) = self.get_account_by_id(account_id)?;
 
-        let account_delta = transaction_result
-            .account_delta();
+        let account_delta = transaction_result.account_delta();
 
-        account.apply_delta(account_delta)
+        account
+            .apply_delta(account_delta)
             .map_err(StoreError::AccountError)?;
 
         let created_notes = created_notes

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -193,7 +193,7 @@ impl Store {
             .collect();
 
         // Insert input notes
-        insert_input_notes(&tx, &input_notes)?;
+        insert_input_notes(tx, &input_notes)?;
 
         Ok(())
     }

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -5,7 +5,7 @@ use crypto::{
 };
 
 use objects::{
-    accounts::{AccountId, AccountDelta},
+    accounts::{AccountDelta, AccountId},
     assembly::{AstSerdeOptions, ProgramAst},
     transaction::{ExecutedTransaction, OutputNotes, ProvenTransaction, TransactionScript},
     Digest,

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -104,10 +104,7 @@ impl Store {
         // Transaction Data
         Self::insert_proven_transaction_data(&tx, proven_transaction, transaction_result)?;
 
-        // Updates for account
-        println!("account update nonce: {}", account.nonce());
-        println!("account updatehash : {}", account.hash());
-
+        // Account Data
         Self::insert_account_storage(&tx, account.storage())?;
         Self::insert_account_asset_vault(&tx, account.vault())?;
         Self::update_account_record(&tx, &account)?;


### PR DESCRIPTION
addresses #83 

Reorders some code so that the database updates that are done after submitting a transaction successfully are done atomically.
I also made some functions to reuse code that was being run in transaction and non transaction contexts and avoid code duplication.