### PR TITLE
Fix breaking change of file naming on node

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,7 @@ use crypto::{
     merkle::MmrError,
     utils::{DeserializationError, HexParseError},
 };
-use miden_node_proto::error::ParseError;
+use miden_node_proto::errors::ParseError;
 use miden_tx::{DataStoreError, TransactionExecutorError, TransactionProverError};
 use objects::{
     accounts::AccountId, notes::NoteId, AccountError, AssetVaultError, Digest, NoteError,


### PR DESCRIPTION
This PR changed the name of the file from `error.rs` to `errors.rs` breaking client: 

https://github.com/0xPolygonMiden/miden-node/pull/207

Should be fixed.