### PR TITLE
feat: add tracing 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
 tonic = { version = "0.10" }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }
 
 [dev-dependencies]
 uuid = { version = "1.6.1", features = ["serde", "v4"] }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -6,6 +6,7 @@ use miden_client::{
 };
 
 use objects::{accounts::AccountId, assets::FungibleAsset, notes::NoteId, Digest};
+use tracing::info;
 
 use super::{Client, Parser};
 
@@ -123,7 +124,7 @@ impl Transaction {
                     .new_transaction(transaction_template.clone())
                     .map_err(|err| err.to_string())?;
 
-                println!("Executed transaction, proving and then submitting...");
+                info!("Executed transaction, proving and then submitting...");
 
                 client
                     .send_transaction(transaction_execution_result)

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -8,6 +8,7 @@ use miden_node_proto::{
 };
 
 use objects::{accounts::AccountId, notes::NoteInclusionProof, BlockHeader, Digest};
+use tracing::{warn, instrument};
 
 use crate::{
     errors::{ClientError, StoreError},
@@ -44,7 +45,7 @@ impl Client {
         match self.store.add_note_tag(tag).map_err(|err| err.into()) {
             Ok(true) => Ok(()),
             Ok(false) => {
-                println!("tag {} is already being tracked", tag);
+                warn!("tag {} is already being tracked", tag);
                 Ok(())
             }
             Err(err) => Err(err),

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -45,7 +45,7 @@ impl Client {
         match self.store.add_note_tag(tag).map_err(|err| err.into()) {
             Ok(true) => Ok(()),
             Ok(false) => {
-                warn!("tag {} is already being tracked", tag);
+                warn!("Tag {} is already being tracked", tag);
                 Ok(())
             }
             Err(err) => Err(err),

--- a/src/client/sync_state.rs
+++ b/src/client/sync_state.rs
@@ -8,7 +8,7 @@ use miden_node_proto::{
 };
 
 use objects::{accounts::AccountId, notes::NoteInclusionProof, BlockHeader, Digest};
-use tracing::{warn, instrument};
+use tracing::warn;
 
 use crate::{
     errors::{ClientError, StoreError},

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -16,6 +16,7 @@ use objects::{
     Digest,
 };
 use rand::Rng;
+use tracing::info;
 
 use crate::{
     errors::ClientError,
@@ -440,7 +441,7 @@ impl Client {
         let proven_transaction =
             transaction_prover.prove_transaction(tx_result.executed_transaction().clone())?;
 
-        println!("Proved transaction, submitting to the node...");
+        info!("Proved transaction, submitting to the node...");
 
         self.submit_proven_transaction_request(proven_transaction.clone())
             .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use cli::Cli;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
     // read command-line args
     let cli = Cli::parse();
 

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -7,6 +7,7 @@ use crypto::{
     utils::{collections::BTreeMap, Deserializable, Serializable},
     Felt,
 };
+use tracing::info;
 
 use super::Store;
 use objects::{
@@ -212,9 +213,8 @@ pub(crate) fn serialize_transaction_data(
 
     let output_notes = executed_transaction.output_notes();
 
-    // TODO: Add proper logging
-    println!("transaction id {}", executed_transaction.id().inner());
-    println!(
+    info!("transaction id {}", executed_transaction.id().inner());
+    info!(
         "transaction account id: {}",
         executed_transaction.account_id()
     );

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -213,9 +213,9 @@ pub(crate) fn serialize_transaction_data(
 
     let output_notes = executed_transaction.output_notes();
 
-    info!("transaction id {}", executed_transaction.id().inner());
+    info!("Transaction id {}", executed_transaction.id().inner());
     info!(
-        "transaction account id: {}",
+        "Transaction account id: {}",
         executed_transaction.account_id()
     );
 


### PR DESCRIPTION
addresses #82 

- adds tracing (currently used for logging only)
- adds tracing subscriber so that we see events when using the cli
  - to do so, you must run the cli using `RUST_LOG=<level>` with `level` being the desired level (such as debug, info, trace, etc.) 
- changed all `println!` that were not part of the cli expected output so that they use the appropiate log function (`info!`, `debug!`, `warn!`, etc.)

## No std. / Wasm considerations

We should be aware that `tracing` has some limitations. Particularly that `tracing_subscriber`'s fmt subscriber won't work on no_std nor wasm targets. Despite that there are two crates with subscribers that can we used for a wasm target:

- [tracing-wasm](https://github.com/old-storyai/tracing-wasm)
- [tracing-web](https://github.com/WorldSEnder/tracing-web), this one having been updated somewhat recently

In the case of no_std it gets a bit trickier and it might mean that we (or the user of the client) have to make a custom impl of the [Subscriber](https://docs.rs/tracing/latest/tracing/trait.Subscriber.html) trait