### PR TITLE
fix: use correct array size for SecretKey

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -9,7 +9,7 @@ use miden_client::{
 use miden_objects::{
     accounts::{AccountData, AccountId, AccountStorage, AccountType, StorageSlotType},
     assets::{Asset, TokenSymbol},
-    crypto::{dsa::rpo_falcon512::SecretKey, rand::FeltRng},
+    crypto::{dsa::rpo_falcon512::SK_LEN, rand::FeltRng},
     ZERO,
 };
 use miden_tx::utils::{bytes_to_hex_string, Deserializable, Serializable};
@@ -291,8 +291,7 @@ pub fn show_account<N: NodeRpcClient, R: FeltRng, S: Store>(
 
         match auth_info {
             miden_client::store::AuthInfo::RpoFalcon512(key_pair) => {
-                const KEY_PAIR_SIZE: usize = std::mem::size_of::<SecretKey>();
-                let auth_info: [u8; KEY_PAIR_SIZE] = key_pair
+                let auth_info: [u8; SK_LEN] = key_pair
                     .to_bytes()
                     .try_into()
                     .expect("Array size is const and should always exactly fit SecretKey");


### PR DESCRIPTION
I noticed that the command `miden-client account show <SOME_ACCOUNT_ID> -k` is failing due to the serialized `SecretKey` not fitting in a `sizeof(SecretKey)` bytes long array.

## Steps to reproduce

Using the CLI:

- create any regular account (e.g. `miden-client account new basic-immutable`)
- show the account keys with `miden-client account show <ACCOUNT_ID> -k`. This'll trigger the error