### PR TITLE
feat: Implement debug mode

### DIFF
--- a/docs/cli-config.md
+++ b/docs/cli-config.md
@@ -32,3 +32,7 @@ By default, the node is set up to run on `localhost:57291`.
 !!! note
     - Running the node locally for development is encouraged. 
     - However, the endpoint can point to any remote node.
+
+### Environment variables
+
+- `MIDEN_DEBUG`: When set to `true`, enables debug mode on the transaction executor and the script compiler. For any script that has been compiled and executed in this mode, debug logs will be output in order to facilitate MASM debugging ([these instructions](https://0xpolygonmiden.github.io/miden-vm/user_docs/assembly/debugging.html) can be used to do so). This variable can be overriden by the `--debug` CLI flag. 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -12,8 +12,16 @@ The following document lists the commands that the CLI currently supports.
 Call a command on the `miden-client` like this:
 
 ```sh
-miden-client <command> <sub-command> <--flag>
+miden-client <command> <sub-command>
 ```
+
+Optionally, you can include the `--debug` flag to run the command with debug mode, which enables debug output logs from scripts that were compiled in this mode:
+
+```sh
+miden-client --debug <command> <sub-command>
+```
+
+Note that the debug flag overrides the `MIDEN_DEBUG` environment variable.
 
 ## Commands
 

--- a/miden-client.toml
+++ b/miden-client.toml
@@ -1,7 +1,11 @@
-[rpc.endpoint]
-protocol = "http"
-host = "localhost"
-port = 57291
+## USAGE:
+## ================================================================================================
+# [rpc]: Settings for the RPC client used to communicate with the node
+#   - endpoint: tuple indicating the protocol (http, https), the host, and the port where the node is listening.
+# [store]: Settings for the client's Store
+#   - database_filepath: path for the sqlite's database
+[rpc]
+endpoint = { protocol = "http", host = "localhost", port = 57291 }
 
 [store]
 database_filepath = "store.sqlite3"

--- a/miden-client.toml
+++ b/miden-client.toml
@@ -1,11 +1,7 @@
-## USAGE:
-## ================================================================================================
-# [rpc]: Settings for the RPC client used to communicate with the node
-#   - endpoint: tuple indicating the protocol (http, https), the host, and the port where the node is listening.
-# [store]: Settings for the client's Store
-#   - database_filepath: path for the sqlite's database
-[rpc]
-endpoint = { protocol = "http", host = "localhost", port = 57291 }
+[rpc.endpoint]
+protocol = "http"
+host = "localhost"
+port = 57291
 
 [store]
 database_filepath = "store.sqlite3"

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -321,8 +321,8 @@ mod tests {
             rng,
             store,
             executor_store,
-        )
-        .unwrap();
+            true,
+        );
 
         // generate test data
         let assembler = TransactionKernel::assembler();
@@ -372,8 +372,8 @@ mod tests {
             rng,
             store,
             executor_store,
-        )
-        .unwrap();
+            true,
+        );
 
         import_note(&mut client, filename_path).unwrap();
         let imported_note_record: InputNoteRecord =
@@ -406,8 +406,8 @@ mod tests {
             rng,
             store,
             executor_store,
-        )
-        .unwrap();
+            true,
+        );
 
         // Ensure we get an error if no note is found
         let non_existent_note_id = "0x123456";

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -4,8 +4,9 @@ use miden_objects::{
 };
 use miden_tx::TransactionExecutor;
 use rand::Rng;
+use tracing::info;
 
-use crate::{errors::ClientError, store::Store};
+use crate::store::Store;
 
 pub mod rpc;
 use rpc::NodeRpcClient;
@@ -52,22 +53,28 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
     ///
     /// ## Arguments
     ///
-    /// - `api`: An instance of [NodeRpcClient] which provides a way for the client to connect to the Miden node.
-    /// - `store`: An instance of [Store], which provides a way to write and read entities to provide persistence.
+    /// - `api`: An instance of [NodeRpcClient] which provides a way for the client to connect
+    ///   to the Miden node.
+    /// - `store`: An instance of [Store], which provides a way to write and read entities to
+    ///   provide persistence.
     /// - `executor_store`: An instance of [Store] that provides a way for [TransactionExecutor] to
-    /// retrieve relevant inputs at the moment of transaction execution. It should be the same
-    /// store as the one for `store`, but it doesn't have to be the **same instance**
+    ///   retrieve relevant inputs at the moment of transaction execution. It should be the same
+    ///   store as the one for `store`, but it doesn't have to be the **same instance**.
+    /// - `in_debug_mode`: Instantiates the transaction executor (and in turn, its compiler)
+    ///   in debug mode, which will enable debug logs for scripts compiled with this mode for
+    ///   easier MASM debugging.
     ///
     /// # Errors
     ///
     /// Returns an error if the client could not be instantiated.
