### PR TITLE
test: validate all other p2idr cases

### DIFF
--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -498,7 +498,10 @@ async fn test_p2idr_transfer_consumed_by_sender() {
     let faucet_account_id = faucet_account_stub.id();
 
     // First Mint necesary token
-    mint_note(&mut client, from_account_id, faucet_account_id, NoteType::OffChain).await;
+    let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::OffChain).await;
+
+    consume_notes(&mut client, from_account_id, &[note]).await;
+    assert_account_has_single_asset(&client, from_account_id, faucet_account_id, MINT_AMOUNT).await;
     // Do a transfer from first account to second account with Recall. In this situation we'll do
     // the happy path where the `to_account_id` consumes the note
     let from_account_balance = client
@@ -513,7 +516,7 @@ async fn test_p2idr_transfer_consumed_by_sender() {
     let tx_template = TransactionTemplate::PayToIdWithRecall(
         PaymentTransactionData::new(Asset::Fungible(asset), from_account_id, to_account_id),
         current_block_num + 5,
-        NoteType::OffChain
+        NoteType::OffChain,
     );
     println!("Running P2IDR tx...");
     let tx_request = client.build_transaction_request(tx_template).unwrap();

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -404,7 +404,7 @@ async fn test_p2id_transfer() {
 }
 
 #[tokio::test]
-async fn test_p2idr_transfer() {
+async fn test_p2idr_transfer_consumed_by_target() {
     let mut client = create_test_client();
 
     let (first_regular_account, second_regular_account, faucet_account_stub) =
@@ -483,6 +483,92 @@ async fn test_p2idr_transfer() {
         panic!("Error: Account should have a fungible asset");
     }
 
+    assert_note_cannot_be_consumed_twice(&mut client, to_account_id, notes[0].id()).await;
+}
+
+#[tokio::test]
+async fn test_p2idr_transfer_consumed_by_sender() {
+    let mut client = create_test_client();
+
+    let (first_regular_account, second_regular_account, faucet_account_stub) =
+        setup(&mut client, AccountStorageMode::Local).await;
+
+    let from_account_id = first_regular_account.id();
+    let to_account_id = second_regular_account.id();
+    let faucet_account_id = faucet_account_stub.id();
+
+    // First Mint necesary token
+    mint_note(&mut client, from_account_id, faucet_account_id, NoteType::OffChain).await;
+    // Do a transfer from first account to second account with Recall. In this situation we'll do
+    // the happy path where the `to_account_id` consumes the note
+    let from_account_balance = client
+        .get_account(from_account_id)
+        .unwrap()
+        .0
+        .vault()
+        .get_balance(faucet_account_id)
+        .unwrap_or(0);
+    let current_block_num = client.get_sync_height().unwrap();
+    let asset = FungibleAsset::new(faucet_account_id, TRANSFER_AMOUNT).unwrap();
+    let tx_template = TransactionTemplate::PayToIdWithRecall(
+        PaymentTransactionData::new(Asset::Fungible(asset), from_account_id, to_account_id),
+        current_block_num + 5,
+        NoteType::OffChain
+    );
+    println!("Running P2IDR tx...");
+    let tx_request = client.build_transaction_request(tx_template).unwrap();
+    execute_tx_and_sync(&mut client, tx_request).await;
+
+    // Check that note is committed
+    println!("Fetching Committed Notes...");
+    let notes = client.get_input_notes(NoteFilter::Committed).unwrap();
+    assert!(!notes.is_empty());
+
+    // Check that it's still too early to consume
+    let tx_template = TransactionTemplate::ConsumeNotes(from_account_id, vec![notes[0].id()]);
+    println!("Consuming Note (too early)...");
+    let tx_request = client.build_transaction_request(tx_template).unwrap();
+    let transaction_execution_result = client.new_transaction(tx_request);
+    assert!(transaction_execution_result.is_err_and(|err| {
+        matches!(
+            err,
+            ClientError::TransactionExecutionError(
+                TransactionExecutorError::ExecuteTransactionProgramFailed(_)
+            )
+        )
+    }));
+
+    // Wait to consume with the sender account
+    println!("Waiting for note to be consumable by sender");
+    let current_block_num = client.get_sync_height().unwrap();
+
+    while client.get_sync_height().unwrap() < current_block_num + 5 {
+        client.sync_state().await.unwrap();
+    }
+
+    // Consume the note with the sender account
+    let tx_template = TransactionTemplate::ConsumeNotes(from_account_id, vec![notes[0].id()]);
+    println!("Consuming Note...");
+    let tx_request = client.build_transaction_request(tx_template).unwrap();
+    execute_tx_and_sync(&mut client, tx_request).await;
+
+    let (regular_account, seed) = client.get_account(from_account_id).unwrap();
+    // The seed should not be retrieved due to the account not being new
+    assert!(!regular_account.is_new() && seed.is_none());
+    assert_eq!(regular_account.vault().assets().count(), 1);
+    let asset = regular_account.vault().assets().next().unwrap();
+
+    // Validate the the sender hasn't lost funds
+    if let Asset::Fungible(fungible_asset) = asset {
+        assert_eq!(fungible_asset.amount(), from_account_balance);
+    } else {
+        panic!("Error: Account should have a fungible asset");
+    }
+
+    let (regular_account, _seed) = client.get_account(to_account_id).unwrap();
+    assert_eq!(regular_account.vault().assets().count(), 0);
+
+    // Check that the target can't consume the note anymore
     assert_note_cannot_be_consumed_twice(&mut client, to_account_id, notes[0].id()).await;
 }
 


### PR DESCRIPTION
closes #239 (The issue says it's not necessary to do an integration test but I'd rather have real blocks stepping over. Plus mocking all the intermediate sync state responses would add a lot of complexity IMHO)

On #219 we added the Pay To ID with Recall transaction along with an integration test for the "happy path" (sender executes the tx, target receives it and consumes it).

On this PR we check the following cases that were left out (The P2IDR tx has one output note which handles the funds transfer):

- The sender tries to reclaim (consume) the note too early and fails
- The sender tries to consume the note after waiting for the recall height and does so successfully
- The sender consumes the note and the target can't consume the note anymore