### PR TITLE
feat: persist account hash

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -153,7 +153,7 @@ fn list_accounts(client: Client) -> Result<(), String> {
             Cell::new("nonce").add_attribute(Attribute::Bold),
         ]);
 
-    accounts.iter().for_each(|(acc, _acc_hash, _acc_seed)| {
+    accounts.iter().for_each(|acc| {
         table.add_row(vec![
             acc.id().to_string(),
             acc.code_root().to_string(),
@@ -175,11 +175,11 @@ pub fn show_account(
     show_storage: bool,
     show_code: bool,
 ) -> Result<(), String> {
-    let (account, _account_hash, account_seed) = client
-        .get_account_stub_by_id(account_id)
+    let account = client
+        .get_account_record_by_id(account_id)
         .map_err(|err| err.to_string())?;
 
-    let formatted_seed = Digest::from(account_seed).to_string();
+    let formatted_seed = Digest::from(account.account_seed()).to_string();
 
     let mut table = Table::new();
     table

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -153,7 +153,7 @@ fn list_accounts(client: Client) -> Result<(), String> {
             Cell::new("nonce").add_attribute(Attribute::Bold),
         ]);
 
-    accounts.iter().for_each(|(acc, _acc_seed)| {
+    accounts.iter().for_each(|(acc, _acc_hash, _acc_seed)| {
         table.add_row(vec![
             acc.id().to_string(),
             acc.code_root().to_string(),
@@ -175,7 +175,7 @@ pub fn show_account(
     show_storage: bool,
     show_code: bool,
 ) -> Result<(), String> {
-    let (account, account_seed) = client
+    let (account, _account_hash, account_seed) = client
         .get_account_stub_by_id(account_id)
         .map_err(|err| err.to_string())?;
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -191,10 +191,7 @@ impl Client {
     }
 
     /// Returns summary info about the specified account.
-    pub fn get_account_by_id(
-        &self,
-        account_id: AccountId,
-    ) -> Result<(Account, Digest, Word), ClientError> {
+    pub fn get_account_by_id(&self, account_id: AccountId) -> Result<Account, ClientError> {
         self.store
             .get_account_by_id(account_id)
             .map_err(|err| err.into())
@@ -207,6 +204,14 @@ impl Client {
     ) -> Result<AccountRecord, ClientError> {
         self.store
             .get_account_record_by_id(account_id)
+            .map_err(|err| err.into())
+    }
+
+    /// Returns an Account struct from the account records info
+    #[cfg(test)]
+    pub fn get_account_from_record(&self, record: &AccountRecord) -> Result<Account, ClientError> {
+        self.store
+            .get_account_from_record(record)
             .map_err(|err| err.into())
     }
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -184,12 +184,15 @@ impl Client {
 
     /// Returns summary info about the accounts managed by this client.
     ///
-    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Word)>, ClientError> {
+    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Digest, Word)>, ClientError> {
         self.store.get_accounts().map_err(|err| err.into())
     }
 
     /// Returns summary info about the specified account.
-    pub fn get_account_by_id(&self, account_id: AccountId) -> Result<(Account, Word), ClientError> {
+    pub fn get_account_by_id(
+        &self,
+        account_id: AccountId,
+    ) -> Result<(Account, Digest, Word), ClientError> {
         self.store
             .get_account_by_id(account_id)
             .map_err(|err| err.into())
@@ -199,7 +202,7 @@ impl Client {
     pub fn get_account_stub_by_id(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Word), ClientError> {
+    ) -> Result<(AccountStub, Digest, Word), ClientError> {
         self.store
             .get_account_stub_by_id(account_id)
             .map_err(|err| err.into())

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -3,8 +3,7 @@ use crypto::{dsa::rpo_falcon512::KeyPair, Felt, Word};
 use miden_lib::AuthScheme;
 use objects::{
     accounts::{
-        Account, AccountData, AccountDelta, AccountId, AccountStorage, AccountStub, AccountType,
-        AuthData,
+        Account, AccountData, AccountDelta, AccountId, AccountStorage, AccountType, AuthData,
     },
     assembly::ModuleAst,
     assets::{Asset, TokenSymbol},
@@ -12,7 +11,10 @@ use objects::{
 };
 use rand::{rngs::ThreadRng, Rng};
 
-use crate::{errors::ClientError, store::accounts::AuthInfo};
+use crate::{
+    errors::ClientError,
+    store::{accounts::AuthInfo, records::AccountRecord},
+};
 
 pub enum AccountTemplate {
     BasicWallet {
@@ -184,7 +186,7 @@ impl Client {
 
     /// Returns summary info about the accounts managed by this client.
     ///
-    pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Digest, Word)>, ClientError> {
+    pub fn get_accounts(&self) -> Result<Vec<AccountRecord>, ClientError> {
         self.store.get_accounts().map_err(|err| err.into())
     }
 
@@ -199,12 +201,12 @@ impl Client {
     }
 
     /// Returns summary info about the specified account.
-    pub fn get_account_stub_by_id(
+    pub fn get_account_record_by_id(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Digest, Word), ClientError> {
+    ) -> Result<AccountRecord, ClientError> {
         self.store
-            .get_account_stub_by_id(account_id)
+            .get_account_record_by_id(account_id)
             .map_err(|err| err.into())
     }
 
@@ -321,34 +323,28 @@ pub mod tests {
         let accounts = client.get_accounts().unwrap();
 
         assert_eq!(accounts.len(), 2);
-        assert_eq!(accounts[0].0.id(), expected_accounts[0].id());
-        assert_eq!(accounts[0].0.nonce(), expected_accounts[0].nonce());
+        assert_eq!(accounts[0].id(), expected_accounts[0].id());
+        assert_eq!(accounts[0].nonce(), expected_accounts[0].nonce());
         assert_eq!(
-            accounts[0].0.vault_root(),
+            accounts[0].vault_root(),
             expected_accounts[0].vault().commitment()
         );
         assert_eq!(
-            accounts[0].0.storage_root(),
+            accounts[0].storage_root(),
             expected_accounts[0].storage().root()
         );
-        assert_eq!(
-            accounts[0].0.code_root(),
-            expected_accounts[0].code().root()
-        );
+        assert_eq!(accounts[0].code_root(), expected_accounts[0].code().root());
 
-        assert_eq!(accounts[1].0.id(), expected_accounts[1].id());
-        assert_eq!(accounts[1].0.nonce(), expected_accounts[1].nonce());
+        assert_eq!(accounts[1].id(), expected_accounts[1].id());
+        assert_eq!(accounts[1].nonce(), expected_accounts[1].nonce());
         assert_eq!(
-            accounts[1].0.vault_root(),
+            accounts[1].vault_root(),
             expected_accounts[1].vault().commitment()
         );
         assert_eq!(
-            accounts[1].0.storage_root(),
+            accounts[1].storage_root(),
             expected_accounts[1].storage().root()
         );
-        assert_eq!(
-            accounts[1].0.code_root(),
-            expected_accounts[1].code().root()
-        );
+        assert_eq!(accounts[1].code_root(), expected_accounts[1].code().root());
     }
 }

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -122,7 +122,7 @@ impl Client {
             .get_accounts()
             .unwrap()
             .into_iter()
-            .map(|(a, _h, _s)| a.id().into())
+            .map(|a| a.id().into())
             .collect();
 
         let nullifiers = self.store.get_unspent_input_note_nullifiers()?;

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -122,7 +122,7 @@ impl Client {
             .get_accounts()
             .unwrap()
             .into_iter()
-            .map(|(a, _s)| a.id().into())
+            .map(|(a, _h, _s)| a.id().into())
             .collect();
 
         let nullifiers = self.store.get_unspent_input_note_nullifiers()?;

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -30,7 +30,7 @@ impl DataStore for SqliteDataStore {
         notes: &[objects::notes::NoteId],
     ) -> Result<TransactionInputs, DataStoreError> {
         // Construct Account
-        let (account, seed) = self.store.get_account_by_id(account_id)?;
+        let (account, _account_hash, seed) = self.store.get_account_by_id(account_id)?;
 
         // Get header data
         let (block_header, _had_notes) = self.store.get_block_header_by_num(block_num)?;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -7,6 +7,7 @@ pub mod accounts;
 pub mod chain_data;
 mod migrations;
 pub mod notes;
+pub mod records;
 pub mod state_sync;
 pub mod transactions;
 

--- a/src/store/records.rs
+++ b/src/store/records.rs
@@ -1,0 +1,70 @@
+use super::accounts::SerializedAccountsParts;
+use crate::errors::StoreError;
+use crypto::{utils::Deserializable, Word};
+use objects::{accounts::AccountId, Digest, Felt};
+
+/// This module is meant to be store YYYRecord structs of the data that we fetch via queries
+
+/// ACCOUNT RECORD
+pub struct AccountRecord {
+    id: AccountId,
+    nonce: Felt,
+    vault_root: Digest,
+    storage_root: Digest,
+    code_root: Digest,
+    account_seed: Word,
+    account_hash: Digest,
+}
+
+impl AccountRecord {
+    /// Parse an account record from the provided parts.
+    pub fn new(
+        serialized_account_parts: SerializedAccountsParts,
+    ) -> Result<AccountRecord, StoreError> {
+        let (id, nonce, vault_root, storage_root, code_root, account_hash, account_seed) =
+            serialized_account_parts;
+        let account_seed_word: Word =
+            Word::read_from_bytes(&account_seed).map_err(StoreError::DataDeserializationError)?;
+
+        Ok(Self {
+            id: (id as u64)
+                .try_into()
+                .expect("Conversion from stored AccountID should not panic"),
+            nonce: (nonce as u64).into(),
+            vault_root: serde_json::from_str(&vault_root)
+                .map_err(StoreError::JsonDataDeserializationError)?,
+            storage_root: Digest::try_from(&storage_root).map_err(StoreError::HexParseError)?,
+            code_root: Digest::try_from(&code_root).map_err(StoreError::HexParseError)?,
+            account_hash: Digest::try_from(&account_hash).map_err(StoreError::HexParseError)?,
+            account_seed: account_seed_word,
+        })
+    }
+
+    pub fn id(&self) -> AccountId {
+        self.id
+    }
+
+    pub fn nonce(&self) -> Felt {
+        self.nonce
+    }
+
+    pub fn vault_root(&self) -> Digest {
+        self.vault_root
+    }
+
+    pub fn storage_root(&self) -> Digest {
+        self.storage_root
+    }
+
+    pub fn code_root(&self) -> Digest {
+        self.code_root
+    }
+
+    pub fn account_seed(&self) -> Word {
+        self.account_seed
+    }
+
+    pub fn account_hash(&self) -> Digest {
+        self.account_hash
+    }
+}

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -96,7 +96,7 @@ impl Store {
         let current_accounts: Vec<AccountStub> = self
             .get_accounts()?
             .iter()
-            .map(|(acc, _)| acc.clone())
+            .map(|(acc, _, _)| acc.clone())
             .collect();
 
         // Check if the returned account hashes match latest account hashes in the database

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -57,8 +57,9 @@ CREATE TABLE transactions (
     committed BOOLEAN NOT NULL,                      -- Status of the transaction: either pending (false) or committed (true).
     commit_height UNSIGNED BIG INT,                  -- Block number of the block at which the transaction was included in the chain.
     
+    PRIMARY KEY (id),
     FOREIGN KEY (script_hash) REFERENCES transaction_scripts(script_hash),
-    PRIMARY KEY (id)
+    FOREIGN KEY (init_account_state) REFERENCES accounts(account_hash)
 );
 
 CREATE TABLE transaction_scripts (

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -33,6 +33,7 @@ CREATE TABLE accounts (
     code_root BLOB NOT NULL,       -- root of the account_code
     storage_root BLOB NOT NULL,    -- root of the account_storage Merkle tree.
     vault_root BLOB NOT NULL,      -- root of the account_vault Merkle tree.
+    account_hash BLOB NOT NULL,    -- root of the account_code
     nonce BIGINT NOT NULL,         -- account nonce.
     committed BOOLEAN NOT NULL,    -- true if recorded, false if not.
     account_seed BLOB NOT NULL,    -- account seed used to generate the ID.

--- a/src/store/store.sql
+++ b/src/store/store.sql
@@ -30,10 +30,10 @@ CREATE TABLE account_auth (
 -- Create accounts table
 CREATE TABLE accounts (
     id UNSIGNED BIG INT NOT NULL,  -- account ID.
+    account_hash BLOB NOT NULL,    -- commitment to the account's state
     code_root BLOB NOT NULL,       -- root of the account_code
     storage_root BLOB NOT NULL,    -- root of the account_storage Merkle tree.
     vault_root BLOB NOT NULL,      -- root of the account_vault Merkle tree.
-    account_hash BLOB NOT NULL,    -- root of the account_code
     nonce BIGINT NOT NULL,         -- account nonce.
     committed BOOLEAN NOT NULL,    -- true if recorded, false if not.
     account_seed BLOB NOT NULL,    -- account seed used to generate the ID.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -134,13 +134,15 @@ async fn insert_basic_account() {
     let fetched_account_data = client.get_account_by_id(account.id());
     assert!(fetched_account_data.is_ok());
 
-    let (fetched_account, fetched_account_seed) = fetched_account_data.unwrap();
+    let (fetched_account, fetched_account_hash, fetched_account_seed) =
+        fetched_account_data.unwrap();
     // Validate stub has matching data
     assert_eq!(account.id(), fetched_account.id());
     assert_eq!(account.nonce(), fetched_account.nonce());
     assert_eq!(account.vault(), fetched_account.vault());
     assert_eq!(account.storage().root(), fetched_account.storage().root());
     assert_eq!(account.code().root(), fetched_account.code().root());
+    assert_eq!(account.hash(), fetched_account_hash);
 
     // Validate seed matches
     assert_eq!(account_seed, fetched_account_seed);
@@ -176,13 +178,15 @@ async fn insert_faucet_account() {
     let fetched_account_data = client.get_account_by_id(account.id());
     assert!(fetched_account_data.is_ok());
 
-    let (fetched_account, fetched_account_seed) = fetched_account_data.unwrap();
+    let (fetched_account, fetched_account_hash, fetched_account_seed) =
+        fetched_account_data.unwrap();
     // Validate stub has matching data
     assert_eq!(account.id(), fetched_account.id());
     assert_eq!(account.nonce(), fetched_account.nonce());
     assert_eq!(account.vault(), fetched_account.vault());
     assert_eq!(account.storage(), fetched_account.storage());
     assert_eq!(account.code().root(), fetched_account.code().root());
+    assert_eq!(account.hash(), fetched_account_hash);
 
     // Validate seed matches
     assert_eq!(account_seed, fetched_account_seed);
@@ -257,7 +261,7 @@ async fn test_acc_code() {
     client
         .insert_account(&account, account_seed, &AuthInfo::RpoFalcon512(key_pair))
         .unwrap();
-    let (retrieved_acc, _) = client.get_account_by_id(account_id).unwrap();
+    let (retrieved_acc, _, _) = client.get_account_by_id(account_id).unwrap();
 
     let mut account_module = account.code().module().clone();
     account_module.clear_locations();
@@ -296,10 +300,11 @@ async fn test_get_account_by_id() {
         .unwrap();
 
     // Retrieving an existing account should succeed
-    let (acc_from_db, _account_seed) = match client.get_account_stub_by_id(account.id()) {
-        Ok(account) => account,
-        Err(err) => panic!("Error retrieving account: {}", err),
-    };
+    let (acc_from_db, _account_hash, _account_seed) =
+        match client.get_account_stub_by_id(account.id()) {
+            Ok(account) => account,
+            Err(err) => panic!("Error retrieving account: {}", err),
+        };
     assert_eq!(AccountStub::from(account), acc_from_db);
 
     // Retrieving a non existing account should fail

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -27,7 +27,7 @@ use mock::{
     },
 };
 use objects::{
-    accounts::{AccountId, AccountStub},
+    accounts::AccountId,
     assets::{FungibleAsset, TokenSymbol},
     transaction::InputNotes,
 };
@@ -300,17 +300,21 @@ async fn test_get_account_by_id() {
         .unwrap();
 
     // Retrieving an existing account should succeed
-    let (acc_from_db, _account_hash, _account_seed) =
-        match client.get_account_stub_by_id(account.id()) {
-            Ok(account) => account,
-            Err(err) => panic!("Error retrieving account: {}", err),
-        };
-    assert_eq!(AccountStub::from(account), acc_from_db);
+    let acc_from_db = match client.get_account_record_by_id(account.id()) {
+        Ok(account) => account,
+        Err(err) => panic!("Error retrieving account: {}", err),
+    };
+    assert_eq!(account.id(), acc_from_db.id());
+    assert_eq!(account.hash(), acc_from_db.account_hash());
+    assert_eq!(account.nonce(), acc_from_db.nonce());
+    assert_eq!(account.storage().root(), acc_from_db.storage_root());
+    assert_eq!(account.code().root(), acc_from_db.code_root());
+    assert_eq!(account.vault().commitment(), acc_from_db.vault_root());
 
     // Retrieving a non existing account should fail
     let hex = format!("0x{}", "1".repeat(16));
     let invalid_id = AccountId::from_hex(&hex).unwrap();
-    assert!(client.get_account_stub_by_id(invalid_id).is_err());
+    assert!(client.get_account_record_by_id(invalid_id).is_err());
 }
 
 #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -130,22 +130,26 @@ async fn insert_basic_account() {
 
     let (account, account_seed) = account_insert_result.unwrap();
 
-    // Fetch Account
-    let fetched_account_data = client.get_account_by_id(account.id());
-    assert!(fetched_account_data.is_ok());
+    // Fetch Account Record
+    let fetched_account_record = client.get_account_record_by_id(account.id());
+    assert!(fetched_account_record.is_ok());
+    let fetched_account_record = fetched_account_record.unwrap();
 
-    let (fetched_account, fetched_account_hash, fetched_account_seed) =
-        fetched_account_data.unwrap();
+    // Fetch Account
+    let fetched_account_data = client.get_account_from_record(&fetched_account_record);
+    assert!(fetched_account_data.is_ok());
+    let fetched_account = fetched_account_data.unwrap();
+
     // Validate stub has matching data
     assert_eq!(account.id(), fetched_account.id());
     assert_eq!(account.nonce(), fetched_account.nonce());
     assert_eq!(account.vault(), fetched_account.vault());
     assert_eq!(account.storage().root(), fetched_account.storage().root());
     assert_eq!(account.code().root(), fetched_account.code().root());
-    assert_eq!(account.hash(), fetched_account_hash);
+    assert_eq!(account.hash(), fetched_account_record.account_hash());
 
     // Validate seed matches
-    assert_eq!(account_seed, fetched_account_seed);
+    assert_eq!(account_seed, fetched_account_record.account_seed());
 }
 
 #[tokio::test]
@@ -174,22 +178,26 @@ async fn insert_faucet_account() {
 
     let (account, account_seed) = account_insert_result.unwrap();
 
-    // Fetch Account
-    let fetched_account_data = client.get_account_by_id(account.id());
-    assert!(fetched_account_data.is_ok());
+    // Fetch Account Record
+    let fetched_account_record = client.get_account_record_by_id(account.id());
+    assert!(fetched_account_record.is_ok());
+    let fetched_account_record = fetched_account_record.unwrap();
 
-    let (fetched_account, fetched_account_hash, fetched_account_seed) =
-        fetched_account_data.unwrap();
+    // Fetch Account
+    let fetched_account_data = client.get_account_from_record(&fetched_account_record);
+    assert!(fetched_account_data.is_ok());
+    let fetched_account = fetched_account_data.unwrap();
+
     // Validate stub has matching data
     assert_eq!(account.id(), fetched_account.id());
     assert_eq!(account.nonce(), fetched_account.nonce());
     assert_eq!(account.vault(), fetched_account.vault());
-    assert_eq!(account.storage(), fetched_account.storage());
+    assert_eq!(account.storage().root(), fetched_account.storage().root());
     assert_eq!(account.code().root(), fetched_account.code().root());
-    assert_eq!(account.hash(), fetched_account_hash);
+    assert_eq!(account.hash(), fetched_account_record.account_hash());
 
     // Validate seed matches
-    assert_eq!(account_seed, fetched_account_seed);
+    assert_eq!(account_seed, fetched_account_record.account_seed());
 }
 
 #[tokio::test]
@@ -261,7 +269,7 @@ async fn test_acc_code() {
     client
         .insert_account(&account, account_seed, &AuthInfo::RpoFalcon512(key_pair))
         .unwrap();
-    let (retrieved_acc, _, _) = client.get_account_by_id(account_id).unwrap();
+    let retrieved_acc = client.get_account_by_id(account_id).unwrap();
 
     let mut account_module = account.code().module().clone();
     account_module.clear_locations();


### PR DESCRIPTION
closes #106 

## Changes

- [X] store the account hash in the `accounts` table ([32487f3](https://github.com/0xPolygonMiden/miden-client/pull/118/commits/32487f3a8ac7b6e07500e1247d53f4e25173fd47))
- [X] add a foreign key constraint to the `transactions` table (via `init_account_state` field) ([46be571](https://github.com/0xPolygonMiden/miden-client/pull/118/commits/46be571846237e21567c99b9839d58494a5a74cb))
- [x] use the cached account hash during sync state ([9a39736](https://github.com/0xPolygonMiden/miden-client/pull/118/commits/9a397369c27480256f1196b51208037e9d2b5e28))