### PR TITLE
Bump rusqlite and tonic version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,12 @@ objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/
     "serde",
 ] }
 rand = { version = "0.8.5" }
-rusqlite = { version = "0.29.0", features = ["bundled"] }
+rusqlite = { version = "0.30.0", features = ["bundled"] }
 rusqlite_migration = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.29", features = ["rt-multi-thread", "net", "macros"] }
-tonic = { version = "0.10" }
+tonic = { version = "0.11" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }
 uuid = { version = "1.6.1", features = ["serde", "v4"], optional = true }


### PR DESCRIPTION
Both rusqlite and tonic had outdated versions in the client. 

Breaking compatibility with the node on some edge cases.