### PR TITLE
fix: compilation errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ std = ["crypto/std", "objects/std"]
 testing = ["objects/testing", "miden_lib/testing"]
 
 [dependencies]
-assembly = { package = "miden-assembly", git = "https://github.com/0xPolygonMiden/miden-vm.git", branch = "next", default-features = false }
 async-trait = { version = "0.1" }
 clap = { version = "4.3", features = ["derive"] }
 comfy-table = "7.1.0"

--- a/src/store/mock_executor_data_store.rs
+++ b/src/store/mock_executor_data_store.rs
@@ -1,4 +1,3 @@
-use assembly::{Library, LibraryPath};
 use miden_lib::{
     transaction::{memory::FAUCET_STORAGE_DATA_SLOT, TransactionKernel},
     MidenLib,
@@ -14,7 +13,7 @@ use mock::{
 };
 use objects::{
     accounts::{Account, AccountCode, AccountId, AccountStorage, StorageSlotType},
-    assembly::{ModuleAst, ProgramAst},
+    assembly::{Library, LibraryPath, ModuleAst, ProgramAst},
     assets::{Asset, AssetVault, FungibleAsset},
     crypto::{dsa::rpo_falcon512::KeyPair, utils::Serializable},
     notes::{Note, NoteId, NoteScript},

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,6 @@ use crate::{
     },
 };
 
-use assembly::ast::{AstSerdeOptions, ModuleAst};
 use crypto::{dsa::rpo_falcon512::KeyPair, Felt, FieldElement, Word};
 use miden_lib::transaction::TransactionKernel;
 use mock::{
@@ -27,6 +26,7 @@ use mock::{
 };
 use objects::{
     accounts::{AccountId, AccountStub},
+    assembly::{AstSerdeOptions, ModuleAst},
     assets::{FungibleAsset, TokenSymbol},
     transaction::InputNotes,
 };


### PR DESCRIPTION
Fixes some compilation errors that pop up when running `cargo clippy --all --all-targets -- -D clippy::all -D warnings`. Apparently there was a refactor and now some assembly related structs were moved to miden-objects