### PR TITLE
enhancement: run integration test job after the test, clippy and fmt jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
   integration_tests:
     name: integration_tests
     runs-on: ubuntu-latest
+    needs: [test, clippy, rustfmt]
     steps:
       - uses: actions/checkout@main
       - name: Install minimal stable with rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
   integration_tests:
     name: integration_tests
     runs-on: ubuntu-latest
-    needs: [test, clippy, rustfmt]
+    needs: [clippy, rustfmt]
     steps:
       - uses: actions/checkout@main
       - name: Install minimal stable with rustfmt


### PR DESCRIPTION
Currently the integration test job starts regardless of the result of the other jobs. It'd be better to wait until those finish since the integration test takes more resources and time and it'd be a waste to run it whilst some of the other steps fail.