### PR TITLE
feat: verify imported note existance in the chain

### DIFF
--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -355,6 +355,7 @@ mod tests {
         let pending_note = InputNoteRecord::from(created_notes.first().unwrap().clone());
 
         client.import_input_note(committed_note.clone(), false).await.unwrap();
+        assert!(client.import_input_note(pending_note.clone(), true).await.is_err());
         client.import_input_note(pending_note.clone(), false).await.unwrap();
         assert!(pending_note.inclusion_proof().is_none());
         assert!(committed_note.inclusion_proof().is_some());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -107,7 +107,7 @@ impl Cli {
             Command::Account(account) => account.execute(client),
             Command::Init => Ok(()),
             Command::Info => info::print_client_info(&client),
-            Command::InputNotes(notes) => notes.execute(client),
+            Command::InputNotes(notes) => notes.execute(client).await,
             Command::Sync => sync::sync_state(client).await,
             Command::Tags(tags) => tags.execute(client).await,
             Command::Transaction(transaction) => transaction.execute(client).await,

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -159,7 +159,15 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
 
         let stored_note_tags: Vec<NoteTag> = self.store.get_note_tags()?;
 
-        let note_tags = [account_note_tags, stored_note_tags].concat();
+        let uncommited_note_tags: Vec<NoteTag> = self
+            .store
+            .get_input_notes(NoteFilter::Pending)?
+            .iter()
+            .filter(|note| note.metadata().is_some())
+            .map(|note| note.metadata().expect("Notes should have metadata after filter").tag())
+            .collect();
+
+        let note_tags = [account_note_tags, stored_note_tags, uncommited_note_tags].concat();
 
         // To receive information about added nullifiers, we reduce them to the higher 16 bits
         // Note that besides filtering by nullifier prefixes, the node also filters by block number

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,6 +28,7 @@ pub enum ClientError {
     StoreError(StoreError),
     TransactionExecutorError(TransactionExecutorError),
     TransactionProvingError(TransactionProverError),
+    ExistanceVerificationError(NoteId),
 }
 
 impl fmt::Display for ClientError {
@@ -62,6 +63,9 @@ impl fmt::Display for ClientError {
             },
             ClientError::TransactionProvingError(err) => {
                 write!(f, "transaction prover error: {err}")
+            },
+            ClientError::ExistanceVerificationError(note_id) => {
+                write!(f, "The note with ID {note_id} doesn't exist in the chain")
             },
         }
     }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -411,12 +411,12 @@ pub async fn insert_mock_data(client: &mut MockClient) -> Vec<BlockHeader> {
 
     // insert notes into database
     for note in consumed_notes.clone() {
-        client.import_input_note(note.into()).unwrap();
+        client.import_input_note(note.into(), false).await.unwrap();
     }
 
     // insert notes into database
     for note in created_notes.clone() {
-        client.import_input_note(note.into()).unwrap();
+        client.import_input_note(note.into(), false).await.unwrap();
     }
 
     // insert account

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,7 +35,7 @@ async fn test_input_notes_round_trip() {
 
     // insert notes into database
     for note in consumed_notes.iter().cloned() {
-        client.import_input_note(note.into()).unwrap();
+        client.import_input_note(note.into(), false).await.unwrap();
     }
 
     // retrieve notes from database
@@ -59,7 +59,10 @@ async fn test_get_input_note() {
     let (_consumed_notes, created_notes) = mock_notes(&assembler);
 
     // insert Note into database
-    client.import_input_note(created_notes.first().unwrap().clone().into()).unwrap();
+    client
+        .import_input_note(created_notes.first().unwrap().clone().into(), false)
+        .await
+        .unwrap();
 
     // retrieve note from database
     let retrieved_note =


### PR DESCRIPTION
closes #277

Added the option to verify a note when importing it to the client. If the verification passes we try to add an inclusion proof to the imported note if possible.

Also we now check for local uncommited notes in every sync. So if the note was imported but it's not relevant for tracked account it can also be updated. 