### PR TITLE
fix: use new function name to add nodes with path to mmr

### DIFF
--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -136,7 +136,7 @@ impl Store {
 
             if header_had_notes {
                 partial_mmr
-                    .add(
+                    .track(
                         current_block_num as usize,
                         current_block_header.hash(),
                         &requested_header_block_path,


### PR DESCRIPTION
[#263](https://github.com/0xPolygonMiden/crypto/pull/263) from miden-crypto got merged and it gives us a compilation error. Luckily the only change is the name of the `add` function of the PartialMmr. It got changed from `add` to `track`