### PR TITLE
fix: miden-base changes for note args

### DIFF
--- a/src/client/transactions.rs
+++ b/src/client/transactions.rs
@@ -13,7 +13,8 @@ use objects::{
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteId},
     transaction::{
-        ExecutedTransaction, OutputNote, OutputNotes, ProvenTransaction, TransactionScript,
+        ExecutedTransaction, OutputNote, OutputNotes, ProvenTransaction, TransactionArgs,
+        TransactionScript,
     },
     Digest,
 };
@@ -130,8 +131,8 @@ impl TransactionResult {
         self.executed_transaction.block_header().block_num()
     }
 
-    pub fn transaction_script(&self) -> Option<&TransactionScript> {
-        self.executed_transaction.tx_script()
+    pub fn transaction_arguments(&self) -> &TransactionArgs {
+        self.executed_transaction.tx_args()
     }
 
     pub fn account_delta(&self) -> &AccountDelta {
@@ -377,12 +378,14 @@ impl Client {
             .tx_executor
             .compile_tx_script(tx_script, script_inputs, vec![])?;
 
+        let tx_args = TransactionArgs::with_tx_script(tx_script);
+
         // Execute the transaction and get the witness
         let executed_transaction = self.tx_executor.execute_transaction(
             account_id,
             block_num,
             input_notes,
-            Some(tx_script),
+            Some(tx_args),
         )?;
 
         Ok(TransactionResult::new(executed_transaction, output_notes))

--- a/src/store/transactions.rs
+++ b/src/store/transactions.rs
@@ -216,11 +216,12 @@ pub(super) fn serialize_transaction_data(
     );
 
     // TODO: Scripts should be in their own tables and only identifiers should be stored here
+    let transaction_args = transaction_result.transaction_arguments();
     let mut script_program = None;
     let mut script_hash = None;
     let mut script_inputs = None;
 
-    if let Some(tx_script) = transaction_result.transaction_script() {
+    if let Some(tx_script) = transaction_args.tx_script() {
         script_program = Some(tx_script.code().to_bytes(AstSerdeOptions {
             serialize_imports: true,
         }));


### PR DESCRIPTION
Merge after #161 (we may actually need to merge it to #161 before merging that one to main)

On [#442](https://github.com/0xPolygonMiden/miden-base/pull/442) from miden-base there was a breaking change introduced where the transaction execution now needs a `TransactionArgs` composed of the `tx_script` and the note args