### PR TITLE
feat: Filter notes by consumable by accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NODE_FEATURES_TESTING=--features testing
 NODE_BINARY=--bin miden-node
 
 integration-test:
-	cargo run --release --bin="integration" --features "$(FEATURES_INTEGRATION_TESTING)"; pkill miden-node
+	cargo run --release --bin="integration" --features "$(FEATURES_INTEGRATION_TESTING)" && pkill miden-node
 
 node:
 	if cd miden-node; then git pull; else git clone https://github.com/0xPolygonMiden/miden-node.git; fi

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ NODE_FEATURES_TESTING=--features testing
 NODE_BINARY=--bin miden-node
 
 integration-test:
-	set -o pipefail; cargo run --release --bin="integration" --features "$(FEATURES_INTEGRATION_TESTING)"; pkill miden-node
-	exit $$? || echo "integration test failed with exit code $$?"
+	cargo run --release --bin="integration" --features "$(FEATURES_INTEGRATION_TESTING)"; pkill miden-node
 
 node:
 	if cd miden-node; then git pull; else git clone https://github.com/0xPolygonMiden/miden-node.git; fi

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -394,4 +394,7 @@ pub enum NoteFilter {
     /// Return a list of pending [InputNoteRecord]. These represent notes for which the store
     /// does not have anchor data.
     Pending,
+    /// Return a list of committed P2ID and P2ID notes that can be consumed by a specific
+    /// [AccountId].
+    ConsumableBy(AccountId),
 }

--- a/src/store/sqlite_store/notes.rs
+++ b/src/store/sqlite_store/notes.rs
@@ -88,7 +88,7 @@ impl NoteFilter {
             NoteFilter::ConsumableBy(account_id) => {
                 let inputs = NoteInputs::new(vec![(*account_id).into()])
                     .expect("Only one argument should not cause errors");
-                let inputs_param = inputs.to_bytes();
+                let _inputs_param = inputs.to_bytes();
                 // vec![rusqlite::types::Value::Blob(inputs_param)]
                 vec![]
             }

--- a/src/store/sqlite_store/notes.rs
+++ b/src/store/sqlite_store/notes.rs
@@ -87,7 +87,7 @@ impl NoteFilter {
             NoteFilter::Consumed => format!("{base} WHERE status = 'consumed'"),
             NoteFilter::Pending => format!("{base} WHERE status = 'pending'"),
             NoteFilter::ConsumableBy(_) => {
-                format!("{base} WHERE status = 'committed' AND (script_hash = '{P2ID_NOTE_SCRIPT_ROOT}' OR script_hash = '{P2IDR_NOTE_SCRIPT_ROOT}')")
+                format!("{base} WHERE status = 'committed' AND (script_hash = '{P2ID_NOTE_SCRIPT_ROOT}' OR script_hash = '{P2IDR_NOTE_SCRIPT_ROOT}') AND inputs=?")
             }
         }
     }
@@ -119,8 +119,7 @@ impl SqliteStore {
             .query_map(
                 rusqlite::params_from_iter(filter.query_params()),
                 parse_input_note_columns,
-            )
-            .expect("no binding parameters used in query")
+            )?
             .map(|result| Ok(result?).and_then(parse_input_note))
             .collect::<Result<Vec<InputNoteRecord>, _>>()
     }
@@ -135,8 +134,7 @@ impl SqliteStore {
             .query_map(
                 rusqlite::params_from_iter(filter.query_params()),
                 parse_input_note_columns,
-            )
-            .expect("no binding parameters used in query")
+            )?
             .map(|result| Ok(result?).and_then(parse_input_note))
             .collect::<Result<Vec<InputNoteRecord>, _>>()
     }

--- a/src/store/sqlite_store/notes.rs
+++ b/src/store/sqlite_store/notes.rs
@@ -89,8 +89,7 @@ impl NoteFilter {
                 let inputs = NoteInputs::new(vec![(*account_id).into()])
                     .expect("Only one argument should not cause errors");
                 let _inputs_param = inputs.to_bytes();
-                // vec![rusqlite::types::Value::Blob(inputs_param)]
-                vec![]
+                vec![rusqlite::types::Value::Blob(inputs_param)]
             }
             _ => vec![],
         }

