### PR TITLE
fix: fix mocked fungible faucet generation for tests

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -12,7 +12,7 @@ use crypto::{
     merkle::{NodeIndex, SimpleSmt},
     Felt, FieldElement, StarkField,
 };
-use miden_lib::transaction::TransactionKernel;
+use miden_lib::{transaction::TransactionKernel, AuthScheme};
 use miden_node_proto::{
     account::AccountId as ProtoAccountId,
     block_header::BlockHeader as NodeBlockHeader,
@@ -30,12 +30,15 @@ use mock::mock::{
     notes::{mock_notes, AssetPreservationStatus},
 };
 use objects::{
+    accounts::{Account, AccountStorage, StorageSlotType},
+    assets::{AssetVault, TokenSymbol},
     crypto::merkle::{Mmr, MmrDelta},
     notes::{Note, NoteInclusionProof},
     transaction::InputNote,
     utils::collections::BTreeMap,
     BlockHeader, NOTE_TREE_DEPTH,
 };
+use rand::Rng;
 use tonic::{IntoRequest, Response, Status};
 
 use crate::store::accounts::AuthInfo;
@@ -428,6 +431,60 @@ pub async fn create_mock_transaction(client: &mut Client) {
         .send_transaction(transaction_execution_result)
         .await
         .unwrap();
+}
+
+pub fn mock_fungible_faucet_account(
+    id: AccountId,
+    initial_balance: u64,
+    key_pair: KeyPair,
+) -> Account {
+    let mut rng = rand::thread_rng();
+    let init_seed: [u8; 32] = rng.gen();
+    let auth_scheme: AuthScheme = AuthScheme::RpoFalcon512 {
+        pub_key: key_pair.public_key(),
+    };
+
+    let (faucet, _seed) = miden_lib::accounts::faucets::create_basic_fungible_faucet(
+        init_seed,
+        TokenSymbol::new("TST").unwrap(),
+        10u8,
+        Felt::try_from(initial_balance.to_le_bytes().as_slice())
+            .expect("u64 can be safely converted to a field element"),
+        auth_scheme,
+    )
+    .unwrap();
+
+    let faucet_storage_slot_1 = [
+        Felt::new(initial_balance),
+        Felt::new(0),
+        Felt::new(0),
+        Felt::new(0),
+    ];
+    let faucet_account_storage = AccountStorage::new(vec![
+        (
+            0,
+            (
+                StorageSlotType::Value { value_arity: 0 },
+                key_pair.public_key().into(),
+            ),
+        ),
+        (
+            1,
+            (
+                StorageSlotType::Value { value_arity: 0 },
+                faucet_storage_slot_1,
+            ),
+        ),
+    ])
+    .unwrap();
+
+    Account::new(
+        id,
+        AssetVault::new(&[]).unwrap(),
+        faucet_account_storage.clone(),
+        faucet.code().clone(),
+        Felt::new(10u64),
+    )
 }
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,7 @@ use crate::{
         accounts::{AccountStorageMode, AccountTemplate},
         transactions::TransactionTemplate,
     },
+    mock::mock_fungible_faucet_account,
     store::{
         accounts::AuthInfo,
         mock_executor_data_store::MockDataStore,
@@ -19,7 +20,7 @@ use miden_lib::transaction::TransactionKernel;
 use mock::{
     constants::{generate_account_seed, AccountSeedType},
     mock::{
-        account::{self, mock_account, MockAccountType},
+        account::{self, MockAccountType},
         notes::AssetPreservationStatus,
         transaction::mock_inputs,
     },
@@ -413,41 +414,37 @@ async fn test_add_tag() {
 }
 
 #[tokio::test]
-#[ignore = "currently fails with PhantomCallsNotAllowed"]
 async fn test_mint_transaction() {
     const FAUCET_ID: u64 = 10347894387879516201u64;
     const FAUCET_SEED: Word = [Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    const INITIAL_BALANCE: u64 = 1000;
 
     // generate test client with a random store name
     let mut client = create_test_client();
 
-    let (faucet, _seed) = client
-        .new_account(AccountTemplate::FungibleFaucet {
-            token_symbol: TokenSymbol::new("TST").unwrap(),
-            decimals: 10u8,
-            max_supply: 1000u64,
-            storage_mode: AccountStorageMode::Local,
-        })
-        .unwrap();
-
-    let faucet = mock_account(
-        Some(FAUCET_ID),
-        Felt::new(10u64),
-        Some(faucet.code().clone()),
-        &TransactionKernel::assembler(),
-    );
-
+    // Faucet account generation
     let key_pair: KeyPair = KeyPair::new()
         .map_err(|err| format!("Error generating KeyPair: {}", err))
         .unwrap();
+
+    let faucet = mock_fungible_faucet_account(
+        AccountId::try_from(FAUCET_ID).unwrap(),
+        INITIAL_BALANCE,
+        key_pair,
+    );
+
     client
         .store
         .insert_account(&faucet, FAUCET_SEED, &AuthInfo::RpoFalcon512(key_pair))
         .unwrap();
-    client.set_data_store(MockDataStore::with_existing(faucet.clone(), None, None));
+
+    client.set_data_store(MockDataStore::with_existing(
+        faucet.clone(),
+        None,
+        Some(vec![]),
+    ));
 
     // Test submitting a mint transaction
-
     let transaction_template = TransactionTemplate::MintFungibleAsset {
         asset: FungibleAsset::new(faucet.id(), 5u64).unwrap(),
         target_account_id: AccountId::from_hex("0x168187d729b31a84").unwrap(),


### PR DESCRIPTION
We had the test for the mint transaction ignored, because it fails with a `PhantomCallsNotAllowed` error. After some debugging I found out the way we were mocking the data store was wrong as it was returning input notes where it shouldn't. I found more errors after fixing that, so I ended up doing something similar to what is done in miden-tx to mock the fungible faucet account.

