### PR TITLE
feat: Add consume all notes, refactor state sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ This will add a transaction and an output note (containing the minted asset) to 
 After creating the note with the minted asset, the regular account can now consume it and add the tokens to its vault. You can do this the following way:
 
 ```bash
-miden-client transaction new consume-note <regular-account-ID-A>
+miden-client transaction new consume-note <regular-account-ID-A> <input-note-ID>
 ```
 
-This will consume the first available note. You can also pass a Note ID to this command (which you can list as stated in the previous step). You will now be able to see the asset in the account's vault by running:
+This will consume the input note ID, which you can get by listing them as explained in the previous step. You will now be able to see the asset in the account's vault by running:
 
 ```bash
 miden-client account show <regular-account-ID-A> -v

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -263,16 +263,18 @@ pub fn show_account(
     Ok(())
 }
 
-// IMPORT INPUT NOTE
+// IMPORT ACCOUNT
 // ================================================================================================
+
 fn import_account(client: &mut Client, filename: &PathBuf) -> Result<(), String> {
+    println!("importing acc");
     let account_data_file_contents = fs::read(filename).map_err(|err| err.to_string())?;
+    println!("read from bytes");
     let account_data =
         AccountData::read_from_bytes(&account_data_file_contents).map_err(|err| err.to_string())?;
+    println!("now importing");
 
-    client.import_account(account_data)?;
-
-    Ok(())
+    client.import_account(account_data)
 }
 
 // HELPERS

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -267,12 +267,9 @@ pub fn show_account(
 // ================================================================================================
 
 fn import_account(client: &mut Client, filename: &PathBuf) -> Result<(), String> {
-    println!("importing acc");
     let account_data_file_contents = fs::read(filename).map_err(|err| err.to_string())?;
-    println!("read from bytes");
     let account_data =
         AccountData::read_from_bytes(&account_data_file_contents).map_err(|err| err.to_string())?;
-    println!("now importing");
 
     client.import_account(account_data)
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -53,7 +53,6 @@ impl Cli {
         // Create the client
         let mut current_dir = std::env::current_dir().map_err(|err| err.to_string())?;
         current_dir.push(CLIENT_CONFIG_FILE_NAME);
-        println!("path {:?}", current_dir);
 
         let client_config = load_config(current_dir.as_path())?;
         let client = Client::new(client_config).map_err(|err| err.to_string())?;

--- a/src/cli/sync_state.rs
+++ b/src/cli/sync_state.rs
@@ -51,19 +51,19 @@ impl SyncStateCmd {
 // ================================================================================================
 fn list_tags(client: Client) -> Result<(), String> {
     let tags = client.get_note_tags().map_err(|err| err.to_string())?;
-    println!("tags: {:?}", tags);
+    println!("Tags: {:?}", tags);
     Ok(())
 }
 
 fn add_tag(mut client: Client, tag: u64) -> Result<(), String> {
     client.add_note_tag(tag).map_err(|err| err.to_string())?;
-    println!("tag {} added", tag);
+    println!("Tag {} added", tag);
     Ok(())
 }
 
 fn print_block_number(client: Client) -> Result<(), String> {
     println!(
-        "block number: {}",
+        "Block number: {}",
         client.get_sync_height().map_err(|e| e.to_string())?
     );
     Ok(())
@@ -71,6 +71,6 @@ fn print_block_number(client: Client) -> Result<(), String> {
 
 async fn sync_state(mut client: Client) -> Result<(), String> {
     let block_num = client.sync_state().await.map_err(|e| e.to_string())?;
-    println!("state synced to block {}", block_num);
+    println!("State synced to block {}", block_num);
     Ok(())
 }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -26,7 +26,10 @@ pub enum TransactionType {
     P2IDR,
     ConsumeNote {
         account_id: String,
-        note_id: Option<String>,
+        note_id: String,
+    },
+    ConsumeAllNotes {
+        account_id: String,
     },
 }
 
@@ -81,16 +84,15 @@ impl TryInto<TransactionTemplate> for &TransactionType {
                 note_id,
             } => {
                 let account_id = AccountId::from_hex(account_id).map_err(|err| err.to_string())?;
-                let note_id = match note_id {
-                    Some(note_id) => Some(
-                        Digest::try_from(note_id)
-                            .map(NoteId::from)
-                            .map_err(|err| err.to_string())?,
-                    ),
-                    None => None,
-                };
+                let note_id = Digest::try_from(note_id)
+                    .map(NoteId::from)
+                    .map_err(|err| err.to_string())?;
 
                 Ok(TransactionTemplate::ConsumeNote(account_id, note_id))
+            }
+            TransactionType::ConsumeAllNotes { account_id } => {
+                let account_id = AccountId::from_hex(account_id).map_err(|err| err.to_string())?;
+                Ok(TransactionTemplate::ConsumeAllNotes(account_id))
             }
         }
     }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -5,7 +5,7 @@ use miden_client::{
     store::transactions::TransactionFilter,
 };
 
-use objects::{accounts::AccountId, assets::FungibleAsset, notes::NoteId, Digest};
+use objects::{accounts::AccountId, assets::FungibleAsset, notes::NoteId};
 use tracing::info;
 
 use super::{Client, Parser};
@@ -85,9 +85,7 @@ impl TryInto<TransactionTemplate> for &TransactionType {
                 note_id,
             } => {
                 let account_id = AccountId::from_hex(account_id).map_err(|err| err.to_string())?;
-                let note_id = Digest::try_from(note_id)
-                    .map(NoteId::from)
-                    .map_err(|err| err.to_string())?;
+                let note_id = NoteId::try_from_hex(note_id).map_err(|err| err.to_string())?;
 
                 Ok(TransactionTemplate::ConsumeNote(account_id, note_id))
             }

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -1,4 +1,3 @@
-use super::Client;
 use crypto::{dsa::rpo_falcon512::KeyPair, Felt, Word};
 use miden_lib::AuthScheme;
 use objects::{
@@ -13,6 +12,8 @@ use objects::{
 use rand::{rngs::ThreadRng, Rng};
 
 use crate::{errors::ClientError, store::accounts::AuthInfo};
+
+use super::Client;
 
 pub enum AccountTemplate {
     BasicWallet {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,7 +7,7 @@ pub use rpc_client::RpcApiEndpoint;
 pub mod accounts;
 mod chain_data;
 mod notes;
-mod rpc_client;
+pub(crate) mod rpc_client;
 pub(crate) mod sync_state;
 pub mod transactions;
 

--- a/src/client/rpc_client.rs
+++ b/src/client/rpc_client.rs
@@ -1,4 +1,98 @@
 use core::fmt;
+use crypto::merkle::{MerklePath, MmrDelta};
+use miden_node_proto::responses::SyncStateResponse;
+use objects::{accounts::AccountId, notes::NoteId, BlockHeader, Digest};
+
+// STATE SYNC INFO
+// ================================================================================================
+
+/// Represents a [SyncStateResponse] with fields converted into domain types
+pub struct StateSyncInfo {
+    pub chain_tip: u32,
+    pub block_header: BlockHeader,
+    pub mmr_delta: MmrDelta,
+    /// Tuples of AccountId alongside their new account hashes
+    pub account_hash_updates: Vec<(AccountId, Digest)>,
+    /// List of tuples of Note ID, Note Index and Merkle Path for all new notes
+    pub note_inclusions: Vec<(NoteId, u64, MerklePath)>,
+    /// List of nullifiers that identify spent notes
+    pub nullifiers: Vec<Digest>,
+}
+
+impl TryFrom<SyncStateResponse> for StateSyncInfo {
+    type Error = RpcApiError;
+
+    fn try_from(value: SyncStateResponse) -> Result<Self, Self::Error> {
+        let chain_tip = value.chain_tip;
+
+        // Validate and convert block header
+        let block_header = value
+            .block_header
+            .ok_or(RpcApiError::ExpectedFieldMissing("BlockHeader".into()))?
+            .try_into()?;
+
+        // Validate and convert MMR Delta
+        let mmr_delta = value
+            .mmr_delta
+            .ok_or(RpcApiError::ExpectedFieldMissing("MmrDelta".into()))?
+            .try_into()?;
+
+        // Validate and convert account hash updates into an (AccountId, Digest) tuple
+        let mut account_hash_updates = vec![];
+        for update in value.accounts {
+            let account_id = update
+                .account_id
+                .ok_or(RpcApiError::ExpectedFieldMissing(
+                    "AccountHashUpdate.AccountId".into(),
+                ))?
+                .try_into()?;
+            let account_hash = update
+                .account_hash
+                .ok_or(RpcApiError::ExpectedFieldMissing(
+                    "AccountHashUpdate.AccountHash".into(),
+                ))?
+                .try_into()?;
+            account_hash_updates.push((account_id, account_hash));
+        }
+
+        // Validate and convert account note inclusions into an (AccountId, Digest) tuple
+        let mut note_inclusions = vec![];
+        for note in value.notes {
+            let note_id: Digest = note
+                .note_hash
+                .ok_or(RpcApiError::ExpectedFieldMissing("Notes.Id".into()))?
+                .try_into()?;
+            let note_id: NoteId = note_id.into();
+
+            let note_merkle_path = note
+                .merkle_path
+                .ok_or(RpcApiError::ExpectedFieldMissing("Notes.MerklePath".into()))?
+                .try_into()?;
+            note_inclusions.push((note_id, note.note_index as u64, note_merkle_path));
+        }
+
+        let nullifiers = value
+            .nullifiers
+            .iter()
+            .map(|nul_update| {
+                nul_update
+                    .clone()
+                    .nullifier
+                    .ok_or(RpcApiError::ExpectedFieldMissing("Nullifier".into()))
+                    .and_then(|n| Digest::try_from(n).map_err(RpcApiError::ConversionFailure))
+            })
+            .collect::<Result<Vec<Digest>, RpcApiError>>()?;
+
+        Ok(Self {
+            chain_tip,
+            block_header,
+            mmr_delta,
+            account_hash_updates,
+            note_inclusions,
+            nullifiers,
+        })
+    }
+}
 
 // RPC CLIENT
 // ================================================================================================
@@ -6,19 +100,20 @@ use core::fmt;
 #[cfg(not(any(test, feature = "mock")))]
 pub(crate) use client::RpcClient;
 
+use crate::errors::RpcApiError;
+
 #[cfg(not(any(test, feature = "mock")))]
 mod client {
-    use super::RpcApiEndpoint;
+    use super::{RpcApiEndpoint, StateSyncInfo};
     use crate::errors::RpcApiError;
     use miden_node_proto::{
         requests::{
             GetBlockHeaderByNumberRequest, SubmitProvenTransactionRequest, SyncStateRequest,
         },
-        responses::{
-            GetBlockHeaderByNumberResponse, SubmitProvenTransactionResponse, SyncStateResponse,
-        },
+        responses::{SubmitProvenTransactionResponse, SyncStateResponse},
         rpc::api_client::ApiClient,
     };
+    use objects::{accounts::AccountId, BlockHeader};
     use tonic::transport::Channel;
 
     /// Wrapper for ApiClient which defers establishing a connection with a node until necessary
@@ -35,8 +130,9 @@ mod client {
             }
         }
 
-        /// Executes the specified sync state request and returns the response.
-        pub async fn sync_state(
+        /// Sends the request through the tonic client the specified sync state request
+        /// and returns the response.
+        async fn sync_state_request(
             &mut self,
             request: impl tonic::IntoRequest<SyncStateRequest>,
         ) -> Result<tonic::Response<SyncStateResponse>, RpcApiError> {
@@ -61,17 +157,25 @@ mod client {
         pub async fn get_block_header_by_number(
             &mut self,
             request: impl tonic::IntoRequest<GetBlockHeaderByNumberRequest>,
-        ) -> Result<tonic::Response<GetBlockHeaderByNumberResponse>, RpcApiError> {
+        ) -> Result<BlockHeader, RpcApiError> {
             let rpc_api = self.rpc_api().await?;
-            rpc_api
-                .get_block_header_by_number(request)
-                .await
-                .map_err(|err| {
-                    RpcApiError::RequestError(RpcApiEndpoint::GetBlockHeaderByNumber, err)
-                })
+            let api_response =
+                rpc_api
+                    .get_block_header_by_number(request)
+                    .await
+                    .map_err(|err| {
+                        RpcApiError::RequestError(RpcApiEndpoint::GetBlockHeaderByNumber, err)
+                    })?;
+
+            api_response
+                .into_inner()
+                .block_header
+                .ok_or(RpcApiError::ExpectedFieldMissing("BlockHeader".into()))?
+                .try_into()
+                .map_err(RpcApiError::ConversionFailure)
         }
 
-        /// Takes care of establishing the rpc connection if not connected yet and returns a reference
+        /// Takes care of establishing the RPC connection if not connected yet and returns a reference
         /// to the inner ApiClient
         async fn rpc_api(&mut self) -> Result<&mut ApiClient<Channel>, RpcApiError> {
             if self.rpc_api.is_some() {
@@ -82,6 +186,35 @@ mod client {
                     .map_err(RpcApiError::ConnectionError)?;
                 Ok(self.rpc_api.insert(rpc_api))
             }
+        }
+
+        /// Sends a sync state request to the Miden node, validates and converts the response
+        /// into a [StateSyncInfo] struct.
+        pub async fn sync_state(
+            &mut self,
+            block_num: u32,
+            account_ids: &Vec<AccountId>,
+            note_tags: &[u16],
+            nullifiers_tags: &[u16],
+        ) -> Result<StateSyncInfo, RpcApiError> {
+            let account_ids = account_ids.iter().map(|acc| (*acc).into()).collect();
+
+            let nullifiers = nullifiers_tags
+                .iter()
+                .map(|&nullifier| nullifier as u32)
+                .collect();
+
+            let note_tags = note_tags.iter().map(|&note_tag| note_tag as u32).collect();
+
+            let request = SyncStateRequest {
+                block_num,
+                account_ids,
+                note_tags,
+                nullifiers,
+            };
+
+            let response = self.sync_state_request(request).await?.into_inner();
+            response.try_into()
         }
     }
 }

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -300,7 +300,7 @@ impl Client {
         let current_peaks = self.store.get_chain_mmr_peaks_by_block_num(block_num)?;
 
         let track_latest = match self.store.get_block_header_by_num(block_num - 1) {
-            Ok((_, should_be_tracked)) => Ok(should_be_tracked),
+            Ok((_, previous_block_had_notes)) => Ok(previous_block_had_notes),
             Err(StoreError::BlockHeaderNotFound(_)) => Ok(false),
             Err(err) => Err(ClientError::StoreError(err)),
         }?;

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -15,6 +15,7 @@ use crate::{
     errors::{ClientError, StoreError},
     store::{chain_data::ChainMmrNodeFilter, Store},
 };
+use tracing::warn;
 
 pub enum SyncStatus {
     SyncedToLastBlock(u32),

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -300,11 +300,15 @@ impl Client {
         let tracked_nodes = self.store.get_chain_mmr_nodes(ChainMmrNodeFilter::All)?;
         let current_peaks = self.store.get_chain_mmr_peaks_by_block_num(block_num)?;
 
-        let track_latest = match self.store.get_block_header_by_num(block_num - 1) {
-            Ok((_, previous_block_had_notes)) => Ok(previous_block_had_notes),
-            Err(StoreError::BlockHeaderNotFound(_)) => Ok(false),
-            Err(err) => Err(ClientError::StoreError(err)),
-        }?;
+        let track_latest = if block_num != 0 {
+            match self.store.get_block_header_by_num(block_num - 1) {
+                Ok((_, previous_block_had_notes)) => Ok(previous_block_had_notes),
+                Err(StoreError::BlockHeaderNotFound(_)) => Ok(false),
+                Err(err) => Err(ClientError::StoreError(err)),
+            }?
+        } else {
+            false
+        };
 
         Ok(PartialMmr::from_parts(
             current_peaks,

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -254,7 +254,7 @@ impl Client {
         let script_inputs = vec![(pubkey_input, advice_map)];
 
         let input_notes = if let Some(note_id) = note_id {
-            vec![self.store.get_input_note_by_id(note_id)?.note_id()]
+            vec![note_id]
         } else {
             self.store
                 .get_input_notes(InputNoteFilter::Committed)?
@@ -267,7 +267,6 @@ impl Client {
             self.tx_executor
                 .compile_tx_script(tx_script_code, script_inputs, vec![])?;
 
-        // TODO: Is it preferrable to execute against the minimum block_num possible (ie, the input note's block_num)
         let block_num = self.store.get_sync_height()?;
 
         // Execute the transaction and get the witness

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -29,8 +29,10 @@ use super::Client;
 
 #[derive(Clone)]
 pub enum TransactionTemplate {
-    /// Consume outstanding note for an account. If none is provided, it consumes the first found
-    ConsumeNote(AccountId, Option<NoteId>),
+    /// Consume outstanding note for an account.
+    ConsumeNote(AccountId, NoteId),
+    /// Consume all outstanding note for an account.
+    ConsumeAllNotes(AccountId),
     // NOTE: Maybe this should be called "distribute"?
     /// Mint fungible assets using a faucet account
     MintFungibleAsset {
@@ -48,6 +50,7 @@ impl TransactionTemplate {
     pub fn account_id(&self) -> AccountId {
         match self {
             TransactionTemplate::ConsumeNote(account_id, _) => *account_id,
+            TransactionTemplate::ConsumeAllNotes(account_id) => *account_id,
             TransactionTemplate::MintFungibleAsset {
                 asset,
                 target_account_id: _target_account_id,
@@ -188,7 +191,6 @@ impl Client {
     // --------------------------------------------------------------------------------------------
 
     /// Creates and executes a transaction specified by the template, but does not change the
-    /// Creates and executes a transaction specified by the template, but does not change the
     /// local database.
     pub fn new_transaction(
         &mut self,
@@ -202,15 +204,22 @@ impl Client {
             }) => self.new_p2id_transaction(fungible_asset, sender_account_id, target_account_id),
             TransactionTemplate::PayToIdWithRecall(_payment_data, _recall_height) => todo!(),
             TransactionTemplate::ConsumeNote(account_id, note_id) => {
-                self.new_consume_notes_transaction(account_id, note_id)
+                self.new_consume_notes_transaction(account_id, Some(note_id))
             }
             TransactionTemplate::MintFungibleAsset {
                 asset,
                 target_account_id,
             } => self.new_mint_fungible_asset_transaction(asset, target_account_id),
+            TransactionTemplate::ConsumeAllNotes(account_id) => {
+                self.new_consume_notes_transaction(account_id, None)
+            }
         }
     }
 
+    /// Creates and executes a transaction that consumes a number of notes
+    ///
+    /// If `note_id` is `None`, all committed input notes are consumed.
+    /// Otherwise, the specified note is consumed.
     fn new_consume_notes_transaction(
         &mut self,
         account_id: AccountId,
@@ -244,18 +253,14 @@ impl Client {
         };
         let script_inputs = vec![(pubkey_input, advice_map)];
 
-        let input_note = if note_id.is_some() {
-            self.store.get_input_note_by_id(note_id.unwrap())?
+        let input_notes = if let Some(note_id) = note_id {
+            vec![self.store.get_input_note_by_id(note_id)?.note_id()]
         } else {
-            let input_notes = self
-                .store
-                .get_input_notes(InputNoteFilter::Committed)
-                .map_err(ClientError::StoreError)?;
-
-            input_notes
-                .first()
-                .ok_or(ClientError::NoConsumableNoteForAccount(account_id))?
-                .clone()
+            self.store
+                .get_input_notes(InputNoteFilter::Committed)?
+                .iter()
+                .map(|n| n.note_id())
+                .collect()
         };
 
         let tx_script = self
@@ -263,18 +268,13 @@ impl Client {
             .compile_tx_script(tx_script_code, script_inputs, vec![])
             .map_err(ClientError::TransactionExecutionError)?;
 
-        // TODO: Change this to last block number after we confirm this execution works
-        let block_num = input_note.inclusion_proof().unwrap().origin().block_num;
+        // TODO: Is it preferrable to execute against the minimum block_num possible (ie, the input note's block_num)
+        let block_num = self.store.get_sync_height()?;
 
         // Execute the transaction and get the witness
         let executed_transaction = self
             .tx_executor
-            .execute_transaction(
-                account_id,
-                block_num,
-                &[input_note.note_id()],
-                Some(tx_script.clone()),
-            )
+            .execute_transaction(account_id, block_num, &input_notes, Some(tx_script.clone()))
             .map_err(ClientError::TransactionExecutionError)?;
 
         Ok(TransactionResult::new(executed_transaction, vec![]))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,8 +22,6 @@ pub enum ClientError {
     NoteError(NoteError),
     NoConsumableNoteForAccount(AccountId),
     RpcApiError(RpcApiError),
-    RpcExpectedFieldMissing(String),
-    RpcTypeConversionFailure(ParseError),
     StoreError(StoreError),
     TransactionExecutionError(TransactionExecutorError),
     TransactionProvingError(TransactionProverError),
@@ -39,12 +37,6 @@ impl fmt::Display for ClientError {
             }
             ClientError::NoteError(err) => write!(f, "note error: {err}"),
             ClientError::RpcApiError(err) => write!(f, "rpc api error: {err}"),
-            ClientError::RpcExpectedFieldMissing(err) => {
-                write!(f, "rpc api reponse missing an expected field: {err}")
-            }
-            ClientError::RpcTypeConversionFailure(err) => {
-                write!(f, "failed to convert data: {err}")
-            }
             ClientError::StoreError(err) => write!(f, "store error: {err}"),
             ClientError::TransactionExecutionError(err) => {
                 write!(f, "transaction executor error: {err}")
@@ -80,12 +72,6 @@ impl From<NoteError> for ClientError {
 impl From<RpcApiError> for ClientError {
     fn from(err: RpcApiError) -> Self {
         Self::RpcApiError(err)
-    }
-}
-
-impl From<ParseError> for ClientError {
-    fn from(err: ParseError) -> Self {
-        Self::RpcTypeConversionFailure(err)
     }
 }
 
@@ -298,6 +284,8 @@ use crate::client::RpcApiEndpoint;
 pub enum RpcApiError {
     ConnectionError(TransportError),
     RequestError(RpcApiEndpoint, TonicStatus),
+    ExpectedFieldMissing(String),
+    ConversionFailure(ParseError),
 }
 
 impl fmt::Display for RpcApiError {
@@ -309,6 +297,18 @@ impl fmt::Display for RpcApiError {
             RpcApiError::RequestError(endpoint, err) => {
                 write!(f, "rpc request failed for {endpoint}: {err}")
             }
+            RpcApiError::ExpectedFieldMissing(err) => {
+                write!(f, "rpc API reponse missing an expected field: {err}")
+            }
+            RpcApiError::ConversionFailure(err) => {
+                write!(f, "failed to convert RPC data: {err}")
+            }
         }
+    }
+}
+
+impl From<ParseError> for RpcApiError {
+    fn from(err: ParseError) -> Self {
+        Self::ConversionFailure(err)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -283,9 +283,10 @@ use crate::client::RpcApiEndpoint;
 #[derive(Debug)]
 pub enum RpcApiError {
     ConnectionError(TransportError),
-    RequestError(RpcApiEndpoint, TonicStatus),
-    ExpectedFieldMissing(String),
     ConversionFailure(ParseError),
+    ExpectedFieldMissing(String),
+    InvalidAccountReceived(AccountError),
+    RequestError(RpcApiEndpoint, TonicStatus),
 }
 
 impl fmt::Display for RpcApiError {
@@ -294,14 +295,20 @@ impl fmt::Display for RpcApiError {
             RpcApiError::ConnectionError(err) => {
                 write!(f, "failed to connect to the API server: {err}")
             }
-            RpcApiError::RequestError(endpoint, err) => {
-                write!(f, "rpc request failed for {endpoint}: {err}")
+            RpcApiError::ConversionFailure(err) => {
+                write!(f, "failed to convert RPC data: {err}")
             }
             RpcApiError::ExpectedFieldMissing(err) => {
                 write!(f, "rpc API reponse missing an expected field: {err}")
             }
-            RpcApiError::ConversionFailure(err) => {
-                write!(f, "failed to convert RPC data: {err}")
+            RpcApiError::InvalidAccountReceived(account_error) => {
+                write!(
+                    f,
+                    "rpc API reponse contained an invalid account: {account_error}"
+                )
+            }
+            RpcApiError::RequestError(endpoint, err) => {
+                write!(f, "rpc request failed for {endpoint}: {err}")
             }
         }
     }
@@ -310,5 +317,11 @@ impl fmt::Display for RpcApiError {
 impl From<ParseError> for RpcApiError {
     fn from(err: ParseError) -> Self {
         Self::ConversionFailure(err)
+    }
+}
+
+impl From<AccountError> for RpcApiError {
+    fn from(err: AccountError) -> Self {
+        Self::InvalidAccountReceived(err)
     }
 }

--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -6,7 +6,7 @@ use clap::error::Result;
 
 use crypto::merkle::{InOrderIndex, MmrPeaks};
 
-use objects::utils::collections::{BTreeMap};
+use objects::utils::collections::BTreeMap;
 use objects::{BlockHeader, Digest};
 use rusqlite::{params, OptionalExtension, Transaction};
 type SerializedBlockHeaderData = (i64, String, String, String, String, bool);

--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -98,7 +98,8 @@ impl Store {
             .query_map(params![], parse_block_headers_columns)?
             .map(|result| {
                 Ok(result?)
-                    .and_then(parse_block_header).map(|(block, _)| block)
+                    .and_then(parse_block_header)
+                    .map(|(block, _)| block)
             })
             .collect()
     }

--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -98,8 +98,7 @@ impl Store {
             .query_map(params![], parse_block_headers_columns)?
             .map(|result| {
                 Ok(result?)
-                    .and_then(parse_block_header)
-                    .and_then(|(block, _)| Ok(block))
+                    .and_then(parse_block_header).map(|(block, _)| block)
             })
             .collect()
     }

--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -1,21 +1,50 @@
+use std::num::NonZeroUsize;
+
 use super::Store;
 use crate::errors::StoreError;
 use clap::error::Result;
-use crypto::merkle::{InOrderIndex, MmrPeaks};
 
+use crypto::merkle::{InOrderIndex, MerklePath, MmrPeaks};
+
+use objects::utils::collections::{BTreeMap, BTreeSet};
 use objects::{BlockHeader, Digest};
 use rusqlite::{params, OptionalExtension, Transaction};
-use std::{collections::BTreeMap, num::NonZeroUsize};
-
 type SerializedBlockHeaderData = (i64, String, String, String, String, bool);
 type SerializedBlockHeaderParts = (u64, String, String, String, String, bool);
 
 type SerializedChainMmrNodeData = (i64, String);
 type SerializedChainMmrNodeParts = (u64, String);
 
+pub enum ChainMmrNodeFilter<'a> {
+    All,
+    List(&'a [InOrderIndex]),
+}
+
+impl ChainMmrNodeFilter<'_> {
+    pub fn to_query(&self) -> String {
+        let base = String::from("SELECT id, node FROM chain_mmr_nodes");
+        match self {
+            ChainMmrNodeFilter::All => base,
+            ChainMmrNodeFilter::List(ids) => {
+                let formatted_list = ids
+                    .iter()
+                    .map(|id| (Into::<u64>::into(*id)).to_string())
+                    .collect::<Vec<String>>()
+                    .join(",");
+                format!("{base} WHERE id IN ({})", formatted_list)
+            }
+        }
+    }
+}
+
 impl Store {
     // CHAIN DATA
     // --------------------------------------------------------------------------------------------
+
+    /// Inserts a block header into the store, alongside peaks information at the block's height.
+    ///
+    /// `has_client_notes` describes whether the block has relevant notes to the client; this means
+    /// the client might want to authenticate merkle paths based on this value.
     pub fn insert_block_header(
         tx: &Transaction<'_>,
         block_header: BlockHeader,
@@ -67,8 +96,25 @@ impl Store {
             .ok_or(StoreError::BlockHeaderNotFound(block_number))?
     }
 
+    /// Retrieves a list of [BlockHeader] that include relevant notes to the client.
+    pub fn get_tracked_block_headers(&self) -> Result<Vec<BlockHeader>, StoreError> {
+        const QUERY: &str = "SELECT block_num, header, notes_root, sub_hash, chain_mmr_peaks, has_client_notes FROM block_headers WHERE has_client_notes=true";
+        self.db
+            .prepare(QUERY)
+            .map_err(StoreError::QueryError)?
+            .query_map(params![], parse_block_headers_columns)
+            .map_err(StoreError::QueryError)?
+            .map(|result| {
+                result
+                    .map_err(StoreError::ColumnParsingError)
+                    .and_then(parse_block_header)
+                    .map(|(block, _had_notes)| block)
+            })
+            .collect::<Result<Vec<BlockHeader>, _>>()
+    }
+
     /// Inserts a node represented by its in-order index and the node value.
-    pub(crate) fn insert_chain_mmr_node(
+    fn insert_chain_mmr_node(
         tx: &Transaction<'_>,
         id: InOrderIndex,
         node: Digest,
@@ -85,20 +131,22 @@ impl Store {
     /// Inserts a list of MMR authentication nodes to the Chain MMR nodes table.
     pub(super) fn insert_chain_mmr_nodes(
         tx: &Transaction<'_>,
-        nodes: impl Iterator<Item = (InOrderIndex, Digest)>,
+        nodes: &[(InOrderIndex, Digest)],
     ) -> Result<(), StoreError> {
         for (index, node) in nodes {
-            Self::insert_chain_mmr_node(tx, index, node)?;
+            Self::insert_chain_mmr_node(tx, *index, *node)?;
         }
 
         Ok(())
     }
 
-    /// Returns all MMR nodes in the store.
-    pub fn get_chain_mmr_nodes(&self) -> Result<BTreeMap<InOrderIndex, Digest>, StoreError> {
-        const QUERY: &str = "SELECT id, node FROM chain_mmr_nodes";
+    /// Retrieves all MMR authentication nodes based on [ChainMmrNodeFilter].
+    pub fn get_chain_mmr_nodes(
+        &self,
+        filter: ChainMmrNodeFilter,
+    ) -> Result<BTreeMap<InOrderIndex, Digest>, StoreError> {
         self.db
-            .prepare(QUERY)
+            .prepare(&filter.to_query())
             .map_err(StoreError::QueryError)?
             .query_map(params![], parse_chain_mmr_nodes_columns)
             .map_err(StoreError::QueryError)?
@@ -130,6 +178,55 @@ impl Store {
         }
 
         MmrPeaks::new(0, vec![]).map_err(StoreError::MmrError)
+    }
+
+    /// Retrieves all Chain MMR nodes required for authenticating the set of blocks, and then
+    /// constructs the path for each of them.
+    ///
+    /// This method assumes `block_nums` cannot contain `forest`.
+    pub fn get_authentication_path_for_blocks(
+        &self,
+        block_nums: &[u32],
+        forest: usize,
+    ) -> Result<Vec<MerklePath>, StoreError> {
+        let mut node_indices = BTreeSet::new();
+
+        // Calculate all needed nodes indices for generating the paths
+        for block_num in block_nums {
+            let block_num = *block_num as usize;
+            let before = forest & block_num;
+            let after = forest ^ before;
+            let path_depth = after.ilog2() as usize;
+
+            let mut idx = InOrderIndex::from_leaf_pos(block_num);
+
+            for _ in 0..path_depth {
+                node_indices.insert(idx.sibling());
+                idx = idx.parent();
+            }
+        }
+
+        // Get all Mmr nodes based on collected indices
+        let node_indices: Vec<InOrderIndex> = node_indices.into_iter().collect();
+
+        let filter = ChainMmrNodeFilter::List(&node_indices);
+        let mmr_nodes = self.get_chain_mmr_nodes(filter)?;
+
+        // Construct authentication paths
+        let mut authentication_paths = vec![];
+        for block_num in block_nums {
+            let mut merkle_nodes = vec![];
+            let mut idx = InOrderIndex::from_leaf_pos(*block_num as usize);
+
+            while let Some(node) = mmr_nodes.get(&idx.sibling()) {
+                merkle_nodes.push(*node);
+                idx = idx.parent();
+            }
+            let path = MerklePath::new(merkle_nodes);
+            authentication_paths.push(path);
+        }
+
+        Ok(authentication_paths)
     }
 }
 

--- a/src/store/chain_data.rs
+++ b/src/store/chain_data.rs
@@ -4,9 +4,9 @@ use super::Store;
 use crate::errors::StoreError;
 use clap::error::Result;
 
-use crypto::merkle::{InOrderIndex, MerklePath, MmrPeaks};
+use crypto::merkle::{InOrderIndex, MmrPeaks};
 
-use objects::utils::collections::{BTreeMap, BTreeSet};
+use objects::utils::collections::{BTreeMap};
 use objects::{BlockHeader, Digest};
 use rusqlite::{params, OptionalExtension, Transaction};
 type SerializedBlockHeaderData = (i64, String, String, String, String, bool);
@@ -183,55 +183,6 @@ impl Store {
         }
 
         Ok(MmrPeaks::new(0, vec![])?)
-    }
-
-    /// Retrieves all Chain MMR nodes required for authenticating the set of blocks, and then
-    /// constructs the path for each of them.
-    ///
-    /// This method assumes `block_nums` cannot contain `forest`.
-    pub fn get_authentication_path_for_blocks(
-        &self,
-        block_nums: &[u32],
-        forest: usize,
-    ) -> Result<Vec<MerklePath>, StoreError> {
-        let mut node_indices = BTreeSet::new();
-
-        // Calculate all needed nodes indices for generating the paths
-        for block_num in block_nums {
-            let block_num = *block_num as usize;
-            let before = forest & block_num;
-            let after = forest ^ before;
-            let path_depth = after.ilog2() as usize;
-
-            let mut idx = InOrderIndex::from_leaf_pos(block_num);
-
-            for _ in 0..path_depth {
-                node_indices.insert(idx.sibling());
-                idx = idx.parent();
-            }
-        }
-
-        // Get all Mmr nodes based on collected indices
-        let node_indices: Vec<InOrderIndex> = node_indices.into_iter().collect();
-
-        let filter = ChainMmrNodeFilter::List(&node_indices);
-        let mmr_nodes = self.get_chain_mmr_nodes(filter)?;
-
-        // Construct authentication paths
-        let mut authentication_paths = vec![];
-        for block_num in block_nums {
-            let mut merkle_nodes = vec![];
-            let mut idx = InOrderIndex::from_leaf_pos(*block_num as usize);
-
-            while let Some(node) = mmr_nodes.get(&idx.sibling()) {
-                merkle_nodes.push(*node);
-                idx = idx.parent();
-            }
-            let path = MerklePath::new(merkle_nodes);
-            authentication_paths.push(path);
-        }
-
-        Ok(authentication_paths)
     }
 }
 

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -128,12 +128,9 @@ pub fn get_authentication_path_for_blocks(
 
     // Calculate all needed nodes indices for generating the paths
     for block_num in block_nums {
-        let block_num = *block_num as usize;
-        let before = forest & block_num;
-        let after = forest ^ before;
-        let path_depth = after.ilog2() as usize;
+        let path_depth = mmr_merkle_path_len(*block_num as usize, forest);
 
-        let mut idx = InOrderIndex::from_leaf_pos(block_num);
+        let mut idx = InOrderIndex::from_leaf_pos(*block_num as usize);
 
         for _ in 0..path_depth {
             node_indices.insert(idx.sibling());
@@ -162,4 +159,14 @@ pub fn get_authentication_path_for_blocks(
     }
 
     Ok(authentication_paths)
+}
+
+/// Calculates the merkle path length for an MMR of a specific forest and a leaf index
+/// `leaf_index` is a 0-indexed leaf number and `forest` is the total amount of leaves
+/// in the MMR at this point.
+fn mmr_merkle_path_len(leaf_index: usize, forest: usize) -> usize {
+    let before = forest & leaf_index;
+    let after = forest ^ before;
+
+    after.ilog2() as usize
 }

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -4,7 +4,6 @@ use crypto::{
 };
 
 use objects::{
-    accounts::AccountStub,
     notes::{NoteId, NoteInclusionProof},
     BlockHeader, Digest,
 };

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -74,7 +74,7 @@ impl Store {
         &mut self,
         block_header: BlockHeader,
         nullifiers: Vec<Digest>,
-        committed_notes: Vec<(Digest, NoteInclusionProof)>,
+        committed_notes: Vec<(NoteId, NoteInclusionProof)>,
         new_mmr_peaks: MmrPeaks,
         new_authentication_nodes: &[(InOrderIndex, Digest)],
     ) -> Result<(), StoreError> {
@@ -108,13 +108,13 @@ impl Store {
                 "UPDATE input_notes SET status = 'committed', inclusion_proof = ? WHERE note_id = ?";
 
             let inclusion_proof = Some(inclusion_proof.to_bytes());
-            tx.execute(SPENT_QUERY, params![inclusion_proof, note_id.to_string()])?;
+            tx.execute(
+                SPENT_QUERY,
+                params![inclusion_proof, note_id.inner().to_string()],
+            )?;
         }
 
-        let note_ids: Vec<NoteId> = committed_notes
-            .iter()
-            .map(|(id, _)| NoteId::from(*id))
-            .collect();
+        let note_ids: Vec<NoteId> = committed_notes.iter().map(|(id, _)| (*id)).collect();
 
         Store::mark_transactions_as_committed_by_note_id(
             &uncommitted_transactions,

--- a/src/store/state_sync.rs
+++ b/src/store/state_sync.rs
@@ -1,11 +1,9 @@
 use crypto::{
-    merkle::{MmrPeaks, PartialMmr},
+    merkle::{InOrderIndex, MmrPeaks},
     utils::Serializable,
 };
-use miden_node_proto::{mmr::MmrDelta, responses::AccountHashUpdate};
 
 use objects::{
-    accounts::AccountStub,
     notes::{NoteId, NoteInclusionProof},
     BlockHeader, Digest,
 };
@@ -57,7 +55,7 @@ impl Store {
         Ok(true)
     }
 
-    /// Returns the block number of the last state sync block
+    /// Returns the block number of the last state sync block.
     pub fn get_sync_height(&self) -> Result<u32, StoreError> {
         const QUERY: &str = "SELECT block_num FROM state_sync";
 
@@ -75,44 +73,33 @@ impl Store {
             .expect("state sync block number exists")
     }
 
-    #[allow(clippy::too_many_arguments)]
+    /// Applies the state sync update to the store. An update involves:
+    ///
+    /// - Inserting the new block header to the store alongside new MMR peaks information
+    /// - Updating the notes, marking them as `committed` or `consumed` based on incoming
+    ///   inclusion proofs and nullifiers
+    /// - Storing new MMR authentication nodes
     pub fn apply_state_sync(
         &mut self,
-        current_block_num: u32,
         block_header: BlockHeader,
         nullifiers: Vec<Digest>,
-        account_updates: Vec<AccountHashUpdate>,
-        mmr_delta: MmrDelta,
         committed_notes: Vec<(Digest, NoteInclusionProof)>,
+        new_mmr_peaks: MmrPeaks,
+        new_authentication_nodes: &[(InOrderIndex, Digest)],
     ) -> Result<(), StoreError> {
-        // retrieve necessary data
-        // we need to do this here because creating a sql tx borrows a mut reference w
-        let (current_block_header, block_had_notes) =
-            self.get_block_header_by_num(current_block_num)?;
-
-        let current_peaks = self.get_chain_mmr_peaks_by_block_num(current_block_num)?;
         let uncommitted_transactions = self.get_transactions(TransactionFilter::Uncomitted)?;
-
-        let current_accounts: Vec<AccountStub> = self
-            .get_accounts()?
-            .iter()
-            .map(|(acc, _)| acc.clone())
-            .collect();
-
-        // Check if the returned account hashes match latest account hashes in the database
-        check_account_hashes(&account_updates, &current_accounts)?;
 
         let tx = self
             .db
             .transaction()
             .map_err(StoreError::TransactionError)?;
 
-        // update state sync block number
+        // Update state sync block number
         const BLOCK_NUMBER_QUERY: &str = "UPDATE state_sync SET block_num = ?";
         tx.execute(BLOCK_NUMBER_QUERY, params![block_header.block_num()])
             .map_err(StoreError::QueryError)?;
 
-        // update spent notes
+        // Update spent notes
         for nullifier in nullifiers {
             const SPENT_QUERY: &str =
                 "UPDATE input_notes SET status = 'consumed' WHERE nullifier = ?";
@@ -124,17 +111,12 @@ impl Store {
         // TODO: Due to the fact that notes are returned based on fuzzy matching of tags,
         // this process of marking if the header has notes needs to be revisited
         let block_has_relevant_notes = !committed_notes.is_empty();
-        let new_partial_mmr = apply_and_store_mmr_changes(
-            &tx,
-            current_peaks,
-            mmr_delta,
-            current_block_header,
-            block_has_relevant_notes,
-        )?;
+        Store::insert_block_header(&tx, block_header, new_mmr_peaks, block_has_relevant_notes)?;
 
-        Store::insert_block_header(&tx, block_header, new_partial_mmr.peaks(), block_had_notes)?;
+        // Insert new authentication nodes (inner nodes of the PartialMmr)
+        Store::insert_chain_mmr_nodes(&tx, new_authentication_nodes)?;
 
-        // update tracked notes
+        // Update tracked notes
         for (note_id, inclusion_proof) in committed_notes.iter() {
             const SPENT_QUERY: &str =
                 "UPDATE input_notes SET status = 'committed', inclusion_proof = ? WHERE note_id = ?";
@@ -156,75 +138,9 @@ impl Store {
             &tx,
         )?;
 
-        // commit the updates
+        // Commit the updates
         tx.commit().map_err(StoreError::QueryError)?;
 
         Ok(())
     }
-}
-
-fn check_account_hashes(
-    account_updates: &[AccountHashUpdate],
-    current_accounts: &[AccountStub],
-) -> Result<(), StoreError> {
-    for account_update in account_updates {
-        if let (Some(update_account_id), Some(remote_account_hash)) =
-            (&account_update.account_id, &account_update.account_hash)
-        {
-            let update_account_id: u64 = update_account_id.clone().into();
-            if let Some(acc_stub) = current_accounts
-                .iter()
-                .find(|acc| update_account_id == u64::from(acc.id()))
-            {
-                let remote_account_hash: Digest = remote_account_hash
-                    .try_into()
-                    .map_err(StoreError::RpcTypeConversionFailure)?;
-
-                if remote_account_hash != acc_stub.hash() {
-                    return Err(StoreError::AccountHashMismatch(
-                        update_account_id
-                            .try_into()
-                            .map_err(StoreError::AccountError)?,
-                    ));
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Applies changes to the Mmr structure, storing authentication nodes for leaves we track
-/// and returns the updated [PartialMmr]
-fn apply_and_store_mmr_changes(
-    tx: &rusqlite::Transaction<'_>,
-    current_peaks: MmrPeaks,
-    mmr_delta: MmrDelta,
-    current_block_header: BlockHeader,
-    block_had_relevant_notes: bool,
-) -> Result<PartialMmr, StoreError> {
-    // TODO: reload local full view of Partial Mmr here
-    let mut partial_mmr: PartialMmr = PartialMmr::from_peaks(current_peaks);
-
-    // first, apply curent_block to the Mmr
-    let new_authentication_nodes = partial_mmr
-        .add(current_block_header.hash(), block_had_relevant_notes)
-        .into_iter();
-
-    // apply the Mmr delta to bring Mmr to forest equal to chain_tip
-    let mmr_delta: crypto::merkle::MmrDelta = mmr_delta
-        .try_into()
-        .map_err(StoreError::RpcTypeConversionFailure)?;
-
-    let delta_new_authentication_nodes = partial_mmr
-        .apply(mmr_delta)
-        .map_err(StoreError::MmrError)?
-        .into_iter();
-
-    // insert new relevant authentication nodes
-    Store::insert_chain_mmr_nodes(
-        tx,
-        new_authentication_nodes.chain(delta_new_authentication_nodes),
-    )?;
-
-    Ok(partial_mmr)
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,19 +15,19 @@ use crate::{
 
 use assembly::ast::{AstSerdeOptions, ModuleAst};
 use crypto::{dsa::rpo_falcon512::KeyPair, Felt, FieldElement, Word};
-use miden_lib::transaction::{TransactionKernel};
+use miden_lib::transaction::TransactionKernel;
 use mock::{
     constants::{generate_account_seed, AccountSeedType},
     mock::{
         account::{self, mock_account, MockAccountType},
         notes::AssetPreservationStatus,
-        transaction::{mock_inputs},
+        transaction::mock_inputs,
     },
 };
 use objects::{
     accounts::{AccountId, AccountStub},
     assets::{FungibleAsset, TokenSymbol},
-    transaction::{InputNotes},
+    transaction::InputNotes,
 };
 
 #[tokio::test]


### PR DESCRIPTION
Closes #114.

This PR adds a new `TransactionTemplate::ConsumeAllNotes(AccountId)` to consume all stored committed notes for an account, and changes the previous existing template to consume a singular note, identified by the `NoteId`. 
In order to be able to consume multiple notes from arbitrary blocks, this PR also changes:
- When syncing, we now build the complete local view of the `PartialMmr` in order to correctly get new authentication nodes when applying the incoming changes. 
- For constructing the `TransactionInputs`, there is now a way to get authentication paths for arbitrary blocks in order to pass to the executor. 

This PR also refactors the sync process to make it more understandable and adds basic comments, but it will get better with some of the current outstanding PRs (like #113)

NOTE: Currently, testing consuming multiple notes in the same transaction (with `ConsumeAllNotes`) is blocked by https://github.com/0xPolygonMiden/miden-base/issues/443, but changes related to the sync process and `TransactionInputs` constructions can be tested by consuming single notes from past blocks