### PR TITLE
feat: add RPC client trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ testing = ["objects/testing", "miden_lib/testing"]
 
 [dependencies]
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
+async-trait = { version = "0.1" }
 clap = { version = "4.3" , features = ["derive"] }
 comfy-table = "7.1.0"
 crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -5,7 +5,7 @@ use crypto::{
     utils::{bytes_to_hex_string, Deserializable, Serializable},
     StarkField, ZERO,
 };
-use miden_client::client::{accounts, Client, NodeRpcClient};
+use miden_client::client::{accounts, rpc::NodeRpcClient, Client};
 
 use miden_tx::DataStore;
 use objects::{

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -5,7 +5,7 @@ use crypto::{
     utils::{bytes_to_hex_string, Deserializable, Serializable},
     StarkField, ZERO,
 };
-use miden_client::client::{accounts, Client, NodeApi};
+use miden_client::client::{accounts, Client, NodeRpcClient};
 
 use miden_tx::DataStore;
 use objects::{
@@ -78,7 +78,7 @@ pub enum AccountTemplate {
 }
 
 impl AccountCmd {
-    pub fn execute<N: NodeApi, D: DataStore>(
+    pub fn execute<N: NodeRpcClient, D: DataStore>(
         &self,
         mut client: Client<N, D>,
     ) -> Result<(), String> {
@@ -140,7 +140,7 @@ impl AccountCmd {
 // LIST ACCOUNTS
 // ================================================================================================
 
-fn list_accounts<N: NodeApi, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
+fn list_accounts<N: NodeRpcClient, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
     let accounts = client.get_accounts()?;
 
     let mut table = create_dynamic_table(&[
@@ -166,7 +166,7 @@ fn list_accounts<N: NodeApi, D: DataStore>(client: Client<N, D>) -> Result<(), S
     Ok(())
 }
 
-pub fn show_account<N: NodeApi, D: DataStore>(
+pub fn show_account<N: NodeRpcClient, D: DataStore>(
     client: Client<N, D>,
     account_id: AccountId,
     show_keys: bool,
@@ -312,7 +312,7 @@ pub fn show_account<N: NodeApi, D: DataStore>(
 // IMPORT ACCOUNT
 // ================================================================================================
 
-fn import_account<N: NodeApi, D: DataStore>(
+fn import_account<N: NodeRpcClient, D: DataStore>(
     client: &mut Client<N, D>,
     filename: &PathBuf,
 ) -> Result<(), String> {

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -5,7 +5,7 @@ use crypto::{
     utils::{bytes_to_hex_string, Deserializable, Serializable},
     StarkField, ZERO,
 };
-use miden_client::client::{accounts, Client};
+use miden_client::client::{accounts, Client, NodeApi};
 
 use objects::{
     accounts::{AccountData, AccountId, AccountStorage, AccountStub, AccountType, StorageSlotType},
@@ -77,7 +77,7 @@ pub enum AccountTemplate {
 }
 
 impl AccountCmd {
-    pub fn execute(&self, mut client: Client) -> Result<(), String> {
+    pub fn execute<N: NodeApi>(&self, mut client: Client<N>) -> Result<(), String> {
         match self {
             AccountCmd::List => {
                 list_accounts(client)?;
@@ -136,7 +136,7 @@ impl AccountCmd {
 // LIST ACCOUNTS
 // ================================================================================================
 
-fn list_accounts(client: Client) -> Result<(), String> {
+fn list_accounts<N: NodeApi>(client: Client<N>) -> Result<(), String> {
     let accounts = client.get_accounts()?;
 
     let mut table = create_dynamic_table(&[
@@ -162,8 +162,8 @@ fn list_accounts(client: Client) -> Result<(), String> {
     Ok(())
 }
 
-pub fn show_account(
-    client: Client,
+pub fn show_account<N: NodeApi>(
+    client: Client<N>,
     account_id: AccountId,
     show_keys: bool,
     show_vault: bool,
@@ -308,7 +308,7 @@ pub fn show_account(
 // IMPORT ACCOUNT
 // ================================================================================================
 
-fn import_account(client: &mut Client, filename: &PathBuf) -> Result<(), String> {
+fn import_account<N: NodeApi>(client: &mut Client<N>, filename: &PathBuf) -> Result<(), String> {
     info!(
         "Attempting to import account data from {}...",
         fs::canonicalize(filename)

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -7,6 +7,7 @@ use crypto::{
 };
 use miden_client::client::{accounts, Client, NodeApi};
 
+use miden_tx::DataStore;
 use objects::{
     accounts::{AccountData, AccountId, AccountStorage, AccountStub, AccountType, StorageSlotType},
     assets::{Asset, TokenSymbol},
@@ -77,7 +78,10 @@ pub enum AccountTemplate {
 }
 
 impl AccountCmd {
-    pub fn execute<N: NodeApi>(&self, mut client: Client<N>) -> Result<(), String> {
+    pub fn execute<N: NodeApi, D: DataStore>(
+        &self,
+        mut client: Client<N, D>,
+    ) -> Result<(), String> {
         match self {
             AccountCmd::List => {
                 list_accounts(client)?;
@@ -136,7 +140,7 @@ impl AccountCmd {
 // LIST ACCOUNTS
 // ================================================================================================
 
-fn list_accounts<N: NodeApi>(client: Client<N>) -> Result<(), String> {
+fn list_accounts<N: NodeApi, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
     let accounts = client.get_accounts()?;
 
     let mut table = create_dynamic_table(&[
@@ -162,8 +166,8 @@ fn list_accounts<N: NodeApi>(client: Client<N>) -> Result<(), String> {
     Ok(())
 }
 
-pub fn show_account<N: NodeApi>(
-    client: Client<N>,
+pub fn show_account<N: NodeApi, D: DataStore>(
+    client: Client<N, D>,
     account_id: AccountId,
     show_keys: bool,
     show_vault: bool,
@@ -308,7 +312,10 @@ pub fn show_account<N: NodeApi>(
 // IMPORT ACCOUNT
 // ================================================================================================
 
-fn import_account<N: NodeApi>(client: &mut Client<N>, filename: &PathBuf) -> Result<(), String> {
+fn import_account<N: NodeApi, D: DataStore>(
+    client: &mut Client<N, D>,
+    filename: &PathBuf,
+) -> Result<(), String> {
     info!(
         "Attempting to import account data from {}...",
         fs::canonicalize(filename)

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,12 +1,12 @@
-use miden_client::client::Client;
+use miden_client::client::{Client, NodeApi};
 
-pub fn print_client_info(client: &Client) -> Result<(), String> {
+pub fn print_client_info<N: NodeApi>(client: &Client<N>) -> Result<(), String> {
     print_block_number(client)
 }
 
 // HELPERS
 // ================================================================================================
-fn print_block_number(client: &Client) -> Result<(), String> {
+fn print_block_number<N: NodeApi>(client: &Client<N>) -> Result<(), String> {
     println!(
         "block number: {}",
         client.get_sync_height().map_err(|e| e.to_string())?

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,12 +1,13 @@
 use miden_client::client::{Client, NodeApi};
+use miden_tx::DataStore;
 
-pub fn print_client_info<N: NodeApi>(client: &Client<N>) -> Result<(), String> {
+pub fn print_client_info<N: NodeApi, D: DataStore>(client: &Client<N, D>) -> Result<(), String> {
     print_block_number(client)
 }
 
 // HELPERS
 // ================================================================================================
-fn print_block_number<N: NodeApi>(client: &Client<N>) -> Result<(), String> {
+fn print_block_number<N: NodeApi, D: DataStore>(client: &Client<N, D>) -> Result<(), String> {
     println!(
         "block number: {}",
         client.get_sync_height().map_err(|e| e.to_string())?

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,13 +1,15 @@
-use miden_client::client::{Client, NodeApi};
+use miden_client::client::{Client, NodeRpcClient};
 use miden_tx::DataStore;
 
-pub fn print_client_info<N: NodeApi, D: DataStore>(client: &Client<N, D>) -> Result<(), String> {
+pub fn print_client_info<N: NodeRpcClient, D: DataStore>(
+    client: &Client<N, D>,
+) -> Result<(), String> {
     print_block_number(client)
 }
 
 // HELPERS
 // ================================================================================================
-fn print_block_number<N: NodeApi, D: DataStore>(client: &Client<N, D>) -> Result<(), String> {
+fn print_block_number<N: NodeRpcClient, D: DataStore>(client: &Client<N, D>) -> Result<(), String> {
     println!(
         "block number: {}",
         client.get_sync_height().map_err(|e| e.to_string())?

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,4 +1,4 @@
-use miden_client::client::{Client, NodeRpcClient};
+use miden_client::client::{rpc::NodeRpcClient, Client};
 use miden_tx::DataStore;
 
 pub fn print_client_info<N: NodeRpcClient, D: DataStore>(

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -10,7 +10,7 @@ use super::{Client, Parser};
 use clap::ValueEnum;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::{
-    client::NodeApi,
+    client::NodeRpcClient,
     store::notes::{InputNoteFilter, InputNoteRecord},
 };
 
@@ -80,7 +80,7 @@ pub enum InputNotes {
 }
 
 impl InputNotes {
-    pub fn execute<N: NodeApi, D: DataStore>(
+    pub fn execute<N: NodeRpcClient, D: DataStore>(
         &self,
         mut client: Client<N, D>,
     ) -> Result<(), String> {
@@ -121,7 +121,7 @@ impl InputNotes {
 
 // LIST INPUT NOTES
 // ================================================================================================
-fn list_input_notes<N: NodeApi, D: DataStore>(
+fn list_input_notes<N: NodeRpcClient, D: DataStore>(
     client: Client<N, D>,
     input_note_filter: InputNoteFilter,
 ) -> Result<(), String> {
@@ -132,7 +132,7 @@ fn list_input_notes<N: NodeApi, D: DataStore>(
 
 // EXPORT INPUT NOTE
 // ================================================================================================
-pub fn export_note<N: NodeApi, D: DataStore>(
+pub fn export_note<N: NodeRpcClient, D: DataStore>(
     client: &Client<N, D>,
     note_id: &str,
     filename: Option<PathBuf>,
@@ -158,7 +158,7 @@ pub fn export_note<N: NodeApi, D: DataStore>(
 
 // IMPORT INPUT NOTE
 // ================================================================================================
-pub fn import_note<N: NodeApi, D: DataStore>(
+pub fn import_note<N: NodeRpcClient, D: DataStore>(
     client: &mut Client<N, D>,
     filename: PathBuf,
 ) -> Result<NoteId, String> {
@@ -180,7 +180,7 @@ pub fn import_note<N: NodeApi, D: DataStore>(
 
 // SHOW INPUT NOTE
 // ================================================================================================
-fn show_input_note<N: NodeApi, D: DataStore>(
+fn show_input_note<N: NodeRpcClient, D: DataStore>(
     client: Client<N, D>,
     note_id: String,
     show_script: bool,
@@ -294,7 +294,7 @@ mod tests {
     use crate::cli::input_notes::{export_note, import_note};
 
     use miden_client::{
-        client::{Client, NodeApi},
+        client::{Client, NodeRpcClient},
         config::{ClientConfig, Endpoint},
         mock::{MockDataStore, MockRpcApi},
         store::notes::InputNoteRecord,

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -294,7 +294,7 @@ mod tests {
     use crate::cli::input_notes::{export_note, import_note};
 
     use miden_client::{
-        client::{rpc::NodeRpcClient, Client},
+        client::Client,
         config::{ClientConfig, Endpoint},
         mock::{MockDataStore, MockRpcApi},
         store::notes::InputNoteRecord,

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -10,7 +10,7 @@ use super::{Client, Parser};
 use clap::ValueEnum;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::{
-    client::NodeRpcClient,
+    client::rpc::NodeRpcClient,
     store::notes::{InputNoteFilter, InputNoteRecord},
 };
 
@@ -294,7 +294,7 @@ mod tests {
     use crate::cli::input_notes::{export_note, import_note};
 
     use miden_client::{
-        client::{Client, NodeRpcClient},
+        client::{rpc::NodeRpcClient, Client},
         config::{ClientConfig, Endpoint},
         mock::{MockDataStore, MockRpcApi},
         store::notes::InputNoteRecord,

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -121,7 +121,10 @@ impl InputNotes {
 
 // LIST INPUT NOTES
 // ================================================================================================
-fn list_input_notes<N: NodeApi, D: DataStore>(client: Client<N, D>, input_note_filter: InputNoteFilter) -> Result<(), String> {
+fn list_input_notes<N: NodeApi, D: DataStore>(
+    client: Client<N, D>,
+    input_note_filter: InputNoteFilter,
+) -> Result<(), String> {
     let notes = client.get_input_notes(input_note_filter)?;
     print_notes_summary(&notes);
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,10 +6,7 @@ use figment::{
     providers::{Format, Toml},
     Figment,
 };
-use miden_client::{
-    client::{rpc::NodeRpcClient, Client},
-    config::ClientConfig,
-};
+use miden_client::{client::Client, config::ClientConfig};
 
 #[cfg(feature = "mock")]
 use miden_client::mock::MockDataStore;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@ use figment::{
     Figment,
 };
 use miden_client::{
-    client::{Client, NodeRpcClient},
+    client::{rpc::NodeRpcClient, Client},
     config::ClientConfig,
 };
 
@@ -17,7 +17,7 @@ use miden_client::mock::MockDataStore;
 use miden_client::mock::MockRpcApi;
 
 #[cfg(not(feature = "mock"))]
-use miden_client::client::rpc_client::RpcClient;
+use miden_client::client::rpc::TonicRpcClient;
 #[cfg(not(feature = "mock"))]
 use miden_client::store::data_store::SqliteDataStore;
 
@@ -79,13 +79,13 @@ impl Cli {
         let rpc_endpoint = client_config.rpc.endpoint.to_string();
 
         #[cfg(not(feature = "mock"))]
-        let client: Client<RpcClient, SqliteDataStore> = {
+        let client: Client<TonicRpcClient, SqliteDataStore> = {
             use miden_client::{errors::ClientError, store::Store};
 
             let store = Store::new((&client_config).into()).map_err(ClientError::StoreError)?;
             Client::new(
                 client_config,
-                RpcClient::new(&rpc_endpoint),
+                TonicRpcClient::new(&rpc_endpoint),
                 SqliteDataStore::new(store),
             )?
         };

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@ use figment::{
     Figment,
 };
 use miden_client::{
-    client::{Client, NodeApi},
+    client::{Client, NodeRpcClient},
     config::ClientConfig,
 };
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,9 @@ use miden_client::{
 #[cfg(feature = "mock")]
 use miden_client::mock::MockRpcApi;
 
+#[cfg(not(feature = "mock"))]
+use miden_client::client::rpc_client::RpcClient;
+
 mod account;
 mod info;
 mod input_notes;

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,4 +1,4 @@
-use miden_client::client::{Client, NodeRpcClient};
+use miden_client::client::{rpc::NodeRpcClient, Client};
 use miden_tx::DataStore;
 
 pub async fn sync_state<N: NodeRpcClient, D: DataStore>(

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,7 +1,9 @@
-use miden_client::client::{Client, NodeApi};
+use miden_client::client::{Client, NodeRpcClient};
 use miden_tx::DataStore;
 
-pub async fn sync_state<N: NodeApi, D: DataStore>(mut client: Client<N, D>) -> Result<(), String> {
+pub async fn sync_state<N: NodeRpcClient, D: DataStore>(
+    mut client: Client<N, D>,
+) -> Result<(), String> {
     let block_num = client.sync_state().await?;
     println!("State synced to block {}", block_num);
     Ok(())

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,6 +1,6 @@
-use miden_client::client::Client;
+use miden_client::client::{Client, NodeApi};
 
-pub async fn sync_state(mut client: Client) -> Result<(), String> {
+pub async fn sync_state<N: NodeApi>(mut client: Client<N>) -> Result<(), String> {
     let block_num = client.sync_state().await?;
     println!("State synced to block {}", block_num);
     Ok(())

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -1,6 +1,7 @@
 use miden_client::client::{Client, NodeApi};
+use miden_tx::DataStore;
 
-pub async fn sync_state<N: NodeApi>(mut client: Client<N>) -> Result<(), String> {
+pub async fn sync_state<N: NodeApi, D: DataStore>(mut client: Client<N, D>) -> Result<(), String> {
     let block_num = client.sync_state().await?;
     println!("State synced to block {}", block_num);
     Ok(())

--- a/src/cli/tags.rs
+++ b/src/cli/tags.rs
@@ -1,4 +1,4 @@
-use miden_client::client::NodeRpcClient;
+use miden_client::client::rpc::NodeRpcClient;
 use miden_tx::DataStore;
 
 use super::{Client, Parser};

--- a/src/cli/tags.rs
+++ b/src/cli/tags.rs
@@ -1,4 +1,4 @@
-use miden_client::client::NodeApi;
+use miden_client::client::NodeRpcClient;
 use miden_tx::DataStore;
 
 use super::{Client, Parser};
@@ -19,7 +19,7 @@ pub enum TagsCmd {
 }
 
 impl TagsCmd {
-    pub async fn execute<N: NodeApi, D: DataStore>(
+    pub async fn execute<N: NodeRpcClient, D: DataStore>(
         &self,
         client: Client<N, D>,
     ) -> Result<(), String> {
@@ -37,13 +37,16 @@ impl TagsCmd {
 
 // HELPERS
 // ================================================================================================
-fn list_tags<N: NodeApi, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
+fn list_tags<N: NodeRpcClient, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
     let tags = client.get_note_tags()?;
     println!("tags: {:?}", tags);
     Ok(())
 }
 
-fn add_tag<N: NodeApi, D: DataStore>(mut client: Client<N, D>, tag: u64) -> Result<(), String> {
+fn add_tag<N: NodeRpcClient, D: DataStore>(
+    mut client: Client<N, D>,
+    tag: u64,
+) -> Result<(), String> {
     client.add_note_tag(tag)?;
     println!("tag {} added", tag);
     Ok(())

--- a/src/cli/tags.rs
+++ b/src/cli/tags.rs
@@ -1,3 +1,5 @@
+use miden_client::client::NodeApi;
+
 use super::{Client, Parser};
 
 #[derive(Debug, Parser, Clone)]
@@ -16,7 +18,7 @@ pub enum TagsCmd {
 }
 
 impl TagsCmd {
-    pub async fn execute(&self, client: Client) -> Result<(), String> {
+    pub async fn execute<N: NodeApi>(&self, client: Client<N>) -> Result<(), String> {
         match self {
             TagsCmd::List => {
                 list_tags(client)?;
@@ -31,13 +33,13 @@ impl TagsCmd {
 
 // HELPERS
 // ================================================================================================
-fn list_tags(client: Client) -> Result<(), String> {
+fn list_tags<N: NodeApi>(client: Client<N>) -> Result<(), String> {
     let tags = client.get_note_tags()?;
     println!("tags: {:?}", tags);
     Ok(())
 }
 
-fn add_tag(mut client: Client, tag: u64) -> Result<(), String> {
+fn add_tag<N: NodeApi>(mut client: Client<N>, tag: u64) -> Result<(), String> {
     client.add_note_tag(tag)?;
     println!("tag {} added", tag);
     Ok(())

--- a/src/cli/tags.rs
+++ b/src/cli/tags.rs
@@ -1,4 +1,5 @@
 use miden_client::client::NodeApi;
+use miden_tx::DataStore;
 
 use super::{Client, Parser};
 
@@ -18,7 +19,10 @@ pub enum TagsCmd {
 }
 
 impl TagsCmd {
-    pub async fn execute<N: NodeApi>(&self, client: Client<N>) -> Result<(), String> {
+    pub async fn execute<N: NodeApi, D: DataStore>(
+        &self,
+        client: Client<N, D>,
+    ) -> Result<(), String> {
         match self {
             TagsCmd::List => {
                 list_tags(client)?;
@@ -33,13 +37,13 @@ impl TagsCmd {
 
 // HELPERS
 // ================================================================================================
-fn list_tags<N: NodeApi>(client: Client<N>) -> Result<(), String> {
+fn list_tags<N: NodeApi, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
     let tags = client.get_note_tags()?;
     println!("tags: {:?}", tags);
     Ok(())
 }
 
-fn add_tag<N: NodeApi>(mut client: Client<N>, tag: u64) -> Result<(), String> {
+fn add_tag<N: NodeApi, D: DataStore>(mut client: Client<N, D>, tag: u64) -> Result<(), String> {
     client.add_note_tag(tag)?;
     println!("tag {} added", tag);
     Ok(())

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -1,7 +1,7 @@
 use miden_client::{
     client::{
+        rpc::NodeRpcClient,
         transactions::{PaymentTransactionData, TransactionRecord, TransactionTemplate},
-        NodeRpcClient,
     },
     store::transactions::TransactionFilter,
 };

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -1,7 +1,7 @@
 use miden_client::{
     client::{
         transactions::{PaymentTransactionData, TransactionRecord, TransactionTemplate},
-        NodeApi,
+        NodeRpcClient,
     },
     store::transactions::TransactionFilter,
 };
@@ -113,7 +113,7 @@ pub enum Transaction {
 }
 
 impl Transaction {
-    pub async fn execute<N: NodeApi, D: DataStore>(
+    pub async fn execute<N: NodeRpcClient, D: DataStore>(
         &self,
         mut client: Client<N, D>,
     ) -> Result<(), String> {
@@ -140,7 +140,7 @@ impl Transaction {
 
 // LIST TRANSACTIONS
 // ================================================================================================
-fn list_transactions<N: NodeApi, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
+fn list_transactions<N: NodeRpcClient, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
     let transactions = client.get_transactions(TransactionFilter::All)?;
     print_transactions_summary(&transactions);
     Ok(())

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -1,5 +1,8 @@
 use miden_client::{
-    client::transactions::{PaymentTransactionData, TransactionRecord, TransactionTemplate},
+    client::{
+        transactions::{PaymentTransactionData, TransactionRecord, TransactionTemplate},
+        NodeApi,
+    },
     store::transactions::TransactionFilter,
 };
 
@@ -109,7 +112,7 @@ pub enum Transaction {
 }
 
 impl Transaction {
-    pub async fn execute(&self, mut client: Client) -> Result<(), String> {
+    pub async fn execute<N: NodeApi>(&self, mut client: Client<N>) -> Result<(), String> {
         match self {
             Transaction::List => {
                 list_transactions(client)?;
@@ -133,7 +136,7 @@ impl Transaction {
 
 // LIST TRANSACTIONS
 // ================================================================================================
-fn list_transactions(client: Client) -> Result<(), String> {
+fn list_transactions<N: NodeApi>(client: Client<N>) -> Result<(), String> {
     let transactions = client.get_transactions(TransactionFilter::All)?;
     print_transactions_summary(&transactions);
     Ok(())

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -6,6 +6,7 @@ use miden_client::{
     store::transactions::TransactionFilter,
 };
 
+use miden_tx::DataStore;
 use objects::{accounts::AccountId, assets::FungibleAsset, notes::NoteId};
 use tracing::info;
 
@@ -112,7 +113,10 @@ pub enum Transaction {
 }
 
 impl Transaction {
-    pub async fn execute<N: NodeApi>(&self, mut client: Client<N>) -> Result<(), String> {
+    pub async fn execute<N: NodeApi, D: DataStore>(
+        &self,
+        mut client: Client<N, D>,
+    ) -> Result<(), String> {
         match self {
             Transaction::List => {
                 list_transactions(client)?;
@@ -136,7 +140,7 @@ impl Transaction {
 
 // LIST TRANSACTIONS
 // ================================================================================================
-fn list_transactions<N: NodeApi>(client: Client<N>) -> Result<(), String> {
+fn list_transactions<N: NodeApi, D: DataStore>(client: Client<N, D>) -> Result<(), String> {
     let transactions = client.get_transactions(TransactionFilter::All)?;
     print_transactions_summary(&transactions);
     Ok(())

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -14,7 +14,7 @@ use rand::{rngs::ThreadRng, Rng};
 
 use crate::{errors::ClientError, store::accounts::AuthInfo};
 
-use super::{Client, NodeApi};
+use super::{Client, NodeRpcClient};
 
 pub enum AccountTemplate {
     BasicWallet {
@@ -34,7 +34,7 @@ pub enum AccountStorageMode {
     OnChain,
 }
 
-impl<N: NodeApi, D: DataStore> Client<N, D> {
+impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -1,5 +1,6 @@
 use crypto::{dsa::rpo_falcon512::KeyPair, Felt, Word};
 use miden_lib::AuthScheme;
+use miden_tx::DataStore;
 use objects::{
     accounts::{
         Account, AccountData, AccountDelta, AccountId, AccountStorage, AccountStub, AccountType,
@@ -33,7 +34,7 @@ pub enum AccountStorageMode {
     OnChain,
 }
 
-impl<N: NodeApi> Client<N> {
+impl<N: NodeApi, D: DataStore> Client<N, D> {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -13,7 +13,7 @@ use rand::{rngs::ThreadRng, Rng};
 
 use crate::{errors::ClientError, store::accounts::AuthInfo};
 
-use super::Client;
+use super::{Client, NodeApi};
 
 pub enum AccountTemplate {
     BasicWallet {
@@ -33,7 +33,7 @@ pub enum AccountStorageMode {
     OnChain,
 }
 
-impl Client {
+impl<N: NodeApi> Client<N> {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -14,7 +14,7 @@ use rand::{rngs::ThreadRng, Rng};
 
 use crate::{errors::ClientError, store::accounts::AuthInfo};
 
-use super::{Client, NodeRpcClient};
+use super::{rpc::NodeRpcClient, Client};
 
 pub enum AccountTemplate {
     BasicWallet {

--- a/src/client/chain_data.rs
+++ b/src/client/chain_data.rs
@@ -1,4 +1,4 @@
-use super::{Client, NodeApi};
+use super::{Client, NodeRpcClient};
 use miden_tx::DataStore;
 
 #[cfg(test)]
@@ -6,7 +6,7 @@ use crate::errors::ClientError;
 #[cfg(test)]
 use objects::BlockHeader;
 
-impl<N: NodeApi, D: DataStore> Client<N, D> {
+impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
     #[cfg(test)]
     pub fn get_block_headers_in_range(
         &self,

--- a/src/client/chain_data.rs
+++ b/src/client/chain_data.rs
@@ -1,4 +1,4 @@
-use super::{Client, NodeRpcClient};
+use super::{rpc::NodeRpcClient, Client};
 use miden_tx::DataStore;
 
 #[cfg(test)]

--- a/src/client/chain_data.rs
+++ b/src/client/chain_data.rs
@@ -1,11 +1,11 @@
-use super::Client;
+use super::{Client, NodeApi};
 
 #[cfg(test)]
 use crate::errors::ClientError;
 #[cfg(test)]
 use objects::BlockHeader;
 
-impl Client {
+impl<N: NodeApi> Client<N> {
     #[cfg(test)]
     pub fn get_block_headers_in_range(
         &self,

--- a/src/client/chain_data.rs
+++ b/src/client/chain_data.rs
@@ -1,11 +1,12 @@
 use super::{Client, NodeApi};
+use miden_tx::DataStore;
 
 #[cfg(test)]
 use crate::errors::ClientError;
 #[cfg(test)]
 use objects::BlockHeader;
 
-impl<N: NodeApi> Client<N> {
+impl<N: NodeApi, D: DataStore> Client<N, D> {
     #[cfg(test)]
     pub fn get_block_headers_in_range(
         &self,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,17 +1,20 @@
 #[cfg(not(any(test, feature = "mock")))]
 use crate::store::data_store::SqliteDataStore;
-use crate::{config::ClientConfig, errors::{ClientError, NodeApiError}, store::Store};
+use crate::{
+    config::ClientConfig,
+    errors::{ClientError, NodeApiError},
+    store::Store,
+};
 use miden_tx::TransactionExecutor;
-use objects::{transaction::ProvenTransaction, BlockHeader, accounts::AccountId};
+use objects::{accounts::AccountId, transaction::ProvenTransaction, BlockHeader};
 pub use rpc_client::RpcApiEndpoint;
 
 pub mod accounts;
 mod chain_data;
 mod notes;
-pub(crate) mod rpc_client;
+pub mod rpc_client;
 pub(crate) mod sync;
 pub mod transactions;
-
 
 // NODE API TRAIT
 // ================================================================================================
@@ -34,7 +37,6 @@ pub trait NodeApi {
         nullifiers_tags: &[u16],
     ) -> Result<StateSyncInfo, NodeApiError>;
 }
-
 
 // MIDEN CLIENT
 // ================================================================================================
@@ -85,21 +87,21 @@ use self::rpc_client::StateSyncInfo;
 
 #[cfg(any(test, feature = "mock"))]
 mod mock {
-    use super::{ClientConfig, ClientError, Store, TransactionExecutor, NodeApi};
-    use crate::{mock::MockRpcApi, store::mock_executor_data_store::MockDataStore};
+    use super::{ClientConfig, ClientError, NodeApi, Store, TransactionExecutor};
+    use crate::store::mock_executor_data_store::MockDataStore;
 
     pub struct Client<N: NodeApi> {
         pub(crate) store: Store,
-        pub(crate) rpc_api: MockRpcApi,
+        pub(crate) rpc_api: N,
         pub(crate) tx_executor: TransactionExecutor<MockDataStore>,
     }
 
     #[cfg(any(test, feature = "mock"))]
     impl<N: NodeApi> Client<N> {
-        pub fn new(config: ClientConfig, _api: N) -> Result<Self, ClientError> {
+        pub fn new(config: ClientConfig, api: N) -> Result<Self, ClientError> {
             Ok(Self {
                 store: Store::new((&config).into())?,
-                rpc_api: Default::default(),
+                rpc_api: api,
                 tx_executor: TransactionExecutor::new(MockDataStore::new()),
             })
         }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     errors::{ClientError, NodeApiError},
     store::Store,
 };
+use async_trait::async_trait;
 use miden_tx::{DataStore, TransactionExecutor};
 use objects::{accounts::AccountId, transaction::ProvenTransaction, BlockHeader};
 
@@ -19,6 +20,7 @@ pub mod transactions;
 // NODE API TRAIT
 // ================================================================================================
 
+#[async_trait]
 pub trait NodeApi {
     fn new(config_endpoint: &str) -> Self;
     async fn submit_proven_transaction(

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,44 +1,14 @@
-use crate::{
-    config::ClientConfig,
-    errors::{ClientError, NodeRpcClientError},
-    store::Store,
-};
-use async_trait::async_trait;
+use crate::{config::ClientConfig, errors::ClientError, store::Store};
 use miden_tx::{DataStore, TransactionExecutor};
-use objects::{accounts::AccountId, transaction::ProvenTransaction, BlockHeader};
 
-pub use rpc_client::RpcApiEndpoint;
-use rpc_client::StateSyncInfo;
+pub mod rpc;
+use rpc::NodeRpcClient;
 
 pub mod accounts;
 mod chain_data;
 mod notes;
-pub mod rpc_client;
 pub(crate) mod sync;
 pub mod transactions;
-
-// NODE API TRAIT
-// ================================================================================================
-
-#[async_trait]
-pub trait NodeRpcClient {
-    fn new(config_endpoint: &str) -> Self;
-    async fn submit_proven_transaction(
-        &mut self,
-        proven_transaction: ProvenTransaction,
-    ) -> Result<(), NodeRpcClientError>;
-    async fn get_block_header_by_number(
-        &mut self,
-        block_number: Option<u32>,
-    ) -> Result<BlockHeader, NodeRpcClientError>;
-    async fn sync_state(
-        &mut self,
-        block_num: u32,
-        account_ids: &[AccountId],
-        note_tags: &[u16],
-        nullifiers_tags: &[u16],
-    ) -> Result<StateSyncInfo, NodeRpcClientError>;
-}
 
 // MIDEN CLIENT
 // ================================================================================================

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::ClientConfig,
-    errors::{ClientError, NodeApiError},
+    errors::{ClientError, NodeRpcClientError},
     store::Store,
 };
 use async_trait::async_trait;
@@ -21,23 +21,23 @@ pub mod transactions;
 // ================================================================================================
 
 #[async_trait]
-pub trait NodeApi {
+pub trait NodeRpcClient {
     fn new(config_endpoint: &str) -> Self;
     async fn submit_proven_transaction(
         &mut self,
         proven_transaction: ProvenTransaction,
-    ) -> Result<(), NodeApiError>;
+    ) -> Result<(), NodeRpcClientError>;
     async fn get_block_header_by_number(
         &mut self,
         block_number: Option<u32>,
-    ) -> Result<BlockHeader, NodeApiError>;
+    ) -> Result<BlockHeader, NodeRpcClientError>;
     async fn sync_state(
         &mut self,
         block_num: u32,
         account_ids: &[AccountId],
         note_tags: &[u16],
         nullifiers_tags: &[u16],
-    ) -> Result<StateSyncInfo, NodeApiError>;
+    ) -> Result<StateSyncInfo, NodeRpcClientError>;
 }
 
 // MIDEN CLIENT
@@ -51,14 +51,14 @@ pub trait NodeApi {
 /// - Connects to one or more Miden nodes to periodically sync with the current state of the
 ///   network.
 /// - Executes, proves, and submits transactions to the network as directed by the user.
-pub struct Client<N: NodeApi, D: DataStore> {
+pub struct Client<N: NodeRpcClient, D: DataStore> {
     /// Local database containing information about the accounts managed by this client.
     store: Store,
     rpc_api: N,
     tx_executor: TransactionExecutor<D>,
 }
 
-impl<N: NodeApi, D: DataStore> Client<N, D> {
+impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -1,4 +1,4 @@
-use super::{Client, NodeApi};
+use super::{Client, NodeRpcClient};
 
 use crate::{
     errors::ClientError,
@@ -7,7 +7,7 @@ use crate::{
 use miden_tx::DataStore;
 use objects::notes::NoteId;
 
-impl<N: NodeApi, D: DataStore> Client<N, D> {
+impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
     // INPUT NOTE DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -4,9 +4,10 @@ use crate::{
     errors::ClientError,
     store::notes::{InputNoteFilter, InputNoteRecord},
 };
+use miden_tx::DataStore;
 use objects::notes::NoteId;
 
-impl<N: NodeApi> Client<N> {
+impl<N: NodeApi, D: DataStore> Client<N, D> {
     // INPUT NOTE DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -1,4 +1,4 @@
-use super::{Client, NodeRpcClient};
+use super::{rpc::NodeRpcClient, Client};
 
 use crate::{
     errors::ClientError,

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -1,4 +1,4 @@
-use super::Client;
+use super::{Client, NodeApi};
 
 use crate::{
     errors::ClientError,
@@ -6,7 +6,7 @@ use crate::{
 };
 use objects::notes::NoteId;
 
-impl Client {
+impl<N: NodeApi> Client<N> {
     // INPUT NOTE DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -59,7 +59,7 @@ pub trait NodeRpcClient {
 // STATE SYNC INFO
 // ================================================================================================
 
-/// Represents a [SyncStateResponse] with fields converted into domain types
+/// Represents a `SyncStateResponse` with fields converted into domain types
 pub struct StateSyncInfo {
     /// The block number of the chain tip at the moment of the response
     pub chain_tip: u32,
@@ -78,7 +78,7 @@ pub struct StateSyncInfo {
 // COMMITTED NOTE
 // ================================================================================================
 
-/// Represents a committed note, returned as part of a [SyncStateResponse]
+/// Represents a committed note, returned as part of a `SyncStateResponse`
 pub struct CommittedNote {
     /// Note ID of the committed note
     note_id: NoteId,

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -15,10 +15,12 @@ pub use tonic_client::TonicRpcClient;
 // NODE API TRAIT
 // ================================================================================================
 
+/// This trait is used for communication with the miden node
+///
+/// The implementers are responsible for connecting to the Miden node, handling endpoint
+/// requests/responses, and translating responses into domain objects relevant for each of the
+/// endpoints.
 #[async_trait]
-/// This trait is mean to be used to abstract the connection between the client and the node. Since
-/// different environments (e.g a mocked client, compiling to wasm or no_std, using other crate for
-/// the communication) may require other implementations it made sense to create a trait for this
 pub trait NodeRpcClient {
     /// Given a Proven Transaction, send it to the node for it to be included in a future block
     async fn submit_proven_transaction(
@@ -26,7 +28,7 @@ pub trait NodeRpcClient {
         proven_transaction: ProvenTransaction,
     ) -> Result<(), NodeRpcClientError>;
 
-    /// Given a block number, fetch the block header corresponding to that height from the node
+    /// Given a block number, fetches the block header corresponding to that height from the node
     ///
     /// When `None` is provided, returns info regarding the latest block
     async fn get_block_header_by_number(
@@ -34,17 +36,17 @@ pub trait NodeRpcClient {
         block_number: Option<u32>,
     ) -> Result<BlockHeader, NodeRpcClientError>;
 
-    /// Fetch info from the node necessary to perform a state sync
+    /// Fetches info from the node necessary to perform a state sync
     ///
-    /// - `block_num` is the last block number known by the client. The returned [ StateSyncInfo ]
-    /// should contain data starting from the next block, until the first block which contains a
-    /// note of matching the requested tag, or the chain tip if there are no notes.
+    /// - `block_num` is the last block number known by the client. The returned [StateSyncInfo]
+    ///   should contain data starting from the next block, until the first block which contains a
+    ///   note of matching the requested tag, or the chain tip if there are no notes.
     /// - `account_ids` is a list of account ids and determines the accounts the client is interested
-    /// in and should receive account updates of.
+    ///   in and should receive account updates of.
     /// - `note_tags` is a list of tags used to filter the notes the client is interested in, which
-    /// serves as a "note group" filter. Notice that you can't filter by a specific note id
+    ///   serves as a "note group" filter. Notice that you can't filter by a specific note id
     /// - `nullifiers_tags` similar to `note_tags`, is a list of tags used to filter the nullifiers
-    /// corresponding to some notes the client is interested in
+    ///   corresponding to some notes the client is interested in
     async fn sync_state(
         &mut self,
         block_num: u32,

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -16,16 +16,35 @@ pub use tonic_client::TonicRpcClient;
 // ================================================================================================
 
 #[async_trait]
+/// This trait is mean to be used to abstract the connection between the client and the node. Since
+/// different environments (e.g a mocked client, compiling to wasm or no_std, using other crate for
+/// the communication) may require other implementations it made sense to create a trait for this
 pub trait NodeRpcClient {
-    fn new(config_endpoint: &str) -> Self;
+    /// Given a Proven Transaction, send it to the node for it to be included in a future block
     async fn submit_proven_transaction(
         &mut self,
         proven_transaction: ProvenTransaction,
     ) -> Result<(), NodeRpcClientError>;
+
+    /// Given a block number, fetch the block header corresponding to that height from the node
+    ///
+    /// When `None` is provided, returns info regarding the latest block
     async fn get_block_header_by_number(
         &mut self,
         block_number: Option<u32>,
     ) -> Result<BlockHeader, NodeRpcClientError>;
+
+    /// Fetch info from the node necessary to perform a state sync
+    ///
+    /// - `block_num` is the last block number known by the client. The returned [ StateSyncInfo ]
+    /// should contain data starting from the next block, until the first block which contains a
+    /// note of matching the requested tag, or the chain tip if there are no notes.
+    /// - `account_ids` is a list of account ids and determines the accounts the client is interested
+    /// in and should receive account updates of.
+    /// - `note_tags` is a list of tags used to filter the notes the client is interested in, which
+    /// serves as a "note group" filter. Notice that you can't filter by a specific note id
+    /// - `nullifiers_tags` similar to `note_tags`, is a list of tags used to filter the nullifiers
+    /// corresponding to some notes the client is interested in
     async fn sync_state(
         &mut self,
         block_num: u32,

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -1,0 +1,123 @@
+use crate::errors::NodeRpcClientError;
+use async_trait::async_trait;
+use core::fmt;
+use crypto::merkle::{MerklePath, MmrDelta};
+use objects::{
+    accounts::AccountId,
+    notes::{NoteId, NoteMetadata},
+    transaction::ProvenTransaction,
+    BlockHeader, Digest,
+};
+
+mod tonic_client;
+pub use tonic_client::TonicRpcClient;
+
+// NODE API TRAIT
+// ================================================================================================
+
+#[async_trait]
+pub trait NodeRpcClient {
+    fn new(config_endpoint: &str) -> Self;
+    async fn submit_proven_transaction(
+        &mut self,
+        proven_transaction: ProvenTransaction,
+    ) -> Result<(), NodeRpcClientError>;
+    async fn get_block_header_by_number(
+        &mut self,
+        block_number: Option<u32>,
+    ) -> Result<BlockHeader, NodeRpcClientError>;
+    async fn sync_state(
+        &mut self,
+        block_num: u32,
+        account_ids: &[AccountId],
+        note_tags: &[u16],
+        nullifiers_tags: &[u16],
+    ) -> Result<StateSyncInfo, NodeRpcClientError>;
+}
+
+// STATE SYNC INFO
+// ================================================================================================
+
+/// Represents a [SyncStateResponse] with fields converted into domain types
+pub struct StateSyncInfo {
+    /// The block number of the chain tip at the moment of the response
+    pub chain_tip: u32,
+    /// The returned block header
+    pub block_header: BlockHeader,
+    /// MMR delta that contains data for (current_block.num, incoming_block_header.num-1)
+    pub mmr_delta: MmrDelta,
+    /// Tuples of AccountId alongside their new account hashes
+    pub account_hash_updates: Vec<(AccountId, Digest)>,
+    /// List of tuples of Note ID, Note Index and Merkle Path for all new notes
+    pub note_inclusions: Vec<CommittedNote>,
+    /// List of nullifiers that identify spent notes
+    pub nullifiers: Vec<Digest>,
+}
+
+// COMMITTED NOTE
+// ================================================================================================
+
+/// Represents a committed note, returned as part of a [SyncStateResponse]
+pub struct CommittedNote {
+    /// Note ID of the committed note
+    note_id: NoteId,
+    /// Note index for the note merkle tree
+    note_index: u32,
+    /// Merkle path for the note merkle tree up to the block's note root
+    merkle_path: MerklePath,
+    /// Note metadata
+    metadata: NoteMetadata,
+}
+
+impl CommittedNote {
+    pub fn new(
+        note_id: NoteId,
+        note_index: u32,
+        merkle_path: MerklePath,
+        metadata: NoteMetadata,
+    ) -> Self {
+        Self {
+            note_id,
+            note_index,
+            merkle_path,
+            metadata,
+        }
+    }
+
+    pub fn note_id(&self) -> &NoteId {
+        &self.note_id
+    }
+
+    pub fn note_index(&self) -> u32 {
+        self.note_index
+    }
+
+    pub fn merkle_path(&self) -> &MerklePath {
+        &self.merkle_path
+    }
+
+    #[allow(dead_code)]
+    pub fn metadata(&self) -> NoteMetadata {
+        self.metadata
+    }
+}
+
+// RPC API ENDPOINT
+// ================================================================================================
+//
+#[derive(Debug)]
+pub enum RpcApiEndpoint {
+    GetBlockHeaderByNumber,
+    SyncState,
+    SubmitProvenTx,
+}
+
+impl fmt::Display for RpcApiEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RpcApiEndpoint::GetBlockHeaderByNumber => write!(f, "get_block_header_by_number"),
+            RpcApiEndpoint::SyncState => write!(f, "sync_state"),
+            RpcApiEndpoint::SubmitProvenTx => write!(f, "submit_proven_transaction"),
+        }
+    }
+}

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -12,7 +12,7 @@ use objects::{
 mod tonic_client;
 pub use tonic_client::TonicRpcClient;
 
-// NODE API TRAIT
+// NODE RPC CLIENT TRAIT
 // ================================================================================================
 
 /// This trait is used for communication with the miden node
@@ -127,18 +127,20 @@ impl CommittedNote {
 // ================================================================================================
 //
 #[derive(Debug)]
-pub enum RpcApiEndpoint {
+pub enum NodeRpcClientEndpoint {
     GetBlockHeaderByNumber,
     SyncState,
     SubmitProvenTx,
 }
 
-impl fmt::Display for RpcApiEndpoint {
+impl fmt::Display for NodeRpcClientEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RpcApiEndpoint::GetBlockHeaderByNumber => write!(f, "get_block_header_by_number"),
-            RpcApiEndpoint::SyncState => write!(f, "sync_state"),
-            RpcApiEndpoint::SubmitProvenTx => write!(f, "submit_proven_transaction"),
+            NodeRpcClientEndpoint::GetBlockHeaderByNumber => {
+                write!(f, "get_block_header_by_number")
+            }
+            NodeRpcClientEndpoint::SyncState => write!(f, "sync_state"),
+            NodeRpcClientEndpoint::SubmitProvenTx => write!(f, "submit_proven_transaction"),
         }
     }
 }

--- a/src/client/rpc/tonic_client.rs
+++ b/src/client/rpc/tonic_client.rs
@@ -138,17 +138,17 @@ mod client {
                 Ok(self.rpc_api.insert(rpc_api))
             }
         }
-    }
 
-    #[async_trait]
-    impl NodeRpcClient for TonicRpcClient {
-        fn new(config_endpoint: &str) -> TonicRpcClient {
+        pub fn new(config_endpoint: &str) -> TonicRpcClient {
             TonicRpcClient {
                 rpc_api: None,
                 endpoint: config_endpoint.to_string(),
             }
         }
+    }
 
+    #[async_trait]
+    impl NodeRpcClient for TonicRpcClient {
         async fn submit_proven_transaction(
             &mut self,
             proven_transaction: ProvenTransaction,

--- a/src/client/rpc/tonic_client.rs
+++ b/src/client/rpc/tonic_client.rs
@@ -16,7 +16,7 @@ use objects::{
     accounts::AccountId,
     notes::{NoteId, NoteMetadata},
     transaction::ProvenTransaction,
-    BlockHeader, Digest, Felt
+    BlockHeader, Digest, Felt,
 };
 use tonic::transport::Channel;
 

--- a/src/client/rpc_client.rs
+++ b/src/client/rpc_client.rs
@@ -174,6 +174,7 @@ mod client {
     use super::{RpcApiEndpoint, StateSyncInfo};
     use crate::client::NodeApi;
     use crate::errors::NodeApiError;
+    use async_trait::async_trait;
     use crypto::utils::Serializable;
     use miden_node_proto::{
         errors::ParseError,
@@ -206,6 +207,7 @@ mod client {
         }
     }
 
+    #[async_trait]
     impl NodeApi for RpcClient {
         fn new(config_endpoint: &str) -> RpcClient {
             RpcClient {

--- a/src/client/rpc_client.rs
+++ b/src/client/rpc_client.rs
@@ -27,7 +27,7 @@ pub struct StateSyncInfo {
 }
 
 impl TryFrom<SyncStateResponse> for StateSyncInfo {
-    type Error = RpcApiError;
+    type Error = NodeApiError;
 
     fn try_from(value: SyncStateResponse) -> Result<Self, Self::Error> {
         let chain_tip = value.chain_tip;
@@ -35,13 +35,13 @@ impl TryFrom<SyncStateResponse> for StateSyncInfo {
         // Validate and convert block header
         let block_header = value
             .block_header
-            .ok_or(RpcApiError::ExpectedFieldMissing("BlockHeader".into()))?
+            .ok_or(NodeApiError::ExpectedFieldMissing("BlockHeader".into()))?
             .try_into()?;
 
         // Validate and convert MMR Delta
         let mmr_delta = value
             .mmr_delta
-            .ok_or(RpcApiError::ExpectedFieldMissing("MmrDelta".into()))?
+            .ok_or(NodeApiError::ExpectedFieldMissing("MmrDelta".into()))?
             .try_into()?;
 
         // Validate and convert account hash updates into an (AccountId, Digest) tuple
@@ -49,13 +49,13 @@ impl TryFrom<SyncStateResponse> for StateSyncInfo {
         for update in value.accounts {
             let account_id = update
                 .account_id
-                .ok_or(RpcApiError::ExpectedFieldMissing(
+                .ok_or(NodeApiError::ExpectedFieldMissing(
                     "AccountHashUpdate.AccountId".into(),
                 ))?
                 .try_into()?;
             let account_hash = update
                 .account_hash
-                .ok_or(RpcApiError::ExpectedFieldMissing(
+                .ok_or(NodeApiError::ExpectedFieldMissing(
                     "AccountHashUpdate.AccountHash".into(),
                 ))?
                 .try_into()?;
@@ -67,13 +67,13 @@ impl TryFrom<SyncStateResponse> for StateSyncInfo {
         for note in value.notes {
             let note_id: Digest = note
                 .note_hash
-                .ok_or(RpcApiError::ExpectedFieldMissing("Notes.Id".into()))?
+                .ok_or(NodeApiError::ExpectedFieldMissing("Notes.Id".into()))?
                 .try_into()?;
             let note_id: NoteId = note_id.into();
 
             let merkle_path = note
                 .merkle_path
-                .ok_or(RpcApiError::ExpectedFieldMissing("Notes.MerklePath".into()))?
+                .ok_or(NodeApiError::ExpectedFieldMissing("Notes.MerklePath".into()))?
                 .try_into()?;
 
             let sender_account_id = note.sender.try_into()?;
@@ -92,10 +92,10 @@ impl TryFrom<SyncStateResponse> for StateSyncInfo {
                 nul_update
                     .clone()
                     .nullifier
-                    .ok_or(RpcApiError::ExpectedFieldMissing("Nullifier".into()))
-                    .and_then(|n| Digest::try_from(n).map_err(RpcApiError::ConversionFailure))
+                    .ok_or(NodeApiError::ExpectedFieldMissing("Nullifier".into()))
+                    .and_then(|n| Digest::try_from(n).map_err(|err| NodeApiError::ConversionFailure(err.to_string())))
             })
-            .collect::<Result<Vec<Digest>, RpcApiError>>()?;
+            .collect::<Result<Vec<Digest>, NodeApiError>>()?;
 
         Ok(Self {
             chain_tip,
@@ -159,23 +159,24 @@ impl CommittedNote {
 // RPC CLIENT
 // ================================================================================================
 //
-#[cfg(not(any(test, feature = "mock")))]
+// #[cfg(not(any(test, feature = "mock")))]
 pub(crate) use client::RpcClient;
 
-use crate::errors::RpcApiError;
+use crate::errors::NodeApiError;
 
-#[cfg(not(any(test, feature = "mock")))]
+// #[cfg(not(any(test, feature = "mock")))]
 mod client {
     use super::{RpcApiEndpoint, StateSyncInfo};
-    use crate::errors::RpcApiError;
+    use crate::errors::NodeApiError;
+    use crate::client::NodeApi;
+    use crypto::utils::Serializable;
     use miden_node_proto::{
         requests::{
-            GetBlockHeaderByNumberRequest, SubmitProvenTransactionRequest, SyncStateRequest,
+            SubmitProvenTransactionRequest, SyncStateRequest, GetBlockHeaderByNumberRequest,
         },
-        responses::SubmitProvenTransactionResponse,
-        rpc::api_client::ApiClient,
+        rpc::api_client::ApiClient, errors::ParseError,
     };
-    use objects::{accounts::AccountId, BlockHeader};
+    use objects::{accounts::AccountId, BlockHeader, transaction::ProvenTransaction};
     use tonic::transport::Channel;
 
     /// Wrapper for ApiClient which defers establishing a connection with a node until necessary
@@ -185,67 +186,76 @@ mod client {
     }
 
     impl RpcClient {
-        pub fn new(config_endpoint: String) -> RpcClient {
-            RpcClient {
-                rpc_api: None,
-                endpoint: config_endpoint,
+        /// Takes care of establishing the RPC connection if not connected yet and returns a reference
+        /// to the inner ApiClient
+        async fn rpc_api(&mut self) -> Result<&mut ApiClient<Channel>, NodeApiError> {
+            if self.rpc_api.is_some() {
+                Ok(self.rpc_api.as_mut().unwrap())
+            } else {
+                let rpc_api = ApiClient::connect(self.endpoint.clone())
+                    .await
+                    .map_err(|err| NodeApiError::ConnectionError(err.to_string()))?;
+                Ok(self.rpc_api.insert(rpc_api))
             }
         }
 
-        pub async fn submit_proven_transaction(
+    }
+
+    impl NodeApi for RpcClient {
+        fn new(config_endpoint: &str) -> RpcClient {
+            RpcClient {
+                rpc_api: None,
+                endpoint: config_endpoint.to_string(),
+            }
+        }
+
+        async fn submit_proven_transaction(
             &mut self,
-            request: impl tonic::IntoRequest<SubmitProvenTransactionRequest>,
-        ) -> Result<tonic::Response<SubmitProvenTransactionResponse>, RpcApiError> {
+            proven_transaction: ProvenTransaction,
+        ) -> Result<(), NodeApiError> {
+            let request = SubmitProvenTransactionRequest {
+                transaction: proven_transaction.to_bytes(),
+            };
             let rpc_api = self.rpc_api().await?;
             rpc_api
                 .submit_proven_transaction(request)
                 .await
-                .map_err(|err| RpcApiError::RequestError(RpcApiEndpoint::SubmitProvenTx, err))
+                .map_err(|err| NodeApiError::RequestError(RpcApiEndpoint::SubmitProvenTx.to_string(), err.to_string()))?;
+
+            Ok(())
         }
 
-        pub async fn get_block_header_by_number(
+        async fn get_block_header_by_number(
             &mut self,
-            request: impl tonic::IntoRequest<GetBlockHeaderByNumberRequest>,
-        ) -> Result<BlockHeader, RpcApiError> {
+            block_num: Option<u32>,
+        ) -> Result<BlockHeader, NodeApiError> {
+            let request = GetBlockHeaderByNumberRequest { block_num };
             let rpc_api = self.rpc_api().await?;
             let api_response =
                 rpc_api
                     .get_block_header_by_number(request)
                     .await
                     .map_err(|err| {
-                        RpcApiError::RequestError(RpcApiEndpoint::GetBlockHeaderByNumber, err)
+                        NodeApiError::RequestError(RpcApiEndpoint::GetBlockHeaderByNumber.to_string(), err.to_string())
                     })?;
 
             api_response
                 .into_inner()
                 .block_header
-                .ok_or(RpcApiError::ExpectedFieldMissing("BlockHeader".into()))?
+                .ok_or(NodeApiError::ExpectedFieldMissing("BlockHeader".into()))?
                 .try_into()
-                .map_err(RpcApiError::ConversionFailure)
-        }
-
-        /// Takes care of establishing the RPC connection if not connected yet and returns a reference
-        /// to the inner ApiClient
-        async fn rpc_api(&mut self) -> Result<&mut ApiClient<Channel>, RpcApiError> {
-            if self.rpc_api.is_some() {
-                Ok(self.rpc_api.as_mut().unwrap())
-            } else {
-                let rpc_api = ApiClient::connect(self.endpoint.clone())
-                    .await
-                    .map_err(RpcApiError::ConnectionError)?;
-                Ok(self.rpc_api.insert(rpc_api))
-            }
+                .map_err(|err: ParseError| NodeApiError::ConversionFailure(err.to_string()))
         }
 
         /// Sends a sync state request to the Miden node, validates and converts the response
         /// into a [StateSyncInfo] struct.
-        pub async fn sync_state(
+        async fn sync_state(
             &mut self,
             block_num: u32,
-            account_ids: &Vec<AccountId>,
+            account_ids: &[AccountId],
             note_tags: &[u16],
             nullifiers_tags: &[u16],
-        ) -> Result<StateSyncInfo, RpcApiError> {
+        ) -> Result<StateSyncInfo, NodeApiError> {
             let account_ids = account_ids.iter().map(|acc| (*acc).into()).collect();
 
             let nullifiers = nullifiers_tags
@@ -266,7 +276,7 @@ mod client {
             let response = rpc_api
                 .sync_state(request)
                 .await
-                .map_err(|err| RpcApiError::RequestError(RpcApiEndpoint::SyncState, err))?;
+                .map_err(|err| NodeApiError::RequestError(RpcApiEndpoint::SyncState.to_string(), err.to_string()))?;
             response.into_inner().try_into()
         }
     }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -1,4 +1,4 @@
-use super::{rpc_client::CommittedNote, Client, NodeRpcClient};
+use super::{rpc::CommittedNote, rpc::NodeRpcClient, Client};
 
 use crypto::merkle::{InOrderIndex, MmrDelta, MmrPeaks, PartialMmr};
 

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -1,7 +1,6 @@
-use super::{rpc_client::CommittedNote, Client};
+use super::{rpc_client::CommittedNote, Client, NodeApi};
 
 use crypto::merkle::{InOrderIndex, MmrDelta, MmrPeaks, PartialMmr};
-use miden_node_proto::requests::GetBlockHeaderByNumberRequest;
 
 use objects::{
     accounts::{AccountId, AccountStub},
@@ -27,7 +26,7 @@ pub enum SyncStatus {
 /// The number of bits to shift identifiers for in use of filters.
 pub const FILTER_ID_SHIFT: u8 = 48;
 
-impl Client {
+impl<N: NodeApi> Client<N> {
     // SYNC STATE
     // --------------------------------------------------------------------------------------------
 
@@ -84,7 +83,7 @@ impl Client {
     async fn retrieve_and_store_genesis(&mut self) -> Result<(), ClientError> {
         let genesis_block = self
             .rpc_api
-            .get_block_header_by_number(GetBlockHeaderByNumberRequest { block_num: Some(0) })
+            .get_block_header_by_number(Some(0))
             .await?;
 
         let tx = self.store.db.transaction()?;

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -136,21 +136,18 @@ impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
             return Ok(SyncStatus::SyncedToLastBlock(current_block_num));
         }
 
-        let committed_notes = <Client<N, D>>::build_inclusion_proofs(
-            self,
-            response.note_inclusions,
-            &response.block_header,
-        )?;
+        let committed_notes =
+            self.build_inclusion_proofs(response.note_inclusions, &response.block_header)?;
 
         // Check if the returned account hashes match latest account hashes in the database
         check_account_hashes(&response.account_hash_updates, &accounts)?;
 
         // Derive new nullifiers data
-        let new_nullifiers = <Client<N, D>>::get_new_nullifiers(self, response.nullifiers)?;
+        let new_nullifiers = self.get_new_nullifiers(response.nullifiers)?;
 
         // Build PartialMmr with current data and apply updates
         let (new_peaks, new_authentication_nodes) = {
-            let current_partial_mmr = <Client<N, D>>::build_current_partial_mmr(self)?;
+            let current_partial_mmr = self.build_current_partial_mmr()?;
 
             let (current_block, has_relevant_notes) =
                 self.store.get_block_header_by_num(current_block_num)?;

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -1,4 +1,4 @@
-use super::{rpc_client::CommittedNote, Client, NodeApi};
+use super::{rpc_client::CommittedNote, Client, NodeRpcClient};
 
 use crypto::merkle::{InOrderIndex, MmrDelta, MmrPeaks, PartialMmr};
 
@@ -27,7 +27,7 @@ pub enum SyncStatus {
 /// The number of bits to shift identifiers for in use of filters.
 pub const FILTER_ID_SHIFT: u8 = 48;
 
-impl<N: NodeApi, D: DataStore> Client<N, D> {
+impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
     // SYNC STATE
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -22,7 +22,7 @@ use crate::{
     store::{accounts::AuthInfo, transactions::TransactionFilter},
 };
 
-use super::{Client, NodeApi};
+use super::{Client, NodeRpcClient};
 
 // MASM SCRIPTS
 // --------------------------------------------------------------------------------------------
@@ -201,7 +201,7 @@ impl std::fmt::Display for TransactionStatus {
     }
 }
 
-impl<N: NodeApi, D: DataStore> Client<N, D> {
+impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
     // TRANSACTION DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -25,7 +25,7 @@ use crate::{
     store::{accounts::AuthInfo, transactions::TransactionFilter},
 };
 
-use super::Client;
+use super::{Client, NodeApi};
 
 // MASM SCRIPTS
 // --------------------------------------------------------------------------------------------
@@ -204,7 +204,7 @@ impl std::fmt::Display for TransactionStatus {
     }
 }
 
-impl Client {
+impl<N: NodeApi> Client<N> {
     // TRANSACTION DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
@@ -412,16 +412,12 @@ impl Client {
     async fn submit_proven_transaction_request(
         &mut self,
         proven_transaction: ProvenTransaction,
-    ) -> Result<SubmitProvenTransactionResponse, ClientError> {
-        let request = SubmitProvenTransactionRequest {
-            transaction: proven_transaction.to_bytes(),
-        };
-
+    ) -> Result<(), ClientError> {
         Ok(self
             .rpc_api
-            .submit_proven_transaction(request)
+            .submit_proven_transaction(proven_transaction)
             .await?
-            .into_inner())
+        )
     }
 
     // HELPERS

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -1,7 +1,7 @@
 use crypto::{rand::RpoRandomCoin, utils::Serializable, Felt, StarkField, Word};
 use miden_lib::notes::create_p2id_note;
 
-use miden_tx::{ProvingOptions, TransactionProver};
+use miden_tx::{DataStore, ProvingOptions, TransactionProver};
 
 use mock::procedures::prepare_word;
 use objects::{
@@ -201,7 +201,7 @@ impl std::fmt::Display for TransactionStatus {
     }
 }
 
-impl<N: NodeApi> Client<N> {
+impl<N: NodeApi, D: DataStore> Client<N, D> {
     // TRANSACTION DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
@@ -272,9 +272,9 @@ impl<N: NodeApi> Client<N> {
         // Construct Account
         self.tx_executor.load_account(faucet_id)?;
 
-        let block_ref = Client::<N>::get_sync_height(self)?;
+        let block_ref = Client::<N, D>::get_sync_height(self)?;
 
-        let random_coin = Client::<N>::get_random_coin(self);
+        let random_coin = Client::<N, D>::get_random_coin(self);
 
         let created_note = create_p2id_note(faucet_id, target_id, vec![asset.into()], random_coin)?;
 
@@ -311,7 +311,7 @@ impl<N: NodeApi> Client<N> {
         sender_account_id: AccountId,
         target_account_id: AccountId,
     ) -> Result<TransactionResult, ClientError> {
-        let random_coin = Client::<N>::get_random_coin(self);
+        let random_coin = Client::<N, D>::get_random_coin(self);
 
         let created_note = create_p2id_note(
             sender_account_id,
@@ -322,7 +322,7 @@ impl<N: NodeApi> Client<N> {
 
         self.tx_executor.load_account(sender_account_id)?;
 
-        let block_ref = Client::<N>::get_sync_height(self)?;
+        let block_ref = Client::<N, D>::get_sync_height(self)?;
 
         let recipient = created_note
             .recipient()
@@ -359,7 +359,7 @@ impl<N: NodeApi> Client<N> {
         tx_script: ProgramAst,
         block_num: u32,
     ) -> Result<TransactionResult, ClientError> {
-        let account_auth = Client::<N>::get_account_auth(self, account_id)?;
+        let account_auth = Client::<N, D>::get_account_auth(self, account_id)?;
         let (pubkey_input, advice_map): (Word, Vec<Felt>) = match account_auth {
             AuthInfo::RpoFalcon512(key) => (
                 key.public_key().into(),

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -272,9 +272,9 @@ impl<N: NodeApi, D: DataStore> Client<N, D> {
         // Construct Account
         self.tx_executor.load_account(faucet_id)?;
 
-        let block_ref = Client::<N, D>::get_sync_height(self)?;
+        let block_ref = Self::get_sync_height(self)?;
 
-        let random_coin = Client::<N, D>::get_random_coin(self);
+        let random_coin = Self::get_random_coin(self);
 
         let created_note = create_p2id_note(faucet_id, target_id, vec![asset.into()], random_coin)?;
 
@@ -311,7 +311,7 @@ impl<N: NodeApi, D: DataStore> Client<N, D> {
         sender_account_id: AccountId,
         target_account_id: AccountId,
     ) -> Result<TransactionResult, ClientError> {
-        let random_coin = Client::<N, D>::get_random_coin(self);
+        let random_coin = Self::get_random_coin(self);
 
         let created_note = create_p2id_note(
             sender_account_id,
@@ -322,7 +322,7 @@ impl<N: NodeApi, D: DataStore> Client<N, D> {
 
         self.tx_executor.load_account(sender_account_id)?;
 
-        let block_ref = Client::<N, D>::get_sync_height(self)?;
+        let block_ref = Self::get_sync_height(self)?;
 
         let recipient = created_note
             .recipient()
@@ -359,7 +359,7 @@ impl<N: NodeApi, D: DataStore> Client<N, D> {
         tx_script: ProgramAst,
         block_num: u32,
     ) -> Result<TransactionResult, ClientError> {
-        let account_auth = Client::<N, D>::get_account_auth(self, account_id)?;
+        let account_auth = Self::get_account_auth(self, account_id)?;
         let (pubkey_input, advice_map): (Word, Vec<Felt>) = match account_auth {
             AuthInfo::RpoFalcon512(key) => (
                 key.public_key().into(),

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -22,7 +22,7 @@ use crate::{
     store::{accounts::AuthInfo, transactions::TransactionFilter},
 };
 
-use super::{Client, NodeRpcClient};
+use super::{rpc::NodeRpcClient, Client};
 
 // MASM SCRIPTS
 // --------------------------------------------------------------------------------------------

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -272,9 +272,8 @@ impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
         // Construct Account
         self.tx_executor.load_account(faucet_id)?;
 
-        let block_ref = Self::get_sync_height(self)?;
-
-        let random_coin = Self::get_random_coin(self);
+        let block_ref = self.get_sync_height()?;
+        let random_coin = self.get_random_coin();
 
         let created_note = create_p2id_note(faucet_id, target_id, vec![asset.into()], random_coin)?;
 
@@ -311,7 +310,7 @@ impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
         sender_account_id: AccountId,
         target_account_id: AccountId,
     ) -> Result<TransactionResult, ClientError> {
-        let random_coin = Self::get_random_coin(self);
+        let random_coin = self.get_random_coin();
 
         let created_note = create_p2id_note(
             sender_account_id,
@@ -322,7 +321,7 @@ impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
 
         self.tx_executor.load_account(sender_account_id)?;
 
-        let block_ref = Self::get_sync_height(self)?;
+        let block_ref = self.get_sync_height()?;
 
         let recipient = created_note
             .recipient()
@@ -359,7 +358,7 @@ impl<N: NodeRpcClient, D: DataStore> Client<N, D> {
         tx_script: ProgramAst,
         block_num: u32,
     ) -> Result<TransactionResult, ClientError> {
-        let account_auth = Self::get_account_auth(self, account_id)?;
+        let account_auth = self.get_account_auth(account_id)?;
         let (pubkey_input, advice_map): (Word, Vec<Felt>) = match account_auth {
             AuthInfo::RpoFalcon512(key) => (
                 key.public_key().into(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,6 @@ use objects::{
     accounts::AccountId, notes::NoteId, AccountError, AssetVaultError, Digest, NoteError,
     TransactionScriptError,
 };
-use tonic::{transport::Error as TransportError, Status as TonicStatus};
 
 // CLIENT ERROR
 // ================================================================================================
@@ -22,7 +21,7 @@ pub enum ClientError {
     ImportNewAccountWithoutSeed,
     NoteError(NoteError),
     NoConsumableNoteForAccount(AccountId),
-    RpcApiError(RpcApiError),
+    NodeApiError(NodeApiError),
     StoreError(StoreError),
     TransactionExecutionError(TransactionExecutorError),
     TransactionProvingError(TransactionProverError),
@@ -41,7 +40,7 @@ impl fmt::Display for ClientError {
                 write!(f, "No consumable note for account ID {}", account_id)
             }
             ClientError::NoteError(err) => write!(f, "note error: {err}"),
-            ClientError::RpcApiError(err) => write!(f, "rpc api error: {err}"),
+            ClientError::NodeApiError(err) => write!(f, "rpc api error: {err}"),
             ClientError::StoreError(err) => write!(f, "store error: {err}"),
             ClientError::TransactionExecutionError(err) => {
                 write!(f, "transaction executor error: {err}")
@@ -74,9 +73,9 @@ impl From<NoteError> for ClientError {
     }
 }
 
-impl From<RpcApiError> for ClientError {
-    fn from(err: RpcApiError) -> Self {
-        Self::RpcApiError(err)
+impl From<NodeApiError> for ClientError {
+    fn from(err: NodeApiError) -> Self {
+        Self::NodeApiError(err)
     }
 }
 
@@ -289,50 +288,48 @@ impl std::error::Error for StoreError {}
 // API CLIENT ERROR
 // ================================================================================================
 
-use crate::client::RpcApiEndpoint;
-
 #[derive(Debug)]
-pub enum RpcApiError {
-    ConnectionError(TransportError),
-    ConversionFailure(ParseError),
+pub enum NodeApiError {
+    ConnectionError(String),
+    ConversionFailure(String),
     ExpectedFieldMissing(String),
-    InvalidAccountReceived(AccountError),
-    RequestError(RpcApiEndpoint, TonicStatus),
+    InvalidAccountReceived(String),
+    RequestError(String, String),
 }
 
-impl fmt::Display for RpcApiError {
+impl fmt::Display for NodeApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RpcApiError::ConnectionError(err) => {
+            NodeApiError::ConnectionError(err) => {
                 write!(f, "failed to connect to the API server: {err}")
             }
-            RpcApiError::ConversionFailure(err) => {
+            NodeApiError::ConversionFailure(err) => {
                 write!(f, "failed to convert RPC data: {err}")
             }
-            RpcApiError::ExpectedFieldMissing(err) => {
+            NodeApiError::ExpectedFieldMissing(err) => {
                 write!(f, "rpc API reponse missing an expected field: {err}")
             }
-            RpcApiError::InvalidAccountReceived(account_error) => {
+            NodeApiError::InvalidAccountReceived(account_error) => {
                 write!(
                     f,
                     "rpc API reponse contained an invalid account: {account_error}"
                 )
             }
-            RpcApiError::RequestError(endpoint, err) => {
+            NodeApiError::RequestError(endpoint, err) => {
                 write!(f, "rpc request failed for {endpoint}: {err}")
             }
         }
     }
 }
 
-impl From<ParseError> for RpcApiError {
+impl From<ParseError> for NodeApiError {
     fn from(err: ParseError) -> Self {
-        Self::ConversionFailure(err)
+        Self::ConversionFailure(err.to_string())
     }
 }
 
-impl From<AccountError> for RpcApiError {
+impl From<AccountError> for NodeApiError {
     fn from(err: AccountError) -> Self {
-        Self::InvalidAccountReceived(err)
+        Self::InvalidAccountReceived(err.to_string())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,7 +21,7 @@ pub enum ClientError {
     ImportNewAccountWithoutSeed,
     NoteError(NoteError),
     NoConsumableNoteForAccount(AccountId),
-    NodeApiError(NodeApiError),
+    NodeRpcClientError(NodeRpcClientError),
     StoreError(StoreError),
     TransactionExecutionError(TransactionExecutorError),
     TransactionProvingError(TransactionProverError),
@@ -40,7 +40,7 @@ impl fmt::Display for ClientError {
                 write!(f, "No consumable note for account ID {}", account_id)
             }
             ClientError::NoteError(err) => write!(f, "note error: {err}"),
-            ClientError::NodeApiError(err) => write!(f, "rpc api error: {err}"),
+            ClientError::NodeRpcClientError(err) => write!(f, "rpc api error: {err}"),
             ClientError::StoreError(err) => write!(f, "store error: {err}"),
             ClientError::TransactionExecutionError(err) => {
                 write!(f, "transaction executor error: {err}")
@@ -73,9 +73,9 @@ impl From<NoteError> for ClientError {
     }
 }
 
-impl From<NodeApiError> for ClientError {
-    fn from(err: NodeApiError) -> Self {
-        Self::NodeApiError(err)
+impl From<NodeRpcClientError> for ClientError {
+    fn from(err: NodeRpcClientError) -> Self {
+        Self::NodeRpcClientError(err)
     }
 }
 
@@ -289,7 +289,7 @@ impl std::error::Error for StoreError {}
 // ================================================================================================
 
 #[derive(Debug)]
-pub enum NodeApiError {
+pub enum NodeRpcClientError {
     ConnectionError(String),
     ConversionFailure(String),
     ExpectedFieldMissing(String),
@@ -297,38 +297,38 @@ pub enum NodeApiError {
     RequestError(String, String),
 }
 
-impl fmt::Display for NodeApiError {
+impl fmt::Display for NodeRpcClientError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NodeApiError::ConnectionError(err) => {
+            NodeRpcClientError::ConnectionError(err) => {
                 write!(f, "failed to connect to the API server: {err}")
             }
-            NodeApiError::ConversionFailure(err) => {
+            NodeRpcClientError::ConversionFailure(err) => {
                 write!(f, "failed to convert RPC data: {err}")
             }
-            NodeApiError::ExpectedFieldMissing(err) => {
+            NodeRpcClientError::ExpectedFieldMissing(err) => {
                 write!(f, "rpc API reponse missing an expected field: {err}")
             }
-            NodeApiError::InvalidAccountReceived(account_error) => {
+            NodeRpcClientError::InvalidAccountReceived(account_error) => {
                 write!(
                     f,
                     "rpc API reponse contained an invalid account: {account_error}"
                 )
             }
-            NodeApiError::RequestError(endpoint, err) => {
+            NodeRpcClientError::RequestError(endpoint, err) => {
                 write!(f, "rpc request failed for {endpoint}: {err}")
             }
         }
     }
 }
 
-impl From<ParseError> for NodeApiError {
+impl From<ParseError> for NodeRpcClientError {
     fn from(err: ParseError) -> Self {
         Self::ConversionFailure(err.to_string())
     }
 }
 
-impl From<AccountError> for NodeApiError {
+impl From<AccountError> for NodeRpcClientError {
     fn from(err: AccountError) -> Self {
         Self::InvalidAccountReceived(err.to_string())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[allow(async_fn_in_trait)]
 pub mod client;
 pub mod config;
 pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[allow(async_fn_in_trait)]
 pub mod client;
 pub mod config;
 pub mod errors;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -12,6 +12,7 @@ use crypto::{
     merkle::{NodeIndex, SimpleSmt},
     Felt, FieldElement, StarkField,
 };
+use async_trait::async_trait;
 use miden_lib::transaction::TransactionKernel;
 use miden_node_proto::{
     account::AccountId as ProtoAccountId,
@@ -65,6 +66,7 @@ impl Default for MockRpcApi {
     }
 }
 
+#[async_trait]
 impl NodeApi for MockRpcApi {
     fn new(_config_endpoint: &str) -> Self {
         Self::default()

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::{
-        rpc::{NodeRpcClient, RpcApiEndpoint, StateSyncInfo},
+        rpc::{NodeRpcClient, NodeRpcClientEndpoint, StateSyncInfo},
         sync::FILTER_ID_SHIFT,
         transactions::{PaymentTransactionData, TransactionTemplate},
         Client,
@@ -96,7 +96,7 @@ impl NodeRpcClient for MockRpcApi {
                 Ok(Response::new(response))
             }
             None => Err(NodeRpcClientError::RequestError(
-                RpcApiEndpoint::SyncState.to_string(),
+                NodeRpcClientEndpoint::SyncState.to_string(),
                 Status::not_found("no response for sync state request").to_string(),
             )),
         }?;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -7,12 +7,12 @@ use crate::{
     },
     errors::NodeApiError,
 };
+use async_trait::async_trait;
 use crypto::{
     dsa::rpo_falcon512::KeyPair,
     merkle::{NodeIndex, SimpleSmt},
     Felt, FieldElement, StarkField,
 };
-use async_trait::async_trait;
 use miden_lib::transaction::TransactionKernel;
 use miden_node_proto::{
     account::AccountId as ProtoAccountId,
@@ -37,7 +37,7 @@ use objects::{
     notes::{Note, NoteInclusionProof},
     transaction::{InputNote, ProvenTransaction},
     utils::collections::BTreeMap,
-    BlockHeader, NOTE_TREE_DEPTH, Digest
+    BlockHeader, NOTE_TREE_DEPTH,
 };
 use tonic::{IntoRequest, Response, Status};
 
@@ -308,7 +308,7 @@ fn mock_full_chain_mmr_and_notes(
 
 /// inserts mock note and account data into the client and returns the last block header of mocked
 /// chain
-pub async fn insert_mock_data(client: &mut Client) -> Vec<BlockHeader> {
+pub async fn insert_mock_data(client: &mut Client<MockRpcApi, MockDataStore>) -> Vec<BlockHeader> {
     // mock notes
     let assembler = TransactionKernel::assembler();
     let (account_id, account_seed) =

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -3,7 +3,7 @@ use crate::{
         rpc_client::StateSyncInfo,
         sync::FILTER_ID_SHIFT,
         transactions::{PaymentTransactionData, TransactionTemplate},
-        Client, RpcApiEndpoint, NodeApi,
+        Client, NodeApi, RpcApiEndpoint,
     },
     errors::NodeApiError,
 };
@@ -17,8 +17,8 @@ use miden_node_proto::{
     account::AccountId as ProtoAccountId,
     block_header::BlockHeader as NodeBlockHeader,
     note::NoteSyncRecord,
-    requests::{GetBlockHeaderByNumberRequest, SubmitProvenTransactionRequest, SyncStateRequest},
-    responses::{NullifierUpdate, SubmitProvenTransactionResponse, SyncStateResponse},
+    requests::{GetBlockHeaderByNumberRequest, SyncStateRequest},
+    responses::{NullifierUpdate, SyncStateResponse},
 };
 use mock::{
     constants::{generate_account_seed, AccountSeedType},
@@ -65,7 +65,7 @@ impl NodeApi for MockRpcApi {
     fn new(_config_endpoint: &str) -> Self {
         Self::default()
     }
-    
+
     /// Executes the specified sync state request and returns the response.
     async fn sync_state(
         &mut self,
@@ -342,7 +342,7 @@ pub async fn insert_mock_data(client: &mut Client) -> Vec<BlockHeader> {
     tracked_block_headers
 }
 
-pub async fn create_mock_transaction(client: &mut Client) {
+pub async fn create_mock_transaction(client: &mut Client<MockRpcApi>) {
     let key_pair: KeyPair = KeyPair::new()
         .map_err(|err| format!("Error generating KeyPair: {}", err))
         .unwrap();
@@ -432,7 +432,7 @@ pub async fn create_mock_transaction(client: &mut Client) {
 }
 
 #[cfg(test)]
-impl Client {
+impl<N: NodeApi> Client<N> {
     /// Helper function to set a data store to conveniently mock data for tests
     pub fn set_data_store(
         &mut self,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -66,12 +66,14 @@ impl Default for MockRpcApi {
     }
 }
 
-#[async_trait]
-impl NodeRpcClient for MockRpcApi {
-    fn new(_config_endpoint: &str) -> Self {
+impl MockRpcApi {
+    pub fn new(_config_endpoint: &str) -> Self {
         Self::default()
     }
+}
 
+#[async_trait]
+impl NodeRpcClient for MockRpcApi {
     /// Executes the specified sync state request and returns the response.
     async fn sync_state(
         &mut self,

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,9 +1,9 @@
 use crate::{
     client::{
-        rpc_client::StateSyncInfo,
+        rpc::{NodeRpcClient, RpcApiEndpoint, StateSyncInfo},
         sync::FILTER_ID_SHIFT,
         transactions::{PaymentTransactionData, TransactionTemplate},
-        Client, NodeRpcClient, RpcApiEndpoint,
+        Client,
     },
     errors::NodeRpcClientError,
 };

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -51,8 +51,6 @@ pub mod tests {
         mock::{MockDataStore, MockRpcApi},
     };
 
-    use crate::client::rpc::NodeRpcClient;
-
     use super::{migrations, Store};
 
     pub fn create_test_client() -> Client<MockRpcApi, MockDataStore> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -51,7 +51,7 @@ pub mod tests {
         mock::{MockDataStore, MockRpcApi},
     };
 
-    use crate::client::NodeApi;
+    use crate::client::NodeRpcClient;
 
     use super::{migrations, Store};
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -48,14 +48,14 @@ pub mod tests {
     use crate::{
         client::Client,
         config::{ClientConfig, RpcConfig},
-        mock::MockRpcApi,
+        mock::{MockDataStore, MockRpcApi},
     };
 
     use crate::client::NodeApi;
 
     use super::{migrations, Store};
 
-    pub fn create_test_client() -> Client<MockRpcApi> {
+    pub fn create_test_client() -> Client<MockRpcApi, MockDataStore> {
         let client_config = ClientConfig {
             store: create_test_store_path()
                 .into_os_string()
@@ -68,7 +68,12 @@ pub mod tests {
 
         let rpc_endpoint = client_config.rpc.endpoint.to_string();
 
-        Client::<MockRpcApi>::new(client_config, MockRpcApi::new(&rpc_endpoint)).unwrap()
+        Client::<MockRpcApi, MockDataStore>::new(
+            client_config,
+            MockRpcApi::new(&rpc_endpoint),
+            MockDataStore::new(),
+        )
+        .unwrap()
     }
 
     pub(crate) fn create_test_store_path() -> std::path::PathBuf {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -48,11 +48,14 @@ pub mod tests {
     use crate::{
         client::Client,
         config::{ClientConfig, RpcConfig},
+        mock::MockRpcApi,
     };
+
+    use crate::client::NodeApi;
 
     use super::{migrations, Store};
 
-    pub fn create_test_client() -> Client {
+    pub fn create_test_client() -> Client<MockRpcApi> {
         let client_config = ClientConfig {
             store: create_test_store_path()
                 .into_os_string()
@@ -63,7 +66,9 @@ pub mod tests {
             rpc: RpcConfig::default(),
         };
 
-        Client::new(client_config).unwrap()
+        let rpc_endpoint = client_config.rpc.endpoint.to_string();
+
+        Client::<MockRpcApi>::new(client_config, MockRpcApi::new(&rpc_endpoint)).unwrap()
     }
 
     pub(crate) fn create_test_store_path() -> std::path::PathBuf {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -51,7 +51,7 @@ pub mod tests {
         mock::{MockDataStore, MockRpcApi},
     };
 
-    use crate::client::NodeRpcClient;
+    use crate::client::rpc::NodeRpcClient;
 
     use super::{migrations, Store};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -327,7 +327,7 @@ async fn test_sync_state_mmr_state() {
     assert_eq!(
         block_num,
         client
-            .rpc_api
+            .rpc_api()
             .state_sync_requests
             .first_key_value()
             .unwrap()
@@ -339,7 +339,7 @@ async fn test_sync_state_mmr_state() {
     assert_eq!(
         client.get_sync_height().unwrap(),
         client
-            .rpc_api
+            .rpc_api()
             .state_sync_requests
             .first_key_value()
             .unwrap()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -276,7 +276,7 @@ async fn test_sync_state() {
     assert_eq!(
         block_num,
         client
-            .rpc_api
+            .rpc_api()
             .state_sync_requests
             .first_key_value()
             .unwrap()
@@ -303,7 +303,7 @@ async fn test_sync_state() {
     assert_eq!(
         client.get_sync_height().unwrap(),
         client
-            .rpc_api
+            .rpc_api()
             .state_sync_requests
             .first_key_value()
             .unwrap()
@@ -441,7 +441,7 @@ async fn test_mint_transaction() {
         .map_err(|err| format!("Error generating KeyPair: {}", err))
         .unwrap();
     client
-        .store
+        .store()
         .insert_account(&faucet, FAUCET_SEED, &AuthInfo::RpoFalcon512(key_pair))
         .unwrap();
     client.set_data_store(MockDataStore::with_existing(faucet.clone(), None, None));


### PR DESCRIPTION
closes #145 

This PR does 2 things:

- introduces the `NodeApi` trait, which provides an interface with the operations used by the client to interact with the node's rpc api
  - the trait contains async functions which caused a warning to trigger which I disabled with `#[allow(async_fn_in_trait)]`
- changes the `Client` implementation to include said trait and make `RpcClient` and `MockRpcApi` implement `NodeApi`
  - In this first iteration I went with using generics as I think it's usually recommended, it can be used in no_std / wasm targets without issues (I'm not sure about trait objects), and it's overall faster. However it made it more cumbersome to implement as I had to add generics all over the place, even in places like `client/transaction.rs` where I had to change `let random_coin = self.get_random_coin();` for `let random_coin = Client::<N>::get_random_coin(self);`. I don't know if there is a preference for either trait objects / generics, but it seems that trait objects would be easier to manage.
  
  
Regarding the consideration of trait objects vs generics, I made another branch at `mFragaBA-add-rpc-client-trait-object` so we can compare possible implementations