### PR TITLE
feat: use tables instead of plain text

### DIFF
--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -4,6 +4,8 @@ use std::{
     path::PathBuf,
 };
 
+use crate::cli::create_dynamic_table;
+
 use super::{Client, Parser};
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::store::notes::{InputNoteFilter, InputNoteRecord};
@@ -229,18 +231,14 @@ fn print_notes_summary<'a, I>(notes: I)
 where
     I: IntoIterator<Item = &'a InputNoteRecord>,
 {
-    let mut table = Table::new();
-    table
-        .load_preset(presets::UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(vec![
-            Cell::new("note id").add_attribute(Attribute::Bold),
-            Cell::new("script hash").add_attribute(Attribute::Bold),
-            Cell::new("vault hash").add_attribute(Attribute::Bold),
-            Cell::new("inputs hash").add_attribute(Attribute::Bold),
-            Cell::new("serial num").add_attribute(Attribute::Bold),
-            Cell::new("commit height").add_attribute(Attribute::Bold),
-        ]);
+    let mut table = create_dynamic_table(&[
+        "note id",
+        "script hash",
+        "vault hash",
+        "inputs hash",
+        "serial num",
+        "commit height",
+    ]);
 
     notes.into_iter().for_each(|input_note_record| {
         let commit_height = input_note_record

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use clap::Parser;
+use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use figment::{
     providers::{Format, Toml},
     Figment,
@@ -89,4 +90,19 @@ pub fn load_config(config_file: &Path) -> Result<ClientConfig, String> {
                 config_file.display()
             )
         })
+}
+
+pub fn create_dynamic_table(headers: &[&str]) -> Table {
+    let header_cells = headers
+        .iter()
+        .map(|header| Cell::new(header).add_attribute(Attribute::Bold))
+        .collect::<Vec<_>>();
+
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+        .set_header(header_cells);
+
+    table
 }

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -1,5 +1,3 @@
-use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
-
 use miden_client::{
     client::transactions::{PaymentTransactionData, TransactionStub, TransactionTemplate},
     store::transactions::TransactionFilter,
@@ -7,6 +5,8 @@ use miden_client::{
 
 use objects::{accounts::AccountId, assets::FungibleAsset, notes::NoteId};
 use tracing::info;
+
+use crate::cli::create_dynamic_table;
 
 use super::{Client, Parser};
 
@@ -152,23 +152,15 @@ fn print_transactions_summary<'a, I>(executed_transactions: I)
 where
     I: IntoIterator<Item = &'a TransactionStub>,
 {
-    let mut table = Table::new();
-    table
-        .load_preset(presets::UTF8_HORIZONTAL_ONLY)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth);
-
-    table
-        .load_preset(presets::UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(vec![
-            Cell::new("account id").add_attribute(Attribute::Bold),
-            Cell::new("script hash").add_attribute(Attribute::Bold),
-            Cell::new("committed").add_attribute(Attribute::Bold),
-            Cell::new("commit height").add_attribute(Attribute::Bold),
-            Cell::new("block num").add_attribute(Attribute::Bold),
-            Cell::new("input notes count").add_attribute(Attribute::Bold),
-            Cell::new("output notes count").add_attribute(Attribute::Bold),
-        ]);
+    let mut table = create_dynamic_table(&[
+        "account id",
+        "script hash",
+        "committed",
+        "commit height",
+        "block num",
+        "input notes count",
+        "output notes count",
+    ]);
 
     for tx in executed_transactions {
         let commit_height = match tx.commit_height {


### PR DESCRIPTION
For displaying account info we were showing some data with println! and the output was sometimes hard to follow. So I replaced those usecases with comfy table. This PR also fixes the `-s` flag of the account show subcommand which was giving me an error.

## Summary of changes

- made a helper function for the initialization of comfy_table `Table`s (I noticed we were always using the same presets.
- changed the asset vault output to use comfy table. Now it shows the asset type, the corresponding faucet Id and the amount  (I assumed it's always 1 for non fungible tokes)
- changed the storage output to show a table of the storage items with their Index, Type, arity and value / commitment depending on whether it's a Value or an Array or a Map.
- changed the keypair to be shown in a table. I have my doubts with this one as it makes it harder to copy the full keypair. I'm. also wondering if we should also show the pub key along with the keypair
- changed the account script info to be shown in 2 tables, first the procedure digests and then the ast. Same as before, it makes it a bit harder to copy the whole script, although it makes the output a bit better.

## Instructions to test

- first you must have some accounts loaded and with some txs executed if possible
- then run `cargo run --release --features testing,concurrent account show <account_id> -k -v -c -s`
- you can also run `cargo run --release --features testing,concurrent input-note list` and `cargo run --release --features testing,concurrent input-note show <note_id> -s -v -i`
- `cargo run --release --features testing,concurrent transaction list`