### PR TITLE
fix: Table columns on `account show`

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -175,7 +175,6 @@ pub fn show_account<N: NodeRpcClient, S: Store>(
     show_code: bool,
 ) -> Result<(), String> {
     let (account, _account_seed) = client.get_account(account_id)?;
-
     let mut table = create_dynamic_table(&[
         "Account ID",
         "Account Hash",
@@ -191,7 +190,8 @@ pub fn show_account<N: NodeRpcClient, S: Store>(
         account_type_display_name(&account.account_type()),
         account.code().root().to_string(),
         account.vault().asset_tree().root().to_string(),
-        account.nonce().to_string(),
+        account.storage().root().to_string(),
+        account.nonce().as_int().to_string(),
     ]);
     println!("{table}\n");
 


### PR DESCRIPTION
Fixes the `account show` table to correctly show all columns (previously, nonce was missing):

Ater:
<img width="576" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/6981132/bc5a234b-d1ad-415d-b837-61bb15a37f61">

Before:
<img width="568" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/6981132/7596b9d2-0f64-4f3f-963f-7a10dac392a7">


We should also look into making these tables "safer" (eg, throw if number of columns and values do not match)