### PR TITLE
refactor: code cleanup and documentation

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -103,9 +103,7 @@ impl AccountCmd {
                     },
                     AccountTemplate::NonFungibleFaucet => todo!(),
                 };
-                let (_new_account, _account_seed) = client
-                    .new_account(client_template)
-                    .map_err(|err| err.to_string())?;
+                let (_new_account, _account_seed) = client.new_account(client_template)?;
             }
             AccountCmd::Show { id: None, .. } => {
                 todo!("Default accounts are not supported yet")
@@ -137,7 +135,7 @@ impl AccountCmd {
 // ================================================================================================
 
 fn list_accounts(client: Client) -> Result<(), String> {
-    let accounts = client.get_accounts().map_err(|err| err.to_string())?;
+    let accounts = client.get_accounts()?;
 
     let mut table = Table::new();
     table
@@ -181,9 +179,7 @@ pub fn show_account(
     show_storage: bool,
     show_code: bool,
 ) -> Result<(), String> {
-    let (account, _account_seed) = client
-        .get_account_stub_by_id(account_id)
-        .map_err(|err| err.to_string())?;
+    let (account, _account_seed) = client.get_account_stub_by_id(account_id)?;
 
     let mut table = Table::new();
     table
@@ -209,9 +205,7 @@ pub fn show_account(
     println!("{table}\n");
 
     if show_keys {
-        let auth_info = client
-            .get_account_auth(account_id)
-            .map_err(|err| err.to_string())?;
+        let auth_info = client.get_account_auth(account_id)?;
 
         match auth_info {
             miden_client::store::accounts::AuthInfo::RpoFalcon512(key_pair) => {
@@ -226,9 +220,7 @@ pub fn show_account(
     }
 
     if show_vault {
-        let assets = client
-            .get_vault_assets(account.vault_root())
-            .map_err(|err| err.to_string())?;
+        let assets = client.get_vault_assets(account.vault_root())?;
 
         println!(
             "Vault assets: {}\n",
@@ -237,9 +229,7 @@ pub fn show_account(
     }
 
     if show_storage {
-        let account_storage = client
-            .get_account_storage(account.storage_root())
-            .map_err(|err| err.to_string())?;
+        let account_storage = client.get_account_storage(account.storage_root())?;
 
         println!(
             "Storage: {}\n",
@@ -249,9 +239,7 @@ pub fn show_account(
     }
 
     if show_code {
-        let (procedure_digests, module) = client
-            .get_account_code(account.code_root())
-            .map_err(|err| err.to_string())?;
+        let (procedure_digests, module) = client.get_account_code(account.code_root())?;
 
         println!(
             "Procedure digests:\n{}\n",
@@ -280,9 +268,7 @@ fn import_account(client: &mut Client, filename: &PathBuf) -> Result<(), String>
         AccountData::read_from_bytes(&account_data_file_contents).map_err(|err| err.to_string())?;
     let account_id = account_data.account.id();
 
-    client
-        .import_account(account_data)
-        .map_err(|err| err.to_string())?;
+    client.import_account(account_data)?;
     println!("Imported account with ID: {}", account_id);
 
     Ok(())

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -280,10 +280,12 @@ fn import_account(client: &mut Client, filename: &PathBuf) -> Result<(), String>
         AccountData::read_from_bytes(&account_data_file_contents).map_err(|err| err.to_string())?;
     let account_id = account_data.account.id();
 
-    println!("Imported account with ID: {}", account_id);
     client
         .import_account(account_data)
-        .map_err(|err| err.to_string())
+        .map_err(|err| err.to_string())?;
+    println!("Imported account with ID: {}", account_id);
+
+    Ok(())
 }
 
 // HELPERS

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -280,10 +280,10 @@ fn import_account(client: &mut Client, filename: &PathBuf) -> Result<(), String>
         AccountData::read_from_bytes(&account_data_file_contents).map_err(|err| err.to_string())?;
     let account_id = account_data.account.id();
 
-    client.import_account(account_data)?;
     println!("Imported account with ID: {}", account_id);
-
-    Ok(())
+    client
+        .import_account(account_data)
+        .map_err(|err| err.to_string())
 }
 
 // HELPERS

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -90,9 +90,7 @@ impl InputNotes {
 // LIST INPUT NOTES
 // ================================================================================================
 fn list_input_notes(client: Client) -> Result<(), String> {
-    let notes = client
-        .get_input_notes(InputNoteFilter::All)
-        .map_err(|err| err.to_string())?;
+    let notes = client.get_input_notes(InputNoteFilter::All)?;
     print_notes_summary(&notes);
     Ok(())
 }
@@ -107,9 +105,7 @@ pub fn export_note(
     let note_id = Digest::try_from(note_id)
         .map_err(|err| format!("Failed to parse input note id: {}", err))?
         .into();
-    let note = client
-        .get_input_note(note_id)
-        .map_err(|err| err.to_string())?;
+    let note = client.get_input_note(note_id)?;
 
     let file_path = filename.unwrap_or_else(|| {
         let mut dir = PathBuf::new();
@@ -139,9 +135,7 @@ pub fn import_note(client: &mut Client, filename: PathBuf) -> Result<NoteId, Str
         InputNoteRecord::read_from_bytes(&contents).map_err(|err| err.to_string())?;
 
     let note_id = input_note_record.note().id();
-    client
-        .import_input_note(input_note_record)
-        .map_err(|err| err.to_string())?;
+    client.import_input_note(input_note_record)?;
 
     Ok(note_id)
 }
@@ -159,9 +153,7 @@ fn show_input_note(
         .map_err(|err| format!("Failed to parse input note with ID: {}", err))?
         .into();
 
-    let input_note_record = client
-        .get_input_note(note_id)
-        .map_err(|err| err.to_string())?;
+    let input_note_record = client.get_input_note(note_id)?;
 
     // print note summary
     print_notes_summary(core::iter::once(&input_note_record));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -62,7 +62,7 @@ impl Cli {
         current_dir.push(CLIENT_CONFIG_FILE_NAME);
 
         let client_config = load_config(current_dir.as_path())?;
-        let client = Client::new(client_config).map_err(|err| err.to_string())?;
+        let client = Client::new(client_config)?;
 
         // Execute cli command
         match &self.action {

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,7 +1,7 @@
 use miden_client::client::Client;
 
 pub async fn sync_state(mut client: Client) -> Result<(), String> {
-    let block_num = client.sync_state().await.map_err(|e| e.to_string())?;
+    let block_num = client.sync_state().await?;
     println!("State synced to block {}", block_num);
     Ok(())
 }

--- a/src/cli/tags.rs
+++ b/src/cli/tags.rs
@@ -32,13 +32,13 @@ impl TagsCmd {
 // HELPERS
 // ================================================================================================
 fn list_tags(client: Client) -> Result<(), String> {
-    let tags = client.get_note_tags().map_err(|err| err.to_string())?;
+    let tags = client.get_note_tags()?;
     println!("tags: {:?}", tags);
     Ok(())
 }
 
 fn add_tag(mut client: Client, tag: u64) -> Result<(), String> {
-    client.add_note_tag(tag).map_err(|err| err.to_string())?;
+    client.add_note_tag(tag)?;
     println!("tag {} added", tag);
     Ok(())
 }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -120,16 +120,14 @@ impl Transaction {
             Transaction::New { transaction_type } => {
                 let transaction_template: TransactionTemplate = transaction_type.try_into()?;
 
-                let transaction_execution_result = client
-                    .new_transaction(transaction_template.clone())
-                    .map_err(|err| err.to_string())?;
+                let transaction_execution_result =
+                    client.new_transaction(transaction_template.clone())?;
 
                 info!("Executed transaction, proving and then submitting...");
 
                 client
                     .send_transaction(transaction_execution_result)
-                    .await
-                    .map_err(|err| err.to_string())?;
+                    .await?
             }
         }
         Ok(())
@@ -139,9 +137,7 @@ impl Transaction {
 // LIST TRANSACTIONS
 // ================================================================================================
 fn list_transactions(client: Client) -> Result<(), String> {
-    let transactions = client
-        .get_transactions(TransactionFilter::All)
-        .map_err(|err| err.to_string())?;
+    let transactions = client.get_transactions(TransactionFilter::All)?;
     print_transactions_summary(&transactions);
     Ok(())
 }

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -7,7 +7,7 @@ use objects::{
     },
     assembly::ModuleAst,
     assets::{Asset, TokenSymbol},
-    Digest, StarkField,
+    Digest,
 };
 use rand::{rngs::ThreadRng, Rng};
 
@@ -68,24 +68,25 @@ impl Client {
         match account_data.auth {
             AuthData::RpoFalcon512Seed(key_pair) => {
                 let keypair = KeyPair::from_seed(&key_pair)?;
-                let account_nonce = account_data.account.nonce().as_int();
+                let is_new_account = account_data.account.is_new();
                 match account_data.account_seed {
-                    Some(seed) if account_nonce == 0 => self.insert_account(
+                    Some(seed) if is_new_account => self.insert_account(
                         &account_data.account,
                         seed,
                         &AuthInfo::RpoFalcon512(keypair),
                     ),
                     Some(_) => {
                         tracing::warn!(
-                            "Imported an account with nonce > 0 and still provided a seed"
+                            "Imported an existing account and still provided a seed when it is not needed. It's possible that the account's file was incorrectly generated."
                         );
-                        Ok(())
+
+                        unimplemented!();
                     }
-                    None if account_nonce > 0 => {
+                    None if !is_new_account => {
                         unimplemented!();
                     }
                     None => Err(ClientError::ImportAccountError(
-                        "tried to import an account without a seed and nonce = 0".to_string(),
+                        "tried to import a new account without its seed".to_string(),
                     )),
                 }
             }

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -97,9 +97,7 @@ impl Client {
                     None if !is_new_account => {
                         unimplemented!();
                     }
-                    None => Err(ClientError::ImportAccountError(
-                        "tried to import a new account without its seed".to_string(),
-                    )),
+                    None => Err(ClientError::ImportNewAccountWithoutSeed),
                 }
             }
         }

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -62,6 +62,8 @@ impl Client {
         Ok(account_and_seed)
     }
 
+    /// Saves in the store the [Account] corresponding to `account_data`. It is expected that the
+    /// provided [AccountData] has an account_seed, otherwise panics.
     pub fn import_account(&mut self, account_data: AccountData) -> Result<(), String> {
         match account_data.auth {
             AuthData::RpoFalcon512Seed(key_pair) => {
@@ -82,6 +84,7 @@ impl Client {
         }
     }
 
+    /// Creates a new regular account and saves it in the store along with its seed and auth data
     fn new_basic_wallet(
         &mut self,
         mutable_code: bool,

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -64,22 +64,22 @@ impl Client {
 
     /// Saves in the store the [Account] corresponding to `account_data`. It is expected that the
     /// provided [AccountData] has an account_seed, otherwise panics.
-    pub fn import_account(&mut self, account_data: AccountData) -> Result<(), String> {
+    pub fn import_account(&mut self, account_data: AccountData) -> Result<(), ClientError> {
         match account_data.auth {
             AuthData::RpoFalcon512Seed(key_pair) => {
-                let keypair = KeyPair::from_seed(&key_pair).map_err(|err| err.to_string())?;
+                let keypair = KeyPair::from_seed(&key_pair)?;
                 // TODO: Handle account data without seed so we can export existing accounts into
                 // other clients where we have no seed (account nonce > 0)
                 let seed = account_data
                     .account_seed
-                    .ok_or("Account seed was expected")?;
+                    .ok_or("Account seed was expected")
+                    .unwrap();
 
                 self.insert_account(
                     &account_data.account,
                     seed,
                     &AuthInfo::RpoFalcon512(keypair),
                 )
-                .map_err(|err| err.to_string())
             }
         }
     }

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -72,8 +72,7 @@ impl Client {
                 // other clients where we have no seed (account nonce > 0)
                 let seed = account_data
                     .account_seed
-                    .ok_or("Account seed was expected")
-                    .unwrap();
+                    .expect("Account seed was expected");
 
                 self.insert_account(
                     &account_data.account,

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -75,12 +75,16 @@ impl Client {
                         seed,
                         &AuthInfo::RpoFalcon512(keypair),
                     ),
-                    Some(_) => {
+                    Some(seed) => {
                         tracing::warn!(
                             "Imported an existing account and still provided a seed when it is not needed. It's possible that the account's file was incorrectly generated."
                         );
 
-                        unimplemented!();
+                        self.insert_account(
+                            &account_data.account,
+                            seed,
+                            &AuthInfo::RpoFalcon512(keypair),
+                        )
                     }
                     None if !is_new_account => {
                         unimplemented!();

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -62,8 +62,16 @@ impl Client {
         Ok(account_and_seed)
     }
 
-    /// Saves in the store the [Account] corresponding to `account_data`. It is expected that the
-    /// provided [AccountData] has an account_seed, otherwise panics.
+    /// Saves in the store the [Account] corresponding to `account_data`.
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if trying to import a new account without providing its seed
+    ///
+    /// # Panics
+    ///
+    /// Will panic when trying to import a non new account without a seed since it's not
+    /// implemented yet
     pub fn import_account(&mut self, account_data: AccountData) -> Result<(), ClientError> {
         match account_data.auth {
             AuthData::RpoFalcon512Seed(key_pair) => {

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -76,14 +76,13 @@ impl Client {
         match account_data.auth {
             AuthData::RpoFalcon512Seed(key_pair) => {
                 let keypair = KeyPair::from_seed(&key_pair)?;
-                let is_new_account = account_data.account.is_new();
-                match account_data.account_seed {
-                    Some(seed) if is_new_account => self.insert_account(
+                match (account_data.account.is_new(), account_data.account_seed) {
+                    (true, Some(seed)) => self.insert_account(
                         &account_data.account,
                         seed,
                         &AuthInfo::RpoFalcon512(keypair),
                     ),
-                    Some(seed) => {
+                    (false, Some(seed)) => {
                         tracing::warn!(
                             "Imported an existing account and still provided a seed when it is not needed. It's possible that the account's file was incorrectly generated."
                         );
@@ -94,10 +93,10 @@ impl Client {
                             &AuthInfo::RpoFalcon512(keypair),
                         )
                     }
-                    None if !is_new_account => {
+                    (false, None) => {
                         unimplemented!();
                     }
-                    None => Err(ClientError::ImportNewAccountWithoutSeed),
+                    (true, None) => Err(ClientError::ImportNewAccountWithoutSeed),
                 }
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -104,6 +104,12 @@ impl From<rusqlite::Error> for ClientError {
     }
 }
 
+impl From<ClientError> for String {
+    fn from(err: ClientError) -> String {
+        err.to_string()
+    }
+}
+
 #[cfg(feature = "std")]
 impl std::error::Error for ClientError {}
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,7 +19,7 @@ use tonic::{transport::Error as TransportError, Status as TonicStatus};
 pub enum ClientError {
     AccountError(AccountError),
     AuthError(FalconError),
-    ImportAccountError(String),
+    ImportNewAccountWithoutSeed,
     NoteError(NoteError),
     NoConsumableNoteForAccount(AccountId),
     RpcApiError(RpcApiError),
@@ -33,7 +33,10 @@ impl fmt::Display for ClientError {
         match self {
             ClientError::AccountError(err) => write!(f, "account error: {err}"),
             ClientError::AuthError(err) => write!(f, "account auth error: {err}"),
-            ClientError::ImportAccountError(err) => write!(f, "import account error: {err}"),
+            ClientError::ImportNewAccountWithoutSeed => write!(
+                f,
+                "import account error: can't import a new account without its initial seed"
+            ),
             ClientError::NoConsumableNoteForAccount(account_id) => {
                 write!(f, "No consumable note for account ID {}", account_id)
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,7 @@ use tonic::{transport::Error as TransportError, Status as TonicStatus};
 pub enum ClientError {
     AccountError(AccountError),
     AuthError(FalconError),
+    ImportAccountError(String),
     NoteError(NoteError),
     NoConsumableNoteForAccount(AccountId),
     RpcApiError(RpcApiError),
@@ -32,6 +33,7 @@ impl fmt::Display for ClientError {
         match self {
             ClientError::AccountError(err) => write!(f, "account error: {err}"),
             ClientError::AuthError(err) => write!(f, "account auth error: {err}"),
+            ClientError::ImportAccountError(err) => write!(f, "import account error: {err}"),
             ClientError::NoConsumableNoteForAccount(account_id) => {
                 write!(f, "No consumable note for account ID {}", account_id)
             }

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -106,7 +106,9 @@ impl Store {
     }
 
     /// Returns a list of [AccountStub] of all accounts stored in the database along with the seeds
-    /// used to create the corresponding accounts
+    /// used to create them.
+    ///
+    /// Said accounts' state is the state at the last sync made.
     pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Word)>, StoreError> {
         const QUERY: &str =
             "SELECT a.id, a.nonce, a.vault_root, a.storage_root, a.code_root, a.account_seed \
@@ -122,7 +124,12 @@ impl Store {
     }
 
     /// Retrieves an [AccountStub] object for the specified [AccountId] along with the seed
-    /// used to create it. Returns an [Err] if the account was not found
+    /// used to create it.
+    ///
+    /// Said accounts' state is the state at the last sync made.
+    ///
+    /// # Errors
+    /// Returns an [Err] if the account was not found
     pub fn get_account_stub_by_id(
         &self,
         account_id: AccountId,

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -105,6 +105,8 @@ impl Store {
             .collect::<Result<Vec<AccountId>, StoreError>>()
     }
 
+    /// Returns a list of [AccountStub] of all accounts stored in the database along with the seeds
+    /// used to create the corresponding accounts
     pub fn get_accounts(&self) -> Result<Vec<(AccountStub, Word)>, StoreError> {
         const QUERY: &str =
             "SELECT a.id, a.nonce, a.vault_root, a.storage_root, a.code_root, a.account_seed \
@@ -119,6 +121,8 @@ impl Store {
             .collect()
     }
 
+    /// Retrieves an [AccountStub] object for the specified [AccountId] along with the seed
+    /// used to create it. Returns an [Err] if the account was not found
     pub fn get_account_stub_by_id(
         &self,
         account_id: AccountId,
@@ -249,6 +253,7 @@ impl Store {
             .ok_or(StoreError::VaultDataNotFound(root))?
     }
 
+    /// Inserts an [Account] along with the seed used to create it and its [AuthInfo]
     pub fn insert_account(
         &mut self,
         account: &Account,
@@ -292,6 +297,7 @@ impl Store {
         Ok(())
     }
 
+    /// Inserts an [AccountCode]
     fn insert_account_code(
         tx: &Transaction<'_>,
         account_code: &AccountCode,
@@ -303,6 +309,7 @@ impl Store {
         Ok(())
     }
 
+    /// Inserts an [AccountStorage]
     pub(crate) fn insert_account_storage(
         tx: &Transaction<'_>,
         account_storage: &AccountStorage,
@@ -313,6 +320,7 @@ impl Store {
         Ok(())
     }
 
+    /// Inserts an [AssetVault]
     pub(crate) fn insert_account_asset_vault(
         tx: &Transaction<'_>,
         asset_vault: &AssetVault,
@@ -323,6 +331,7 @@ impl Store {
         Ok(())
     }
 
+    /// Inserts an [AuthInfo] for the account with id `account_id`
     pub fn insert_account_auth(
         tx: &Transaction<'_>,
         account_id: AccountId,

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -126,7 +126,7 @@ impl Store {
     /// Retrieves an [AccountStub] object for the specified [AccountId] along with the seed
     /// used to create it.
     ///
-    /// Said accounts' state is the state at the last sync made.
+    /// Said account's state is the state according to the last sync performed.
     ///
     /// # Errors
     /// Returns an [Err] if the account was not found

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -310,7 +310,7 @@ impl Store {
     }
 
     /// Inserts an [AccountStorage]
-    pub(crate) fn insert_account_storage(
+    pub(super) fn insert_account_storage(
         tx: &Transaction<'_>,
         account_storage: &AccountStorage,
     ) -> Result<(), StoreError> {

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -321,7 +321,7 @@ impl Store {
     }
 
     /// Inserts an [AssetVault]
-    pub(crate) fn insert_account_asset_vault(
+    pub(super) fn insert_account_asset_vault(
         tx: &Transaction<'_>,
         asset_vault: &AssetVault,
     ) -> Result<(), StoreError> {

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -332,7 +332,7 @@ impl Store {
     }
 
     /// Inserts an [AuthInfo] for the account with id `account_id`
-    pub fn insert_account_auth(
+    pub(super) fn insert_account_auth(
         tx: &Transaction<'_>,
         account_id: AccountId,
         auth_info: &AuthInfo,

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -17,7 +17,7 @@ use objects::{
 
 pub struct SqliteDataStore {
     /// Local database containing information about the accounts managed by this client.
-    pub(crate) store: Store,
+    pub store: Store,
 }
 
 impl SqliteDataStore {

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -17,7 +17,7 @@ use objects::{
 
 pub struct SqliteDataStore {
     /// Local database containing information about the accounts managed by this client.
-    pub store: Store,
+    pub(crate) store: Store,
 }
 
 impl SqliteDataStore {

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -14,6 +14,6 @@ lazy_static! {
 // PUBLIC FUNCTIONS
 // ================================================================================================
 
-pub fn update_to_latest(conn: &mut Connection) -> Result<(), StoreError> {
+pub(crate) fn update_to_latest(conn: &mut Connection) -> Result<(), StoreError> {
     Ok(MIGRATIONS.to_latest(conn)?)
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -66,13 +66,13 @@ pub mod tests {
         Client::new(client_config).unwrap()
     }
 
-    pub fn create_test_store_path() -> std::path::PathBuf {
+    pub(crate) fn create_test_store_path() -> std::path::PathBuf {
         let mut temp_file = temp_dir();
         temp_file.push(format!("{}.sqlite3", Uuid::new_v4()));
         temp_file
     }
 
-    pub fn create_test_store() -> Store {
+    pub(crate) fn create_test_store() -> Store {
         let temp_file = create_test_store_path();
         let mut db = Connection::open(temp_file).unwrap();
         migrations::update_to_latest(&mut db).unwrap();

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -47,6 +47,7 @@ pub enum InputNoteFilter {
 }
 
 impl InputNoteFilter {
+    /// Returns a [String] containing the query for this Filter
     pub fn to_query(&self) -> String {
         let base = String::from("SELECT script, inputs, vault, serial_num, sender_id, tag, inclusion_proof FROM input_notes");
         match self {

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -168,7 +168,7 @@ impl Store {
     }
 
     /// Updates transactions as committed if the input `note_ids` belongs to one uncommitted transaction
-    pub(crate) fn mark_transactions_as_committed_by_note_id(
+    pub(super) fn mark_transactions_as_committed_by_note_id(
         uncommitted_transactions: &[TransactionStub],
         note_ids: &[NoteId],
         block_num: u32,
@@ -194,7 +194,7 @@ impl Store {
     }
 }
 
-pub(crate) fn serialize_transaction_data(
+pub(super) fn serialize_transaction_data(
     transaction_result: TransactionResult,
 ) -> Result<SerializedTransactionData, StoreError> {
     let executed_transaction = transaction_result.executed_transaction();

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -37,6 +37,7 @@ pub enum TransactionFilter {
 }
 
 impl TransactionFilter {
+    /// Returns a [String] containing the query for this Filter
     pub fn to_query(&self) -> String {
         const QUERY: &str = "SELECT tx.id, tx.account_id, tx.init_account_state, tx.final_account_state, \
             tx.input_notes, tx.output_notes, tx.script_hash, script.program, tx.script_inputs, tx.block_num, tx.committed, tx.commit_height \
@@ -80,6 +81,7 @@ impl Store {
             .collect::<Result<Vec<TransactionStub>, _>>()
     }
 
+    /// Inserts a transaction and updates the current state based on the `tx_result` changes
     pub fn insert_transaction_data(
         &mut self,
         tx_result: TransactionResult,
@@ -251,7 +253,7 @@ pub(crate) fn serialize_transaction_data(
     ))
 }
 
-pub fn parse_transaction_columns(
+fn parse_transaction_columns(
     row: &rusqlite::Row<'_>,
 ) -> Result<SerializedTransactionData, rusqlite::Error> {
     let id: String = row.get(0)?;


### PR DESCRIPTION
I followed these guidelines:

- I first tried restricting pub functions as much as possible
- Then for each public function that was missing some doc comment,  I added it
- I didn't add a doc string for:
  - Constructors
  - Getters and setters
  - Functions only used in tests 