### PR TITLE
Update code to be compatible with Winterfell 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ testing = ["objects/testing", "miden_lib/testing"]
 assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 clap = { version = "4.3", features = ["derive"] }
 comfy-table = "7.1.0"
-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+crypto = { package = "miden-crypto", version = "0.8", default-features = false }
 figment = { version = "0.10", features = ["toml", "env"] }
 lazy_static = "1.4.0"
 miden_lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base", branch = "main", default-features = false }

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -3,7 +3,7 @@ use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use crypto::{
     dsa::rpo_falcon512::KeyPair,
     utils::{bytes_to_hex_string, Deserializable, Serializable},
-    StarkField, ZERO,
+    ZERO,
 };
 use miden_client::client::{accounts, Client};
 

--- a/src/client/rpc_client.rs
+++ b/src/client/rpc_client.rs
@@ -1,5 +1,8 @@
 use core::fmt;
-use crypto::merkle::{MerklePath, MmrDelta};
+use crypto::{
+    merkle::{MerklePath, MmrDelta},
+    utils::DeserializationError,
+};
 use miden_node_proto::generated::responses::SyncStateResponse;
 use objects::{
     accounts::AccountId,
@@ -84,7 +87,7 @@ impl TryFrom<SyncStateResponse> for StateSyncInfo {
                 sender_account_id,
                 note.tag
                     .try_into()
-                    .expect("tag value is greater than or equal to the field modulus"),
+                    .map_err(DeserializationError::InvalidValue)?,
             );
 
             let committed_note =

--- a/src/client/rpc_client.rs
+++ b/src/client/rpc_client.rs
@@ -80,7 +80,12 @@ impl TryFrom<SyncStateResponse> for StateSyncInfo {
                 .sender
                 .ok_or(RpcApiError::ExpectedFieldMissing("Notes.Sender".into()))?
                 .try_into()?;
-            let metadata = NoteMetadata::new(sender_account_id, note.tag.into());
+            let metadata = NoteMetadata::new(
+                sender_account_id,
+                note.tag
+                    .try_into()
+                    .expect("tag value is greater than or equal to the field modulus"),
+            );
 
             let committed_note =
                 CommittedNote::new(note_id, note.note_index, merkle_path, metadata);

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -7,7 +7,7 @@ use objects::{
     accounts::{AccountId, AccountStub},
     crypto,
     notes::{NoteId, NoteInclusionProof},
-    BlockHeader, Digest, StarkField,
+    BlockHeader, Digest,
 };
 
 use crate::{

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -13,7 +13,8 @@ use objects::{
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteId},
     transaction::{
-        ExecutedTransaction, OutputNote, OutputNotes, ProvenTransaction, TransactionScript,
+        ExecutedTransaction, OutputNote, OutputNotes, ProvenTransaction, TransactionArgs,
+        TransactionScript,
     },
     Digest,
 };
@@ -130,8 +131,8 @@ impl TransactionResult {
         self.executed_transaction.block_header().block_num()
     }
 
-    pub fn transaction_script(&self) -> Option<&TransactionScript> {
-        self.executed_transaction.tx_script()
+    pub fn transaction_arguments(&self) -> &TransactionArgs {
+        self.executed_transaction.tx_args()
     }
 
     pub fn account_delta(&self) -> &AccountDelta {
@@ -377,12 +378,14 @@ impl Client {
             .tx_executor
             .compile_tx_script(tx_script, script_inputs, vec![])?;
 
+        let tx_args = TransactionArgs::with_tx_script(tx_script);
+
         // Execute the transaction and get the witness
         let executed_transaction = self.tx_executor.execute_transaction(
             account_id,
             block_num,
             input_notes,
-            Some(tx_script),
+            Some(tx_args),
         )?;
 
         Ok(TransactionResult::new(executed_transaction, output_notes))

--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -1,4 +1,4 @@
-use crypto::{rand::RpoRandomCoin, utils::Serializable, Felt, StarkField, Word};
+use crypto::{rand::RpoRandomCoin, utils::Serializable, Felt, Word};
 use miden_lib::notes::create_p2id_note;
 use miden_node_proto::generated::{
     requests::SubmitProvenTransactionRequest, responses::SubmitProvenTransactionResponse,
@@ -433,6 +433,6 @@ impl Client {
         let mut rng = rand::thread_rng();
         let coin_seed: [u64; 4] = rng.gen();
 
-        RpoRandomCoin::new(coin_seed.map(|x| x.into()))
+        RpoRandomCoin::new(coin_seed.map(Felt::new))
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -295,6 +295,7 @@ use crate::client::RpcApiEndpoint;
 pub enum RpcApiError {
     ConnectionError(TransportError),
     ConversionFailure(ParseError),
+    DeserializationError(DeserializationError),
     ExpectedFieldMissing(String),
     InvalidAccountReceived(AccountError),
     RequestError(RpcApiEndpoint, TonicStatus),
@@ -308,6 +309,9 @@ impl fmt::Display for RpcApiError {
             }
             RpcApiError::ConversionFailure(err) => {
                 write!(f, "failed to convert RPC data: {err}")
+            }
+            RpcApiError::DeserializationError(err) => {
+                write!(f, "failed to deserialize RPC data: {err}")
             }
             RpcApiError::ExpectedFieldMissing(err) => {
                 write!(f, "rpc API reponse missing an expected field: {err}")
@@ -325,14 +329,20 @@ impl fmt::Display for RpcApiError {
     }
 }
 
-impl From<ParseError> for RpcApiError {
-    fn from(err: ParseError) -> Self {
-        Self::ConversionFailure(err)
-    }
-}
-
 impl From<AccountError> for RpcApiError {
     fn from(err: AccountError) -> Self {
         Self::InvalidAccountReceived(err)
+    }
+}
+
+impl From<DeserializationError> for RpcApiError {
+    fn from(err: DeserializationError) -> Self {
+        Self::DeserializationError(err)
+    }
+}
+
+impl From<ParseError> for RpcApiError {
+    fn from(err: ParseError) -> Self {
+        Self::ConversionFailure(err)
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -10,7 +10,7 @@ use crate::{
 use crypto::{
     dsa::rpo_falcon512::KeyPair,
     merkle::{NodeIndex, SimpleSmt},
-    Felt, FieldElement, StarkField,
+    Felt, FieldElement,
 };
 use miden_lib::{transaction::TransactionKernel, AuthScheme};
 use miden_node_proto::generated::{

--- a/src/store/accounts.rs
+++ b/src/store/accounts.rs
@@ -7,7 +7,7 @@ use crypto::{
     dsa::rpo_falcon512::KeyPair,
     hash::rpo::RpoDigest,
     utils::{Deserializable, Serializable},
-    StarkField, Word,
+    Felt, Word,
 };
 use miden_lib::transaction::TransactionKernel;
 use objects::{
@@ -379,7 +379,7 @@ pub(crate) fn parse_accounts(
             (id as u64)
                 .try_into()
                 .expect("Conversion from stored AccountID should not panic"),
-            (nonce as u64).into(),
+            Felt::new(nonce as u64),
             serde_json::from_str(&vault_root).map_err(StoreError::JsonDataDeserializationError)?,
             Digest::try_from(&storage_root)?,
             Digest::try_from(&code_root)?,

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -88,8 +88,8 @@ impl InputNoteRecord {
 
 impl Serializable for InputNoteRecord {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(self.note().to_bytes());
-        target.write(self.inclusion_proof.to_bytes());
+        self.note().write_into(target);
+        self.inclusion_proof.write_into(target);
     }
 }
 
@@ -97,8 +97,8 @@ impl Deserializable for InputNoteRecord {
     fn read_from<R: ByteReader>(
         source: &mut R,
     ) -> std::prelude::v1::Result<Self, DeserializationError> {
-        let note: Note = source.read()?;
-        let proof: Option<NoteInclusionProof> = source.read()?;
+        let note = Note::read_from(source)?;
+        let proof = Option::<NoteInclusionProof>::read_from(source)?;
         Ok(InputNoteRecord::new(note, proof))
     }
 }

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -216,11 +216,12 @@ pub(super) fn serialize_transaction_data(
     );
 
     // TODO: Scripts should be in their own tables and only identifiers should be stored here
+    let transaction_args = transaction_result.transaction_arguments();
     let mut script_program = None;
     let mut script_hash = None;
     let mut script_inputs = None;
 
-    if let Some(tx_script) = transaction_result.transaction_script() {
+    if let Some(tx_script) = transaction_args.tx_script() {
         script_program = Some(tx_script.code().to_bytes(AstSerdeOptions {
             serialize_imports: true,
         }));


### PR DESCRIPTION
This PR updates the code to be compatible with new 0.8 version of the Winterfell.

This update mostly contains changes in `Felt` creation, since casting of `u64` to `FieldElement` was removed. It also updates the serialization and deserialization of the structs, which contain vectors of `Felt`s or `RpoDigest`s.