### PR TITLE
test: add sync state mmr tests

### DIFF
--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -140,7 +140,7 @@ impl Client {
         }
 
         let committed_notes =
-            dbg!(self.build_inclusion_proofs(response.note_inclusions, &response.block_header)?);
+            self.build_inclusion_proofs(response.note_inclusions, &response.block_header)?;
 
         // Check if the returned account hashes match latest account hashes in the database
         check_account_hashes(&response.account_hash_updates, &accounts)?;
@@ -197,12 +197,6 @@ impl Client {
             .iter()
             .map(|n| n.note().id())
             .collect();
-
-        dbg!(&pending_notes);
-        dbg!(&committed_notes
-            .iter()
-            .map(|note| note.note_id())
-            .collect::<Vec<&NoteId>>());
 
         committed_notes
             .iter()

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -140,7 +140,7 @@ impl Client {
         }
 
         let committed_notes =
-            self.build_inclusion_proofs(response.note_inclusions, &response.block_header)?;
+            dbg!(self.build_inclusion_proofs(response.note_inclusions, &response.block_header)?);
 
         // Check if the returned account hashes match latest account hashes in the database
         check_account_hashes(&response.account_hash_updates, &accounts)?;
@@ -198,6 +198,12 @@ impl Client {
             .map(|n| n.note().id())
             .collect();
 
+        dbg!(&pending_notes);
+        dbg!(&committed_notes
+            .iter()
+            .map(|note| note.note_id())
+            .collect::<Vec<&NoteId>>());
+
         committed_notes
             .iter()
             .filter_map(|commited_note| {
@@ -236,7 +242,7 @@ impl Client {
     ///
     /// As part of the syncing process, we add the current block number so we don't need to
     /// track it here.
-    fn build_current_partial_mmr(&self) -> Result<PartialMmr, ClientError> {
+    pub(crate) fn build_current_partial_mmr(&self) -> Result<PartialMmr, ClientError> {
         let current_block_num = self.store.get_sync_height()?;
 
         let tracked_nodes = self.store.get_chain_mmr_nodes(ChainMmrNodeFilter::All)?;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,7 @@ use crypto::{
     merkle::MmrError,
     utils::{DeserializationError, HexParseError},
 };
-use miden_node_proto::error::ParseError;
+use miden_node_proto::errors::ParseError;
 use miden_tx::{DataStoreError, TransactionExecutorError, TransactionProverError};
 use objects::{
     accounts::AccountId, notes::NoteId, AccountError, AssetVaultError, Digest, NoteError,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -151,6 +151,7 @@ fn create_mock_sync_state_request_for_account_and_notes(
         .map(|header| header.block_num())
         .unwrap_or(10);
     let mut deltas_iter = mmr_delta.unwrap_or_default().into_iter();
+    let mut created_notes_iter = created_notes.iter();
 
     for (block_order, block_header) in tracked_block_headers.iter().enumerate() {
         let request = SyncStateRequest {
@@ -174,7 +175,7 @@ fn create_mock_sync_state_request_for_account_and_notes(
             accounts: vec![],
             notes: vec![NoteSyncRecord {
                 note_index: 0,
-                note_hash: Some(created_notes.first().unwrap().id().into()),
+                note_hash: Some(created_notes_iter.next().unwrap().id().into()),
                 sender: account.id().into(),
                 tag: 0u64,
                 merkle_path: Some(miden_node_proto::merkle::MerklePath::default()),
@@ -253,6 +254,8 @@ fn mock_full_chain_mmr_and_notes(
         mock_block_header(2, None, note_tree_iter.next().map(|x| x.root()), &[]),
         mock_block_header(3, None, note_tree_iter.next().map(|x| x.root()), &[]),
         mock_block_header(4, None, note_tree_iter.next().map(|x| x.root()), &[]),
+        mock_block_header(5, None, note_tree_iter.next().map(|x| x.root()), &[]),
+        mock_block_header(6, None, note_tree_iter.next().map(|x| x.root()), &[]),
     ];
 
     // instantiate and populate MMR
@@ -263,6 +266,9 @@ fn mock_full_chain_mmr_and_notes(
         }
         if block_num == 4 {
             mmr_deltas.push(mmr.get_delta(3, mmr.forest()).unwrap());
+        }
+        if block_num == 6 {
+            mmr_deltas.push(mmr.get_delta(5, mmr.forest()).unwrap());
         }
         mmr.add(block_header.hash());
     }
@@ -291,7 +297,7 @@ fn mock_full_chain_mmr_and_notes(
     (
         mmr,
         recorded_notes,
-        vec![block_chain[2], block_chain[4]],
+        vec![block_chain[2], block_chain[4], block_chain[6]],
         mmr_deltas,
     )
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -119,15 +119,13 @@ impl MockRpcApi {
 
 /// Generates mock sync state requests and responses
 fn create_mock_sync_state_request_for_account_and_notes(
-    requests: &mut BTreeMap<SyncStateRequest, SyncStateResponse>,
     account_id: AccountId,
     created_notes: &[Note],
     consumed_notes: &[InputNote],
     mmr_delta: Option<Vec<MmrDelta>>,
     tracked_block_headers: Option<Vec<BlockHeader>>,
-) {
-    // Clear existing mocked data
-    requests.clear();
+) -> BTreeMap<SyncStateRequest, SyncStateResponse> {
+    let mut requests: BTreeMap<SyncStateRequest, SyncStateResponse> = BTreeMap::new();
 
     let accounts = vec![ProtoAccountId {
         id: u64::from(account_id),
@@ -195,6 +193,8 @@ fn create_mock_sync_state_request_for_account_and_notes(
         };
         requests.insert(request, response);
     }
+
+    requests
 }
 
 /// Generates mock sync state requests and responses
@@ -208,10 +208,7 @@ fn generate_state_sync_mock_requests() -> BTreeMap<SyncStateRequest, SyncStateRe
     );
 
     // create sync state requests
-    let mut requests = BTreeMap::new();
-
-    create_mock_sync_state_request_for_account_and_notes(
-        &mut requests,
+    let requests = create_mock_sync_state_request_for_account_and_notes(
         transaction_inputs.account().id(),
         &transaction_inputs
             .input_notes()
@@ -333,8 +330,7 @@ pub async fn insert_mock_data(client: &mut Client) -> Vec<BlockHeader> {
         .insert_account(&account, account_seed, &AuthInfo::RpoFalcon512(key_pair))
         .unwrap();
 
-    create_mock_sync_state_request_for_account_and_notes(
-        &mut client.rpc_api.state_sync_requests,
+    client.rpc_api.state_sync_requests = create_mock_sync_state_request_for_account_and_notes(
         account.id(),
         &created_notes,
         &consumed_notes,

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -142,7 +142,7 @@ pub fn get_authentication_path_for_blocks(
     let node_indices: Vec<InOrderIndex> = node_indices.into_iter().collect();
 
     let filter = ChainMmrNodeFilter::List(&node_indices);
-    let mmr_nodes = store.get_chain_mmr_nodes(filter)?;
+    let mmr_nodes = dbg!(store.get_chain_mmr_nodes(filter)?);
 
     // Construct authentication paths
     let mut authentication_paths = vec![];

--- a/src/store/data_store.rs
+++ b/src/store/data_store.rs
@@ -142,7 +142,7 @@ pub fn get_authentication_path_for_blocks(
     let node_indices: Vec<InOrderIndex> = node_indices.into_iter().collect();
 
     let filter = ChainMmrNodeFilter::List(&node_indices);
-    let mmr_nodes = dbg!(store.get_chain_mmr_nodes(filter)?);
+    let mmr_nodes = store.get_chain_mmr_nodes(filter)?;
 
     // Construct authentication paths
     let mut authentication_paths = vec![];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -370,9 +370,16 @@ async fn test_sync_state_mmr_state() {
     assert!(partial_mmr.open(4).unwrap().is_some());
     assert!(partial_mmr.open(5).unwrap().is_none());
 
-    // Ensure the proof is valid
-    // let mmr_proof = dbg!(partial_mmr.open(2).unwrap().unwrap());
-    // assert!(partial_mmr.peaks().verify(tracked_block_headers[0].hash(), mmr_proof));
+    // Ensure the proofs are valid
+    let mmr_proof = partial_mmr.open(2).unwrap().unwrap();
+    assert!(partial_mmr
+        .peaks()
+        .verify(tracked_block_headers[0].hash(), mmr_proof));
+
+    let mmr_proof = partial_mmr.open(4).unwrap().unwrap();
+    assert!(partial_mmr
+        .peaks()
+        .verify(tracked_block_headers[1].hash(), mmr_proof));
 }
 
 #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -369,6 +369,10 @@ async fn test_sync_state_mmr_state() {
     assert!(partial_mmr.open(3).unwrap().is_none());
     assert!(partial_mmr.open(4).unwrap().is_some());
     assert!(partial_mmr.open(5).unwrap().is_none());
+
+    // Ensure the proof is valid
+    // let mmr_proof = dbg!(partial_mmr.open(2).unwrap().unwrap());
+    // assert!(partial_mmr.peaks().verify(tracked_block_headers[0].hash(), mmr_proof));
 }
 
 #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -358,11 +358,17 @@ async fn test_sync_state_mmr_state() {
     // Try reconstructing the chain_mmr from what's in the database
     let partial_mmr = client.build_current_partial_mmr().unwrap();
 
-    // Since Mocked data contains two sync updates we should be "tracking" those blocks
+    // Since Mocked data contains three sync updates we should be "tracking" those blocks
+    // However, remember that we don't actually update the partial_mmr with the latest block but up
+    // to one block before instead. This is because the prologue will already build the
+    // authentication path for that block.
+    assert_eq!(partial_mmr.forest(), 6);
     assert!(partial_mmr.open(0).unwrap().is_none());
     assert!(partial_mmr.open(1).unwrap().is_none());
     assert!(partial_mmr.open(2).unwrap().is_some());
     assert!(partial_mmr.open(3).unwrap().is_none());
+    assert!(partial_mmr.open(4).unwrap().is_some());
+    assert!(partial_mmr.open(5).unwrap().is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR adds another test for the sync state but this will use the mocked data via `insert_mock_data` to check that we can still rebuild the required partial mmr