--- a/src/store/sqlite_store/store.sql
+++ b/src/store/sqlite_store/store.sql
@@ -97,7 +97,7 @@ CREATE TABLE output_notes (
     sender_id UNSIGNED BIG INT NOT NULL,                    -- the account ID of the sender
     tag UNSIGNED BIG INT NOT NULL,                          -- the note tag
     inclusion_proof BLOB NULL,                              -- the inclusion proof of the note against a block number
-    script_ast BLOB NOT NULL,                               -- the serialized script ProgramAst
+    script_ast BLOB NULL,                                   -- the serialized script ProgramAst
     script_hash BLOB NULL,                                  -- the note script hash in order to facilitate searches
     status TEXT CHECK( status IN (                          -- the status of the note - either pending, committed or consumed
         'pending', 'committed', 'consumed'

--- a/src/store/sqlite_store/store.sql
+++ b/src/store/sqlite_store/store.sql
@@ -72,14 +72,14 @@ CREATE TABLE input_notes (
     note_id BLOB NOT NULL,                                  -- the note id
     nullifier BLOB NOT NULL,                                -- the nullifier of the note
     recipient BLOB NOT NULL,                                -- the note recipient
-    script BLOB NOT NULL,                                   -- the serialized NoteScript, including script hash and ProgramAst
     assets BLOB NOT NULL,                                   -- the serialized NoteAssets, including vault hash and list of assets
     inputs BLOB NOT NULL,                                   -- the serialized NoteInputs, including inputs hash and list of inputs
     serial_num BLOB NOT NULL,                               -- the note serial number.
     sender_id UNSIGNED BIG INT NULL,                        -- the account ID of the sender. Known once the note is recorded on chain
     tag UNSIGNED BIG INT NULL,                              -- the note tag. Known once the note is recorded on-chain
     inclusion_proof BLOB NULL,                              -- the inclusion proof of the note against a block number. Known once the note is recorded on-chain
-    script_hash BLOB NOT NULL,                              -- the note script hash in order to facilitate searches
+    script_ast BLOB NOT NULL,                               -- the serialized script ProgramAst
+    script_hash BLOB NOT NULL,                              -- the note script hash
     status TEXT CHECK( status IN (                          -- the status of the note - either pending, committed or consumed
         'pending', 'committed', 'consumed'
         )),
@@ -91,13 +91,13 @@ CREATE TABLE output_notes (
     note_id BLOB NOT NULL,                                  -- the note id
     nullifier BLOB NULL,                                    -- the nullifier of the note, only known if we know script, inputs, serial_num
     recipient BLOB NOT NULL,                                -- the note recipient
-    script BLOB NULL,                                       -- the serialized NoteScript, including script hash and ProgramAst. May not be known
     assets BLOB NOT NULL,                                   -- the serialized NoteAssets, including vault hash and list of assets
     inputs BLOB NULL,                                       -- the serialized NoteInputs, including inputs hash and list of inputs. May not be known
     serial_num BLOB NULL,                                   -- the note serial number. May not be known
     sender_id UNSIGNED BIG INT NOT NULL,                    -- the account ID of the sender
     tag UNSIGNED BIG INT NOT NULL,                          -- the note tag
     inclusion_proof BLOB NULL,                              -- the inclusion proof of the note against a block number
+    script_ast BLOB NOT NULL,                               -- the serialized script ProgramAst
     script_hash BLOB NULL,                                  -- the note script hash in order to facilitate searches
     status TEXT CHECK( status IN (                          -- the status of the note - either pending, committed or consumed
         'pending', 'committed', 'consumed'

--- a/src/store/sqlite_store/store.sql
+++ b/src/store/sqlite_store/store.sql
@@ -79,6 +79,7 @@ CREATE TABLE input_notes (
     sender_id UNSIGNED BIG INT NULL,                        -- the account ID of the sender. Known once the note is recorded on chain
     tag UNSIGNED BIG INT NULL,                              -- the note tag. Known once the note is recorded on-chain
     inclusion_proof BLOB NULL,                              -- the inclusion proof of the note against a block number. Known once the note is recorded on-chain
+    script_hash BLOB NOT NULL,                              -- the note script hash in order to facilitate searches
     status TEXT CHECK( status IN (                          -- the status of the note - either pending, committed or consumed
         'pending', 'committed', 'consumed'
         )),
@@ -97,6 +98,7 @@ CREATE TABLE output_notes (
     sender_id UNSIGNED BIG INT NOT NULL,                    -- the account ID of the sender
     tag UNSIGNED BIG INT NOT NULL,                          -- the note tag
     inclusion_proof BLOB NULL,                              -- the inclusion proof of the note against a block number
+    script_hash BLOB NULL,                                  -- the note script hash in order to facilitate searches
     status TEXT CHECK( status IN (                          -- the status of the note - either pending, committed or consumed
         'pending', 'committed', 'consumed'
         )),

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -217,7 +217,7 @@ async fn main() {
     let notes = client
         .get_input_notes(NoteFilter::ConsumableBy(first_regular_account_id))
         .unwrap();
-    assert!(!notes.is_empty());
+    assert!(notes.is_empty());
 
     // Consume P2ID note
     let tx_template =

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -239,10 +239,10 @@ async fn main() {
     }
 
     // After consuming the note, no notes are expected to be consumable by the account
-    let notes = client
+    let consumable_notes_after_tx = client
         .get_input_notes(NoteFilter::ConsumableBy(regular_account.id()))
         .unwrap();
-    assert!(notes.is_empty());
+    assert!(consumable_notes_after_tx.is_empty());
 
     let (regular_account, _seed) = client.get_account(second_regular_account_id).unwrap();
     assert_eq!(regular_account.vault().assets().count(), 1);

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -206,7 +206,7 @@ async fn main() {
     println!("Fetching Committed Notes...");
     let notes = client.get_input_notes(NoteFilter::Committed).unwrap();
     assert!(!notes.is_empty());
-    
+
     // No notes are expected to be consumable by the sender account ID
     let notes = client
         .get_input_notes(NoteFilter::ConsumableBy(first_regular_account_id))

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -207,7 +207,7 @@ async fn main() {
     let notes = client.get_input_notes(NoteFilter::Committed).unwrap();
     assert!(!notes.is_empty());
 
-    // Check that the note filter for account IDs works correctly
+    // One note is expected to be consumable by the account ID
     let notes = client
         .get_input_notes(NoteFilter::ConsumableBy(regular_account.id()))
         .unwrap();
@@ -232,7 +232,7 @@ async fn main() {
         panic!("ACCOUNT SHOULD HAVE A FUNGIBLE ASSET");
     }
 
-    // Check that the note filter for account IDs works correctly
+    // After consuming the note, no notes are expected to be consumable by the account
     let notes = client
         .get_input_notes(NoteFilter::ConsumableBy(regular_account.id()))
         .unwrap();

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -207,6 +207,12 @@ async fn main() {
     let notes = client.get_input_notes(NoteFilter::Committed).unwrap();
     assert!(!notes.is_empty());
 
+    // Check that the note filter for account IDs works correctly
+    let notes = client
+        .get_input_notes(NoteFilter::ConsumableBy(regular_account.id()))
+        .unwrap();
+    assert!(!notes.is_empty());
+
     // Consume P2ID note
     let tx_template =
         TransactionTemplate::ConsumeNotes(second_regular_account_id, vec![notes[0].note_id()]);
@@ -225,6 +231,12 @@ async fn main() {
     } else {
         panic!("ACCOUNT SHOULD HAVE A FUNGIBLE ASSET");
     }
+
+    // Check that the note filter for account IDs works correctly
+    let notes = client
+        .get_input_notes(NoteFilter::ConsumableBy(regular_account.id()))
+        .unwrap();
+    assert!(notes.is_empty());
 
     let (regular_account, _seed) = client.get_account(second_regular_account_id).unwrap();
     assert_eq!(regular_account.vault().assets().count(), 1);

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -206,18 +206,18 @@ async fn main() {
     println!("Fetching Committed Notes...");
     let notes = client.get_input_notes(NoteFilter::Committed).unwrap();
     assert!(!notes.is_empty());
+    
+    // No notes are expected to be consumable by the sender account ID
+    let notes = client
+        .get_input_notes(NoteFilter::ConsumableBy(first_regular_account_id))
+        .unwrap();
+    assert!(notes.is_empty());
 
     // One note is expected to be consumable by the target account ID
     let notes = client
         .get_input_notes(NoteFilter::ConsumableBy(second_regular_account_id))
         .unwrap();
     assert!(!notes.is_empty());
-
-    // No notes are expected to be consumable by the sender account ID
-    let notes = client
-        .get_input_notes(NoteFilter::ConsumableBy(first_regular_account_id))
-        .unwrap();
-    assert!(notes.is_empty());
 
     // Consume P2ID note
     let tx_template =

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -69,7 +69,7 @@ async fn execute_tx_and_sync(client: &mut TestClient, tx_template: TransactionTe
     // Wait until we've actually gotten a new block
     println!("Syncing State...");
     while client.sync_state().await.unwrap() == current_block_num {
-        std::thread::sleep(std::time::Duration::new(5, 0));
+        std::thread::sleep(std::time::Duration::new(2, 0));
     }
 }
 
@@ -93,7 +93,10 @@ async fn wait_for_node(client: &mut TestClient) {
             Err(other_error) => {
                 panic!("Unexpected error: {other_error}");
             }
-            _ => return,
+            _ => {
+                println!("Node is up and sync was successful!");
+                return;
+            }
         }
     }
 
@@ -133,9 +136,6 @@ async fn main() {
         .unwrap();
 
     wait_for_node(&mut client).await;
-
-    println!("Syncing State...");
-    client.sync_state().await.unwrap();
 
     // Get Faucet and regular accounts
     println!("Fetching Accounts...");
@@ -207,9 +207,15 @@ async fn main() {
     let notes = client.get_input_notes(NoteFilter::Committed).unwrap();
     assert!(!notes.is_empty());
 
-    // One note is expected to be consumable by the account ID
+    // One note is expected to be consumable by the target account ID
     let notes = client
-        .get_input_notes(NoteFilter::ConsumableBy(regular_account.id()))
+        .get_input_notes(NoteFilter::ConsumableBy(second_regular_account_id))
+        .unwrap();
+    assert!(!notes.is_empty());
+
+    // No notes are expected to be consumable by the sender account ID
+    let notes = client
+        .get_input_notes(NoteFilter::ConsumableBy(first_regular_account_id))
         .unwrap();
     assert!(!notes.is_empty());
 


### PR DESCRIPTION
Closes #200.
Because we serialize `NoteScript`, there is no current good way to search by note script hash. Due to other incoming refactors to these tables I have just added the column for now to make it searchable.