### PR TITLE
refactor: remove account indices argument, add command to load single account

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -1,13 +1,19 @@
-use super::Client;
+use std::{fs, path::PathBuf};
+
 use clap::Parser;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use crypto::{
     dsa::rpo_falcon512::KeyPair,
-    utils::{bytes_to_hex_string, Serializable},
+    utils::{bytes_to_hex_string, Deserializable, Serializable},
 };
 use miden_client::client::accounts;
 
-use objects::{accounts::AccountId, assets::TokenSymbol, Digest};
+use super::Client;
+use objects::{
+    accounts::{AccountData, AccountId},
+    assets::TokenSymbol,
+    Digest,
+};
 
 // ACCOUNT COMMAND
 // ================================================================================================
@@ -40,6 +46,14 @@ pub enum AccountCmd {
     New {
         #[clap(subcommand)]
         template: AccountTemplate,
+    },
+
+    /// Import accounts from binary files (with .mac extension)
+    #[clap(short_flag = 'i')]
+    Import {
+        /// Path to the file that contains the input note data
+        #[clap(short, long, num_args = 1..)]
+        filenames: Vec<PathBuf>,
     },
 }
 
@@ -109,6 +123,12 @@ impl AccountCmd {
                 let account_id: AccountId = AccountId::from_hex(v)
                     .map_err(|_| "Input number was not a valid Account Id")?;
                 show_account(client, account_id, *keys, *vault, *storage, *code)?;
+            }
+            AccountCmd::Import { filenames } => {
+                validate_paths(filenames, None)?;
+                for filename in filenames {
+                    import_account(&mut client, filename)?;
+                }
             }
         }
         Ok(())
@@ -239,4 +259,41 @@ pub fn show_account(
     }
 
     Ok(())
+}
+
+// IMPORT INPUT NOTE
+// ================================================================================================
+fn import_account(client: &mut Client, filename: &PathBuf) -> Result<(), String> {
+    let account_data_file_contents = fs::read(filename).map_err(|err| err.to_string())?;
+    let account_data =
+        AccountData::read_from_bytes(&account_data_file_contents).map_err(|err| err.to_string())?;
+
+    client.import_account(account_data)?;
+
+    Ok(())
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Checks that all files exist, otherwise returns an error. It can also validate that all files
+/// have a specific extension
+fn validate_paths(paths: &[PathBuf], expected_extension: Option<&str>) -> Result<(), String> {
+    let invalid_path = if let Some(extension) = expected_extension {
+        paths
+            .iter()
+            .find(|path| !path.exists() || path.extension().map_or(false, |ext| ext != extension))
+    } else {
+        paths.iter().find(|path| !path.exists())
+    };
+
+    if let Some(path) = invalid_path {
+        Err(format!(
+            "The path `{}` does not exist or does not have the appropiate extension",
+            path.to_string_lossy()
+        )
+        .to_string())
+    } else {
+        Ok(())
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -80,15 +80,11 @@ impl Cli {
                 }
                 Ok(())
             }
-            Command::LoadAccounts {
-                accounts_path,
-            } => {
+            Command::LoadAccounts { accounts_path } => {
                 let mut client = client;
                 load_accounts_data(&mut client, accounts_path)
             }
-            Command::LoadAccount {
-                account_path,
-            } => {
+            Command::LoadAccount { account_path } => {
                 let mut client = client;
                 load_account(&mut client, account_path)
             }
@@ -96,10 +92,7 @@ impl Cli {
     }
 }
 
-fn load_accounts_data(
-    client: &mut Client,
-    path: &Path,
-) -> Result<(), String> {
+fn load_accounts_data(client: &mut Client, path: &Path) -> Result<(), String> {
     if !PathBuf::new().join(path).exists() {
         return Err("The specified path does not exist".to_string());
     }
@@ -117,10 +110,9 @@ fn load_accounts_data(
 }
 
 fn load_account(client: &mut Client, account_data_path: &PathBuf) -> Result<(), String> {
-    let account_data_file_contents =
-        fs::read(account_data_path).map_err(|err| err.to_string())?;
-    let account_data = AccountData::read_from_bytes(&account_data_file_contents)
-        .map_err(|err| err.to_string())?;
+    let account_data_file_contents = fs::read(account_data_path).map_err(|err| err.to_string())?;
+    let account_data =
+        AccountData::read_from_bytes(&account_data_file_contents).map_err(|err| err.to_string())?;
 
     client.import_account(account_data)?;
 


### PR DESCRIPTION
addresses #101 

I also added a load-account command so the user can add a single account by specifying the path. This is also doable by moving the account to a separate directory and using the load-accounts command, but thought this is a bit simpler for the user. I would consider changing it anyways.

Another thing I considered is adding a flag in `LoadAccounts` command to specify it's a single account instead of adding a separate `LoadAccount` command. I also would consider doing this instead