### PR TITLE
Fix rpc error because of try_into() and into()

### DIFF
--- a/src/client/rpc_client.rs
+++ b/src/client/rpc_client.rs
@@ -76,7 +76,10 @@ impl TryFrom<SyncStateResponse> for StateSyncInfo {
                 .ok_or(RpcApiError::ExpectedFieldMissing("Notes.MerklePath".into()))?
                 .try_into()?;
 
-            let sender_account_id = note.sender.try_into()?;
+            let sender_account_id = note
+                .sender
+                .ok_or(RpcApiError::ExpectedFieldMissing("Notes.Sender".into()))?
+                .try_into()?;
             let metadata = NoteMetadata::new(sender_account_id, note.tag.into());
 
             let committed_note =

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -31,6 +31,8 @@ use mock::mock::{
 };
 use objects::{
     accounts::{Account, AccountStorage, StorageSlotType},
+    accounts::{AccountId, AccountType},
+    assets::FungibleAsset,
     assets::{AssetVault, TokenSymbol},
     crypto::merkle::{Mmr, MmrDelta},
     notes::{Note, NoteInclusionProof},
@@ -42,11 +44,6 @@ use rand::Rng;
 use tonic::{IntoRequest, Response, Status};
 
 use crate::store::accounts::AuthInfo;
-
-use objects::{
-    accounts::{AccountId, AccountType},
-    assets::FungibleAsset,
-};
 
 /// Mock RPC API
 ///
@@ -177,7 +174,7 @@ fn create_mock_sync_state_request_for_account_and_notes(
             notes: vec![NoteSyncRecord {
                 note_index: 0,
                 note_id: Some(created_notes_iter.next().unwrap().id().into()),
-                sender: account.id().into(),
+                sender: Some(account.id().into()),
                 tag: 0u64,
                 merkle_path: Some(miden_node_proto::generated::merkle::MerklePath::default()),
             }],


### PR DESCRIPTION
This PR: https://github.com/0xPolygonMiden/miden-node/commit/78e5f5bb5e6c9da86bcf783ffc05aecb8f1d832c on the node-proto has added breaking changes to the miden-client 

Should be fixed by this PR.