### PR TITLE
tests: Run the node on `debug`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ node:
 	rm -rf miden-node/miden-store.sqlite3 miden-node/miden-store.sqlite3-wal miden-node/miden-store.sqlite3-shm
 	rm -rf miden-node/accounts
 	rm -f miden-node/genesis.dat
-	cd miden-node && cargo run --release $(NODE_BINARY) $(NODE_FEATURES_TESTING) -- make-genesis --inputs-path node/genesis.toml
+	cd miden-node && cargo run $(NODE_BINARY) $(NODE_FEATURES_TESTING) -- make-genesis --inputs-path node/genesis.toml
 
 start-node: node
-	cd miden-node && cargo run --release $(NODE_BINARY) $(NODE_FEATURES_TESTING) -- start --config node/miden-node.toml
+	cd miden-node && cargo run $(NODE_BINARY) $(NODE_FEATURES_TESTING) -- start --config node/miden-node.toml
 
 kill-node:
 	pkill miden-node


### PR DESCRIPTION
By running the node on `debug`, we can compile it faster and performance doesn't take too much of a noticeable hit because proof verification is fast anyway. It shaves off about a minute according to some quick tests:

https://github.com/0xPolygonMiden/miden-client/actions/runs/8177753061/job/22360161677
https://github.com/0xPolygonMiden/miden-client/actions/runs/8179954642/job/22367088556?pr=212