### PR TITLE
feat: Add account details endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ comfy-table = "7.1.0"
 figment = { version = "0.10", features = ["toml", "env"] }
 lazy_static = "1.4.0"
 miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", default-features = false }
-miden-node-proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "polydez-onchain-accounts-apply", default-features = false }
+miden-node-proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "next", default-features = false }
 miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", default-features = false }
 miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", default-features = false }
 rand = { version = "0.8.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ comfy-table = "7.1.0"
 figment = { version = "0.10", features = ["toml", "env"] }
 lazy_static = "1.4.0"
 miden-lib = { package = "miden-lib", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", default-features = false }
-miden-node-proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "next", default-features = false }
+miden-node-proto = { package = "miden-node-proto", git = "https://github.com/0xPolygonMiden/miden-node.git", branch = "polydez-onchain-accounts-apply", default-features = false }
 miden-tx = { package = "miden-tx", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", default-features = false }
 miden-objects = { package = "miden-objects", git = "https://github.com/0xPolygonMiden/miden-base.git", branch = "next", default-features = false }
 rand = { version = "0.8.5" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -49,7 +49,7 @@ args = ["-rf", "miden-node"]
 description = "Clone or update miden-node repository and clean up files"
 script_runner = "bash"
 script = [
-    'if [ -d miden-node ]; then cd miden-node && git checkout next && git pull origin next && cargo update; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi',
+    'if [ -d miden-node ]; then cd miden-node && git checkout next && git pull origin next && cargo update; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node && cargo update; fi',
     'rm -rf miden-store.sqlite3 miden-store.sqlite3-wal miden-store.sqlite3-shm',
     'cargo run --bin $NODE_BINARY --features $NODE_FEATURES_TESTING -- make-genesis --inputs-path node/genesis.toml --force'
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -49,7 +49,7 @@ args = ["-rf", "miden-node"]
 description = "Clone or update miden-node repository and clean up files"
 script_runner = "bash"
 script = [
-    'if [ -d miden-node ]; then cd miden-node && git pull ; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi',
+    'if [ -d miden-node ]; then cd miden-node && git pull origin next; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi',
     'rm -rf miden-store.sqlite3 miden-store.sqlite3-wal miden-store.sqlite3-shm',
     'cargo run --bin $NODE_BINARY --features $NODE_FEATURES_TESTING -- make-genesis --inputs-path node/genesis.toml --force'
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -49,7 +49,7 @@ args = ["-rf", "miden-node"]
 description = "Clone or update miden-node repository and clean up files"
 script_runner = "bash"
 script = [
-    'if [ -d miden-node ]; then cd miden-node && git checkout next && git pull origin next; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi',
+    'if [ -d miden-node ]; then cd miden-node && git checkout next && git pull origin next && cargo update; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi',
     'rm -rf miden-store.sqlite3 miden-store.sqlite3-wal miden-store.sqlite3-shm',
     'cargo run --bin $NODE_BINARY --features $NODE_FEATURES_TESTING -- make-genesis --inputs-path node/genesis.toml --force'
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -49,7 +49,7 @@ args = ["-rf", "miden-node"]
 description = "Clone or update miden-node repository and clean up files"
 script_runner = "bash"
 script = [
-    'if [ -d miden-node ]; then cd miden-node && git pull origin next; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi',
+    'if [ -d miden-node ]; then cd miden-node && git checkout next && git pull origin next; else git clone --branch next https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi',
     'rm -rf miden-store.sqlite3 miden-store.sqlite3-wal miden-store.sqlite3-shm',
     'cargo run --bin $NODE_BINARY --features $NODE_FEATURES_TESTING -- make-genesis --inputs-path node/genesis.toml --force'
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 large-error-threshold = 256
+too-many-arguments-threshold = 8

--- a/docs/library.md
+++ b/docs/library.md
@@ -33,7 +33,18 @@ With the Miden client, you can create and track local (not on-chain) accounts. W
     let (new_account, account_seed) = client.new_account(client_template)?;
 ```
 
-The `AccountTemplate` enum defines which type of account will be created. Note that once an account is created, it will be kept locally and its state will automatically be tracked by the client. Any number of accounts can be created and stored by the client.
+The `AccountTemplate` enum defines which type of account will be created. Note that once an account is created, it will be kept locally and its state will automatically be tracked by the client. Any number of accounts can be created and stored by the client. You can also create onchain accounts with: `accounts::AccountStorageMode::OnChain`
+
+```Rust
+    let account_template = AccountTemplate::BasicWallet {
+        mutable_code: false,
+        storage_mode: accounts::AccountStorageMode::OnChain,
+    };
+    
+    let (new_account, account_seed) = client.new_account(client_template)?;
+```
+
+The account's state is also tracked locally, but during sync the client updates the account state by querying the node for outdated on-chain accounts.
 
 ## Execute a transaction
 

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -88,6 +88,7 @@ pub enum AccountTemplate {
     },
 }
 
+// TODO: Review this enum and variant names to have a consistent naming across all crates
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum AccountStorageMode {
     OffChain,

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::{
     client::{accounts, rpc::NodeRpcClient, Client},
@@ -61,9 +61,15 @@ pub enum AccountCmd {
 #[clap()]
 pub enum AccountTemplate {
     /// Creates a basic account (Regular account with immutable code)
-    BasicImmutable,
+    BasicImmutable {
+        #[clap(short, long, value_enum, default_value_t = AccountStorageMode::OffChain)]
+        storage_mode: AccountStorageMode,
+    },
     /// Creates a basic account (Regular account with mutable code)
-    BasicMutable,
+    BasicMutable {
+        #[clap(short, long, value_enum, default_value_t = AccountStorageMode::OffChain)]
+        storage_mode: AccountStorageMode,
+    },
     /// Creates a faucet for fungible tokens
     FungibleFaucet {
         #[clap(short, long)]
@@ -72,9 +78,35 @@ pub enum AccountTemplate {
         decimals: u8,
         #[clap(short, long)]
         max_supply: u64,
+        #[clap(short, long, value_enum, default_value_t = AccountStorageMode::OffChain)]
+        storage_mode: AccountStorageMode,
     },
     /// Creates a faucet for non-fungible tokens
-    NonFungibleFaucet,
+    NonFungibleFaucet {
+        #[clap(short, long, value_enum, default_value_t = AccountStorageMode::OffChain)]
+        storage_mode: AccountStorageMode,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum AccountStorageMode {
+    OffChain,
+    OnChain,
+}
+
+impl From<AccountStorageMode> for accounts::AccountStorageMode {
+    fn from(value: AccountStorageMode) -> Self {
+        match value {
+            AccountStorageMode::OffChain => accounts::AccountStorageMode::Local,
+            AccountStorageMode::OnChain => accounts::AccountStorageMode::OnChain,
+        }
+    }
+}
+
+impl From<&AccountStorageMode> for accounts::AccountStorageMode {
+    fn from(value: &AccountStorageMode) -> Self {
+        accounts::AccountStorageMode::from(*value)
+    }
 }
 
 impl AccountCmd {
@@ -88,26 +120,31 @@ impl AccountCmd {
             },
             AccountCmd::New { template } => {
                 let client_template = match template {
-                    AccountTemplate::BasicImmutable => accounts::AccountTemplate::BasicWallet {
-                        mutable_code: false,
-                        storage_mode: accounts::AccountStorageMode::Local,
+                    AccountTemplate::BasicImmutable { storage_mode } => {
+                        accounts::AccountTemplate::BasicWallet {
+                            mutable_code: false,
+                            storage_mode: storage_mode.into(),
+                        }
                     },
-                    AccountTemplate::BasicMutable => accounts::AccountTemplate::BasicWallet {
-                        mutable_code: true,
-                        storage_mode: accounts::AccountStorageMode::Local,
+                    AccountTemplate::BasicMutable { storage_mode } => {
+                        accounts::AccountTemplate::BasicWallet {
+                            mutable_code: true,
+                            storage_mode: storage_mode.into(),
+                        }
                     },
                     AccountTemplate::FungibleFaucet {
                         token_symbol,
                         decimals,
                         max_supply,
+                        storage_mode,
                     } => accounts::AccountTemplate::FungibleFaucet {
                         token_symbol: TokenSymbol::new(token_symbol)
                             .map_err(|err| format!("error: token symbol is invalid: {}", err))?,
                         decimals: *decimals,
                         max_supply: *max_supply,
-                        storage_mode: accounts::AccountStorageMode::Local,
+                        storage_mode: storage_mode.into(),
                     },
-                    AccountTemplate::NonFungibleFaucet => todo!(),
+                    AccountTemplate::NonFungibleFaucet { storage_mode: _ } => todo!(),
                 };
                 let (_new_account, _account_seed) = client.new_account(client_template)?;
             },

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -30,6 +30,7 @@ pub enum AccountTemplate {
     },
 }
 
+// TODO: Review this enum and variant names to have a consistent naming across all crates
 #[derive(Debug, Clone, Copy)]
 pub enum AccountStorageMode {
     Local,

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -30,6 +30,7 @@ pub enum AccountTemplate {
     },
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum AccountStorageMode {
     Local,
     OnChain,

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -177,9 +177,8 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
             decimals,
             Felt::try_from(max_supply.to_le_bytes().as_slice())
                 .expect("u64 can be safely converted to a field element"),
-            AccountStorageType::OffChain,
-            auth_scheme,
             account_storage_mode.into(),
+            auth_scheme,
         )?;
 
         self.insert_account(&account, Some(seed), &AuthInfo::RpoFalcon512(key_pair))?;

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -2,10 +2,10 @@ use core::fmt;
 
 use async_trait::async_trait;
 use miden_objects::{
-    accounts::AccountId,
+    accounts::{Account, AccountId},
     crypto::merkle::{MerklePath, MmrDelta},
     notes::{NoteId, NoteMetadata},
-    transaction::{AccountDetails, ProvenTransaction},
+    transaction::ProvenTransaction,
     BlockHeader, Digest,
 };
 
@@ -57,10 +57,10 @@ pub trait NodeRpcClient {
         nullifiers_tags: &[u16],
     ) -> Result<StateSyncInfo, NodeRpcClientError>;
 
-    async fn get_account_details(
+    async fn get_account_update(
         &mut self,
         account_id: AccountId,
-    ) -> Result<AccountDetails, NodeRpcClientError>;
+    ) -> Result<Option<Account>, NodeRpcClientError>;
 }
 
 // STATE SYNC INFO

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -60,7 +60,7 @@ pub trait NodeRpcClient {
     async fn get_account_update(
         &mut self,
         account_id: AccountId,
-    ) -> Result<Option<Account>, NodeRpcClientError>;
+    ) -> Result<Account, NodeRpcClientError>;
 }
 
 // STATE SYNC INFO

--- a/src/client/rpc/mod.rs
+++ b/src/client/rpc/mod.rs
@@ -5,7 +5,7 @@ use miden_objects::{
     accounts::AccountId,
     crypto::merkle::{MerklePath, MmrDelta},
     notes::{NoteId, NoteMetadata},
-    transaction::ProvenTransaction,
+    transaction::{AccountDetails, ProvenTransaction},
     BlockHeader, Digest,
 };
 
@@ -56,6 +56,11 @@ pub trait NodeRpcClient {
         note_tags: &[u16],
         nullifiers_tags: &[u16],
     ) -> Result<StateSyncInfo, NodeRpcClientError>;
+
+    async fn get_account_details(
+        &mut self,
+        account_id: AccountId,
+    ) -> Result<AccountDetails, NodeRpcClientError>;
 }
 
 // STATE SYNC INFO
@@ -130,6 +135,7 @@ impl CommittedNote {
 //
 #[derive(Debug)]
 pub enum NodeRpcClientEndpoint {
+    GetAccountDetails,
     GetBlockHeaderByNumber,
     SyncState,
     SubmitProvenTx,
@@ -141,6 +147,7 @@ impl fmt::Display for NodeRpcClientEndpoint {
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
         match self {
+            NodeRpcClientEndpoint::GetAccountDetails => write!(f, "get_account_details"),
             NodeRpcClientEndpoint::GetBlockHeaderByNumber => {
                 write!(f, "get_block_header_by_number")
             },

--- a/src/client/rpc/tonic_client.rs
+++ b/src/client/rpc/tonic_client.rs
@@ -150,7 +150,7 @@ impl NodeRpcClient for TonicRpcClient {
                 err.to_string(),
             )
         })?;
-        let response = dbg!(response.into_inner());
+        let response = response.into_inner();
         // TODO: remove unwrap and use proper handling
         let account_info = response.account.unwrap();
         let details = account_info

--- a/src/client/rpc/tonic_client.rs
+++ b/src/client/rpc/tonic_client.rs
@@ -11,9 +11,9 @@ use miden_node_proto::{
     },
 };
 use miden_objects::{
-    accounts::AccountId,
+    accounts::{Account, AccountId},
     notes::{NoteId, NoteMetadata, NoteType},
-    transaction::{AccountDetails, ProvenTransaction},
+    transaction::ProvenTransaction,
     utils::Deserializable,
     BlockHeader, Digest,
 };
@@ -131,10 +131,10 @@ impl NodeRpcClient for TonicRpcClient {
     }
 
     /// TODO: fill description
-    async fn get_account_details(
+    async fn get_account_update(
         &mut self,
         account_id: AccountId,
-    ) -> Result<AccountDetails, NodeRpcClientError> {
+    ) -> Result<Option<Account>, NodeRpcClientError> {
         debug_assert!(account_id.is_on_chain());
 
         let account_id = account_id.into();
@@ -153,7 +153,10 @@ impl NodeRpcClient for TonicRpcClient {
         let response = dbg!(response.into_inner());
         // TODO: remove unwrap and use proper handling
         let account_info = response.account.unwrap();
-        let details = AccountDetails::read_from_bytes(&account_info.details.unwrap())?;
+        let details = account_info
+            .details
+            .map(|details| Account::read_from_bytes(&details))
+            .transpose()?;
 
         Ok(details)
     }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -3,7 +3,7 @@ use miden_objects::{
     accounts::{Account, AccountId, AccountStub},
     crypto::{self, rand::FeltRng},
     notes::{NoteId, NoteInclusionProof},
-    transaction::{AccountDetails, TransactionId},
+    transaction::TransactionId,
     BlockHeader, Digest,
 };
 use tracing::{info, warn};
@@ -308,14 +308,9 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
 
             if let Some(tracked_account) = current_account {
                 info!("On-chain account hash difference detected for account with ID: {}. Fetching node for updates...", tracked_account.id());
-                match dbg!(self.rpc_api.get_account_details(tracked_account.id()).await)? {
-                    AccountDetails::Full(account) => {
-                        accounts_to_update.push(account);
-                    },
-                    _ => {
-                        // TODO: Handle this
-                        panic!("unexpected account")
-                    },
+                if let Some(account) = self.rpc_api.get_account_update(tracked_account.id()).await?
+                {
+                    accounts_to_update.push(account);
                 }
             }
         }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -308,10 +308,8 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
 
             if let Some(tracked_account) = current_account {
                 info!("On-chain account hash difference detected for account with ID: {}. Fetching node for updates...", tracked_account.id());
-                if let Some(account) = self.rpc_api.get_account_update(tracked_account.id()).await?
-                {
-                    accounts_to_update.push(account);
-                }
+                let account = self.rpc_api.get_account_update(tracked_account.id()).await?;
+                accounts_to_update.push(account);
             }
         }
         Ok(accounts_to_update)

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -236,7 +236,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
             account_id,
             block_num,
             &note_ids,
-            Some(transaction_request.into()),
+            transaction_request.into(),
         )?;
 
         // Check that the expected output notes is a subset of the transaction's output notes

--- a/src/client/transactions/transaction_request.rs
+++ b/src/client/transactions/transaction_request.rs
@@ -5,6 +5,7 @@ use miden_objects::{
     assets::{Asset, FungibleAsset},
     notes::{Note, NoteId},
     transaction::{TransactionArgs, TransactionScript},
+    vm::AdviceMap,
     Word,
 };
 
@@ -88,7 +89,12 @@ impl TransactionRequest {
 impl From<TransactionRequest> for TransactionArgs {
     fn from(val: TransactionRequest) -> Self {
         let note_args = val.get_note_args();
-        TransactionArgs::new(val.tx_script, Some(note_args))
+        let mut tx_args = TransactionArgs::new(val.tx_script, Some(note_args), AdviceMap::new());
+
+        let output_notes = val.expected_output_notes.into_iter();
+        tx_args.extend_expected_output_notes(output_notes);
+
+        tx_args
     }
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -469,6 +469,7 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
         Felt::try_from(max_supply.as_slice()).unwrap(),
         AccountStorageType::OffChain,
         auth_scheme,
+        AccountStorageType::OffChain,
     )
     .unwrap();
 
@@ -511,6 +512,7 @@ pub fn mock_fungible_faucet_account(
             .expect("u64 can be safely converted to a field element"),
         AccountStorageType::OffChain,
         auth_scheme,
+        AccountStorageType::OffChain,
     )
     .unwrap();
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -469,7 +469,6 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
         Felt::try_from(max_supply.as_slice()).unwrap(),
         AccountStorageType::OffChain,
         auth_scheme,
-        AccountStorageType::OffChain,
     )
     .unwrap();
 
@@ -512,7 +511,6 @@ pub fn mock_fungible_faucet_account(
             .expect("u64 can be safely converted to a field element"),
         AccountStorageType::OffChain,
         auth_scheme,
-        AccountStorageType::OffChain,
     )
     .unwrap();
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -25,7 +25,7 @@ use miden_objects::{
         Note, NoteAssets, NoteInclusionProof, NoteInputs, NoteMetadata, NoteRecipient, NoteScript,
         NoteType,
     },
-    transaction::{InputNote, ProvenTransaction},
+    transaction::{AccountDetails, InputNote, ProvenTransaction},
     BlockHeader, Felt, Word, NOTE_TREE_DEPTH,
 };
 use rand::Rng;
@@ -133,6 +133,13 @@ impl NodeRpcClient for MockRpcApi {
     ) -> std::result::Result<(), NodeRpcClientError> {
         // TODO: add some basic validations to test error cases
         Ok(())
+    }
+
+    async fn get_account_details(
+        &mut self,
+        _account_id: AccountId,
+    ) -> Result<AccountDetails, NodeRpcClientError> {
+        panic!("shouldn't be used for now")
     }
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -25,7 +25,7 @@ use miden_objects::{
         Note, NoteAssets, NoteInclusionProof, NoteInputs, NoteMetadata, NoteRecipient, NoteScript,
         NoteType,
     },
-    transaction::{AccountDetails, InputNote, ProvenTransaction},
+    transaction::{InputNote, ProvenTransaction},
     BlockHeader, Felt, Word, NOTE_TREE_DEPTH,
 };
 use rand::Rng;
@@ -135,10 +135,10 @@ impl NodeRpcClient for MockRpcApi {
         Ok(())
     }
 
-    async fn get_account_details(
+    async fn get_account_update(
         &mut self,
         _account_id: AccountId,
-    ) -> Result<AccountDetails, NodeRpcClientError> {
+    ) -> Result<Option<Account>, NodeRpcClientError> {
         panic!("shouldn't be used for now")
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -138,7 +138,7 @@ impl NodeRpcClient for MockRpcApi {
     async fn get_account_update(
         &mut self,
         _account_id: AccountId,
-    ) -> Result<Option<Account>, NodeRpcClientError> {
+    ) -> Result<Account, NodeRpcClientError> {
         panic!("shouldn't be used for now")
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -219,6 +219,12 @@ pub trait Store {
         auth_info: &AuthInfo,
     ) -> Result<(), StoreError>;
 
+    /// Updates an existing account corresponding to the provided [Account]
+    fn update_account(
+        &mut self,
+        account: &Account,
+    ) -> Result<(), StoreError>;
+
     // SYNC
     // --------------------------------------------------------------------------------------------
 
@@ -250,6 +256,7 @@ pub trait Store {
         committed_transactions: &[TransactionId],
         new_mmr_peaks: MmrPeaks,
         new_authentication_nodes: &[(InOrderIndex, Digest)],
+        updated_onchain_accounts: &[Account],
     ) -> Result<(), StoreError>;
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -219,12 +219,6 @@ pub trait Store {
         auth_info: &AuthInfo,
     ) -> Result<(), StoreError>;
 
-    /// Updates an existing account corresponding to the provided [Account]
-    fn update_account(
-        &mut self,
-        account: &Account,
-    ) -> Result<(), StoreError>;
-
     // SYNC
     // --------------------------------------------------------------------------------------------
 

--- a/src/store/sqlite_store/accounts.rs
+++ b/src/store/sqlite_store/accounts.rs
@@ -184,10 +184,35 @@ impl SqliteStore {
 
         Ok(tx.commit()?)
     }
+
+    pub(crate) fn update_account(
+        &mut self,
+        account: &Account,
+    ) -> Result<(), StoreError> {
+        let tx = self.db.transaction()?;
+
+        update_account(&tx, account)?;
+
+        Ok(tx.commit()?)
+    }
 }
 
 // HELPERS
 // ================================================================================================
+
+/// Update previously-existing account after a transaction execution
+///
+/// Because the Client retrieves the account by account ID before applying the delta, we don't
+/// need to check that it exists here. This inserts a new row into the accounts table.
+/// We can later identify the proper account state by looking at the nonce.
+pub(crate) fn update_account(
+    tx: &Transaction<'_>,
+    new_account_state: &Account,
+) -> Result<(), StoreError> {
+    insert_account_storage(tx, new_account_state.storage())?;
+    insert_account_asset_vault(tx, new_account_state.vault())?;
+    insert_account_record(tx, new_account_state, None)
+}
 
 pub(super) fn insert_account_record(
     tx: &Transaction<'_>,

--- a/src/store/sqlite_store/accounts.rs
+++ b/src/store/sqlite_store/accounts.rs
@@ -184,17 +184,6 @@ impl SqliteStore {
 
         Ok(tx.commit()?)
     }
-
-    pub(crate) fn update_account(
-        &mut self,
-        account: &Account,
-    ) -> Result<(), StoreError> {
-        let tx = self.db.transaction()?;
-
-        update_account(&tx, account)?;
-
-        Ok(tx.commit()?)
-    }
 }
 
 // HELPERS

--- a/src/store/sqlite_store/mod.rs
+++ b/src/store/sqlite_store/mod.rs
@@ -132,6 +132,7 @@ impl Store for SqliteStore {
         committed_transactions: &[TransactionId],
         new_mmr_peaks: MmrPeaks,
         new_authentication_nodes: &[(InOrderIndex, Digest)],
+        updated_onchain_accounts: &[Account],
     ) -> Result<(), StoreError> {
         self.apply_state_sync(
             block_header,
@@ -140,6 +141,7 @@ impl Store for SqliteStore {
             committed_transactions,
             new_mmr_peaks,
             new_authentication_nodes,
+            updated_onchain_accounts,
         )
     }
 
@@ -226,6 +228,13 @@ impl Store for SqliteStore {
         auth_info: &AuthInfo,
     ) -> Result<(), StoreError> {
         self.insert_account(account, account_seed, auth_info)
+    }
+
+    fn update_account(
+        &mut self,
+        account: &Account,
+    ) -> Result<(), StoreError> {
+        self.update_account(account)
     }
 
     fn get_account_ids(&self) -> Result<Vec<AccountId>, StoreError> {

--- a/src/store/sqlite_store/mod.rs
+++ b/src/store/sqlite_store/mod.rs
@@ -230,13 +230,6 @@ impl Store for SqliteStore {
         self.insert_account(account, account_seed, auth_info)
     }
 
-    fn update_account(
-        &mut self,
-        account: &Account,
-    ) -> Result<(), StoreError> {
-        self.update_account(account)
-    }
-
     fn get_account_ids(&self) -> Result<Vec<AccountId>, StoreError> {
         self.get_account_ids()
     }

--- a/src/store/sqlite_store/transactions.rs
+++ b/src/store/sqlite_store/transactions.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeMap;
 
 use miden_objects::{
-    accounts::{Account, AccountId},
+    accounts::AccountId,
     assembly::{AstSerdeOptions, ProgramAst},
     crypto::utils::{Deserializable, Serializable},
     transaction::{OutputNotes, ToNullifier, TransactionId, TransactionScript},
@@ -11,7 +11,7 @@ use rusqlite::{params, Transaction};
 use tracing::info;
 
 use super::{
-    accounts::{insert_account_asset_vault, insert_account_record, insert_account_storage},
+    accounts::update_account,
     notes::{insert_input_note_tx, insert_output_note_tx},
     SqliteStore,
 };
@@ -107,7 +107,7 @@ impl SqliteStore {
         insert_proven_transaction_data(&tx, tx_result)?;
 
         // Account Data
-        update_account(&tx, account)?;
+        update_account(&tx, &account)?;
 
         // Updates for notes
 
@@ -146,20 +146,6 @@ impl SqliteStore {
 
         Ok(rows)
     }
-}
-
-/// Update previously-existing account after a transaction execution
-///
-/// Because the Client retrieves the account by account ID before applying the delta, we don't
-/// need to check that it exists here. This inserts a new row into the accounts table.
-/// We can later identify the proper account state by looking at the nonce.
-fn update_account(
-    tx: &Transaction<'_>,
-    new_account_state: Account,
-) -> Result<(), StoreError> {
-    insert_account_storage(tx, new_account_state.storage())?;
-    insert_account_asset_vault(tx, new_account_state.vault())?;
-    insert_account_record(tx, &new_account_state, None)
 }
 
 pub(super) fn insert_proven_transaction_data(

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -236,7 +236,7 @@ async fn test_added_notes() {
     assert!(notes.is_empty())
 }
 
-// #[tokio::test]
+#[tokio::test]
 async fn test_p2id_transfer() {
     let mut client = create_test_client();
 
@@ -304,7 +304,7 @@ async fn test_p2id_transfer() {
     assert_note_cannot_be_consumed_twice(&mut client, to_account_id, notes[0].id()).await;
 }
 
-// #[tokio::test]
+#[tokio::test]
 async fn test_p2idr_transfer() {
     let mut client = create_test_client();
 
@@ -425,7 +425,7 @@ async fn assert_note_cannot_be_consumed_twice(
 //
 // Because it's currently not possible to create/consume notes without assets, the P2ID code
 // is used as the base for the note code.
-// #[tokio::test]
+#[tokio::test]
 async fn test_transaction_request() {
     let mut client = create_test_client();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -16,10 +16,7 @@ use miden_client::{
 };
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
-    accounts::{
-        Account, AccountData, AccountId, AuthData,
-        ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN,
-    },
+    accounts::{Account, AccountId, ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN},
     assembly::ProgramAst,
     assets::{Asset, FungibleAsset, TokenSymbol},
     crypto::rand::{FeltRng, RpoRandomCoin},
@@ -214,7 +211,7 @@ async fn consume_notes(
     }
 }
 
-// #[tokio::test]
+#[tokio::test]
 async fn test_added_notes() {
     let mut client = create_test_client();
 
@@ -635,20 +632,26 @@ async fn test_onchain_mint() {
     let (first_regular_account, _second_regular_account, faucet_account_stub) =
         setup(&mut client_1, AccountStorageMode::OnChain).await;
 
+    let (
+        second_client_first_regular_account,
+        _other_second_regular_account,
+        _other_faucet_account_stub,
+    ) = setup(&mut client_2, AccountStorageMode::Local).await;
+
     let target_account_id = first_regular_account.id();
+    let second_client_target_account_id = second_client_first_regular_account.id();
     let faucet_account_id = faucet_account_stub.id();
 
     let (_, faucet_seed) = client_1.get_account_stub_by_id(faucet_account_id).unwrap();
-    let account_data = AccountData::new(
-        faucet_account_stub.clone(),
-        faucet_seed,
-        AuthData::RpoFalcon512Seed([0; 32]),
-    );
-    client_2.import_account(account_data).unwrap();
+    let auth_info = client_1.get_account_auth(faucet_account_id).unwrap();
+    client_2.insert_account(&faucet_account_stub, faucet_seed, &auth_info).unwrap();
 
     // First Mint necesary token
+    println!("First client consuming note");
     let note = mint_note(&mut client_1, target_account_id, faucet_account_id).await;
 
+    // Update the state in the other client and ensure the onchain faucet hash is consistent
+    // between clients
     client_2.sync_state().await.unwrap();
 
     let (client_1_faucet, _) = client_1.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
@@ -656,7 +659,21 @@ async fn test_onchain_mint() {
 
     assert_eq!(client_1_faucet.hash(), client_2_faucet.hash());
 
-    println!("about to consume");
+    // Now use the faucet in the second client to mint to its own account
+    println!("Second client consuming note");
+    let second_client_note =
+        mint_note(&mut client_2, second_client_target_account_id, faucet_account_id).await;
 
+    // Update the state in the other client and ensure the onchain faucet hash is consistent
+    // between clients
+    client_1.sync_state().await.unwrap();
+
+    println!("about to consume");
     consume_notes(&mut client_1, target_account_id, &[note]).await;
+    consume_notes(&mut client_2, second_client_target_account_id, &[second_client_note]).await;
+
+    let (client_1_faucet, _) = client_1.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
+    let (client_2_faucet, _) = client_2.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
+
+    assert_eq!(client_1_faucet.hash(), client_2_faucet.hash());
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -649,6 +649,8 @@ async fn test_onchain_mint() {
     // First Mint necesary token
     let note = mint_note(&mut client_1, target_account_id, faucet_account_id).await;
 
+    client_2.sync_state().await.unwrap();
+
     let (client_1_faucet, _) = client_1.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
     let (client_2_faucet, _) = client_2.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -632,7 +632,7 @@ async fn test_onchain_mint() {
     let mut client_1 = create_test_client();
     let mut client_2 = create_test_client();
 
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
+    let (first_regular_account, _second_regular_account, faucet_account_stub) =
         setup(&mut client_1, AccountStorageMode::OnChain).await;
 
     let target_account_id = first_regular_account.id();


### PR DESCRIPTION
This PR introduces a few things:

- Adds a new param to the CLI for the `account new` command, `--storage-mode=onchain,offchain(default)` that enables the creation of onchain accounts
- Adds to the node rpc client a `get_account_updates` trait function. This function takes an account ID and fetches the `GetAccountDetails` endpoint on the node added on [#294](https://github.com/0xPolygonMiden/miden-node/pull/294) from miden-node (and previous PRs)
- Updates the sync behavior
  - When doing a sync we check the account updates in two ways (always doing so **for tracked accounts**).
    - First, validating that the updated offchain account hashes match the ones of our client
    - Second, checking the updated onchain accounts, if the hash does not match ours that means it's outdated and thus we'll use the `get_account_updates` function to fetch the most up to date account