### PR TITLE
feat: ask confirmation before submitting transaction

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -125,13 +125,40 @@ After a transaction gets executed, two entities start being tracked:
 For `consume-notes` subcommand, you can also provide a partial ID instead of the full ID for each note. So instead of 
 
 ```sh
-miden-client consume-notes <some-account-id> 0x70b7ecba1db44c3aa75e87a3394de95463cc094d7794b706e02a9228342faeb0 0x80b7ecba1db44c3aa75e87a3394de95463cc094d7794b706e02a9228342faeb0
+miden-client tx new consume-notes <some-account-id> 0x70b7ecba1db44c3aa75e87a3394de95463cc094d7794b706e02a9228342faeb0 0x80b7ecba1db44c3aa75e87a3394de95463cc094d7794b706e02a9228342faeb0
 ``` 
 
 You can do: 
 
 ```sh
-miden-client consume-notes <some-account-id> 0x70b7ecb 0x80b7ecb
+miden-client tx new consume-notes <some-account-id> 0x70b7ecb 0x80b7ecb
+```
+
+#### Transaction confirmation
+
+When creating a new transaction, a summary of the transaction updates will be shown and confirmation for those updates will be prompted:
+
+```sh
+miden-client tx new ...
+
+TX Summary:
+
+...
+
+Proceed? (Y/N)
+```
+
+This confirmation can be skipped in non-interactive environments by providing the `--force` flag:
+
+```sh
+miden-client tx new ...
+
+TX Summary:
+
+...
+
+# no "Proceed?" here
+Proving and then submitting...
 ```
 
 For every command which needs an account ID (either wallet or faucet), you can also provide a partial ID instead of the full ID for each account. So instead of

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -151,7 +151,7 @@ Proceed? (Y/N)
 This confirmation can be skipped in non-interactive environments by providing the `--force` flag:
 
 ```sh
-miden-client tx new ...
+miden-client tx new --force ...
 
 TX Summary:
 

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -6,13 +6,12 @@ use miden_client::{
         rpc::NodeRpcClient,
         transactions::{
             transaction_request::{PaymentTransactionData, TransactionTemplate},
-            TransactionRecord,
+            TransactionRecord, TransactionResult,
         },
     },
     store::{Store, TransactionFilter},
 };
 use miden_objects::{
-    accounts::AccountDelta,
     assets::{Asset, FungibleAsset},
     crypto::rand::FeltRng,
     notes::{NoteId, NoteType as MidenNoteType},
@@ -137,7 +136,7 @@ async fn new_transaction<N: NodeRpcClient, R: FeltRng, S: Store>(
     println!("Executed transaction.");
 
     // Show delta and ask for confirmation
-    print_transaction_delta(transaction_execution_result.account_delta());
+    print_transaction_details(&transaction_execution_result);
     if !force {
         println!("Proceed? (Y/N)");
         let mut proceed_str: String = String::new();
@@ -155,7 +154,13 @@ async fn new_transaction<N: NodeRpcClient, R: FeltRng, S: Store>(
     Ok(())
 }
 
-fn print_transaction_delta(account_delta: &AccountDelta) {
+fn print_transaction_details(transaction_result: &TransactionResult) {
+    println!(
+        "Transaction Executed Against {}",
+        transaction_result.executed_transaction().account_id()
+    );
+
+    let account_delta = transaction_result.account_delta();
     let mut table = create_dynamic_table(&["Storage Slot", "Effect"]);
 
     for cleared_item_slot in account_delta.storage().cleared_items.iter() {

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -133,12 +133,10 @@ async fn new_transaction<N: NodeRpcClient, R: FeltRng, S: Store>(
     let transaction_request = client.build_transaction_request(transaction_template)?;
     let transaction_execution_result = client.new_transaction(transaction_request)?;
 
-    println!("Executed transaction.");
-
     // Show delta and ask for confirmation
     print_transaction_details(&transaction_execution_result);
     if !force {
-        println!("Proceed? (Y/N)");
+        println!("Continue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (Y/N)");
         let mut proceed_str: String = String::new();
         io::stdin().read_line(&mut proceed_str).expect("Should read line");
 
@@ -156,7 +154,7 @@ async fn new_transaction<N: NodeRpcClient, R: FeltRng, S: Store>(
 
 fn print_transaction_details(transaction_result: &TransactionResult) {
     println!(
-        "Transaction Executed Against {}",
+        "The transaction will have the following effects on the account with ID {}",
         transaction_result.executed_transaction().account_id()
     );
 
@@ -164,7 +162,7 @@ fn print_transaction_details(transaction_result: &TransactionResult) {
     let mut table = create_dynamic_table(&["Storage Slot", "Effect"]);
 
     for cleared_item_slot in account_delta.storage().cleared_items.iter() {
-        table.add_row(vec![cleared_item_slot.to_string(), "CLEARED".to_string()]);
+        table.add_row(vec![cleared_item_slot.to_string(), "Cleared".to_string()]);
     }
 
     for (updated_item_slot, new_value) in account_delta.storage().updated_items.iter() {
@@ -175,7 +173,7 @@ fn print_transaction_details(transaction_result: &TransactionResult) {
         ]);
     }
 
-    println!("Storage Changes:");
+    println!("Storage changes:");
     println!("{table}");
 
     let mut table = create_dynamic_table(&["Asset Type", "Faucet ID", "Amount"]);
@@ -204,13 +202,13 @@ fn print_transaction_details(transaction_result: &TransactionResult) {
         table.add_row(vec![asset_type, &faucet_id.to_hex(), &format!("-{}", amount)]);
     }
 
-    println!("Vault Changes:");
+    println!("Vault changes:");
     println!("{table}");
 
     if let Some(new_nonce) = account_delta.nonce() {
-        println!("New Nonce: {new_nonce}.")
+        println!("New nonce: {new_nonce}.")
     } else {
-        println!("No Nonce changes.")
+        println!("No nonce changes.")
     }
 }
 


### PR DESCRIPTION
closes #257 

## Summary of changes

- Shows the TX details before proving and submitting the tx [f0fb419](https://github.com/0xPolygonMiden/miden-client/pull/290/commits/f0fb4194e8a11bbb3a224e2bdc749413e5dd6c70)
- Adds a "--force" flag to the new transaction command to skip the confirmation step (ideal for non-interactive environments) [b712ede](https://github.com/0xPolygonMiden/miden-client/pull/290/commits/b712ede241784ab7550f3deaa43b6f2457b7f950)

## Steps to test

You can start from either a fresh client or an existing one. To test this change, you can run any transaction (i.e `miden-client tx new ...`) and check that it asks for confirmation and it prints a summary of the changes applied to the account. Enusure that if you submit a "y" or "Y" the transaction gets proven and sent to the node, and doesn't do anything else otherwise (no state shall be changed in that case)

Here's how it would look like:

<img width="1422" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/25107475/f21e6733-99d7-498c-ad0e-d8355e04c3a4">

After confirmation:

<img width="1440" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/25107475/ac24cbf0-9b5f-44ea-b0f8-1a345be2608e">