-    pub fn new(api: N, rng: R, store: S, executor_store: S) -> Result<Self, ClientError> {
-        Ok(Self {
-            store,
-            rng,
-            rpc_api: api,
-            tx_executor: TransactionExecutor::new(ClientDataStore::new(executor_store)),
-        })
+    pub fn new(api: N, rng: R, store: S, executor_store: S, in_debug_mode: bool) -> Self {
+        if in_debug_mode {
+            info!("Creating the Client in debug mode.");
+        }
+        let tx_executor = TransactionExecutor::new(ClientDataStore::new(executor_store))
+            .with_debug_mode(in_debug_mode);
+
+        Self { store, rng, rpc_api: api, tx_executor }
     }
 
     #[cfg(any(test, feature = "test_utils"))]

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -1,4 +1,9 @@
-use miden_objects::{crypto::rand::FeltRng, notes::NoteId};
+use miden_objects::{
+    assembly::ProgramAst,
+    crypto::rand::FeltRng,
+    notes::{NoteId, NoteScript},
+};
+use miden_tx::ScriptTarget;
 
 use super::{rpc::NodeRpcClient, Client};
 use crate::{
@@ -26,5 +31,18 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
     /// Imports a new input note into the client's store.
     pub fn import_input_note(&mut self, note: InputNoteRecord) -> Result<(), ClientError> {
         self.store.insert_input_note(&note).map_err(|err| err.into())
+    }
+
+    /// Compiles the provided program into a [NoteScript] and checks (to the extent possible) if
+    /// the specified note program could be executed against all accounts with the specified
+    /// interfaces.
+    pub fn compile_note_script(
+        &self,
+        note_script_ast: ProgramAst,
+        target_account_procs: Vec<ScriptTarget>,
+    ) -> Result<NoteScript, ClientError> {
+        self.tx_executor
+            .compile_note_script(note_script_ast, target_account_procs)
+            .map_err(ClientError::TransactionExecutorError)
     }
 }

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -216,7 +216,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
         let account_id = transaction_request.account_id();
         self.tx_executor
             .load_account(account_id)
-            .map_err(ClientError::TransactionExecutionError)?;
+            .map_err(ClientError::TransactionExecutorError)?;
 
         let block_num = self.store.get_sync_height()?;
 
@@ -296,7 +296,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
     {
         self.tx_executor
             .compile_tx_script(program, inputs, target_account_procs)
-            .map_err(ClientError::TransactionExecutionError)
+            .map_err(ClientError::TransactionExecutorError)
     }
 
     async fn submit_proven_transaction_request(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,7 +26,7 @@ pub enum ClientError {
     NodeRpcClientError(NodeRpcClientError),
     ScreenerError(ScreenerError),
     StoreError(StoreError),
-    TransactionExecutionError(TransactionExecutorError),
+    TransactionExecutorError(TransactionExecutorError),
     TransactionProvingError(TransactionProverError),
 }
 
@@ -57,7 +57,7 @@ impl fmt::Display for ClientError {
             ClientError::NodeRpcClientError(err) => write!(f, "rpc api error: {err}"),
             ClientError::ScreenerError(err) => write!(f, "note screener error: {err}"),
             ClientError::StoreError(err) => write!(f, "store error: {err}"),
-            ClientError::TransactionExecutionError(err) => {
+            ClientError::TransactionExecutorError(err) => {
                 write!(f, "transaction executor error: {err}")
             },
             ClientError::TransactionProvingError(err) => {
@@ -108,7 +108,7 @@ impl From<StoreError> for ClientError {
 
 impl From<TransactionExecutorError> for ClientError {
     fn from(err: TransactionExecutorError) -> Self {
-        Self::TransactionExecutionError(err)
+        Self::TransactionExecutorError(err)
     }
 }
 

--- a/src/store/sqlite_store/mod.rs
+++ b/src/store/sqlite_store/mod.rs
@@ -272,7 +272,7 @@ pub mod tests {
         let rng = get_random_coin();
         let executor_store = SqliteStore::new((&client_config).into()).unwrap();
 
-        MockClient::new(MockRpcApi::new(&rpc_endpoint), rng, store, executor_store).unwrap()
+        MockClient::new(MockRpcApi::new(&rpc_endpoint), rng, store, executor_store, true)
     }
 
     pub(crate) fn create_test_store_path() -> std::path::PathBuf {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -49,7 +49,7 @@ fn create_test_client() -> TestClient {
     let store = SqliteStore::new((&client_config).into()).unwrap();
     let executor_store = SqliteStore::new((&client_config).into()).unwrap();
     let rng = get_random_coin();
-    TestClient::new(TonicRpcClient::new(&rpc_endpoint), rng, store, executor_store).unwrap()
+    TestClient::new(TonicRpcClient::new(&rpc_endpoint), rng, store, executor_store, true)
 }
 
 fn create_test_store_path() -> std::path::PathBuf {
@@ -499,7 +499,7 @@ async fn assert_note_cannot_be_consumed_twice(
     // Double-spend error expected to be received since we are consuming the same note
     let tx_request = client.build_transaction_request(tx_template).unwrap();
     match client.new_transaction(tx_request) {
-        Err(ClientError::TransactionExecutionError(
+        Err(ClientError::TransactionExecutorError(
             TransactionExecutorError::FetchTransactionInputsFailed(
                 DataStoreError::NoteAlreadyConsumed(_),
             ),


### PR DESCRIPTION
- After https://github.com/0xPolygonMiden/miden-base/pull/562, implements debug mode.
- Adds a new method for compiling note scripts, so that users do not need to instantiate the assembler separately. This way if the client is created with debug mode, all scripts compiled and executed by it should show debug output.
- Changes return type of `Client::new()` removing the unnecessary `Result<>`
- Smaller renames/refactors

Follow-up work: 
- Create a test that confirms that debug output is shown