### PR TITLE
feat: add timeout to rpc config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Added rpc timeout configuration
 * Add offchain account support for the tonic client method `get_account_update`.
 * Refactorized `get_account` to create the account from a single query.
 * Admit partial account IDs for the commands that need them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-* Added rpc timeout configuration
+* Added RPC timeout configuration field
 * Add offchain account support for the tonic client method `get_account_update`.
 * Refactorized `get_account` to create the account from a single query.
 * Admit partial account IDs for the commands that need them.

--- a/docs/cli-config.md
+++ b/docs/cli-config.md
@@ -18,6 +18,7 @@ We configure the client using a [TOML](https://en.wikipedia.org/wiki/TOML) file 
 ```sh
 [rpc]
 endpoint = { protocol = "http", host = "localhost", port = 57291 }
+timeout_ms = 10000
 
 [store]
 database_filepath = "store.sqlite3"
@@ -25,7 +26,7 @@ database_filepath = "store.sqlite3"
 
 The TOML file should reside in same the directory from which you run the CLI.
 
-In the configuration file, you will find a section for defining the node's `endpoint` and the store's filename `database_filepath`. 
+In the configuration file, you will find a section for defining the node's rpc `endpoint` and timeout and the store's filename `database_filepath`. 
 
 By default, the node is set up to run on `localhost:57291`.
 

--- a/miden-client.toml
+++ b/miden-client.toml
@@ -6,6 +6,7 @@
 #   - database_filepath: path for the sqlite's database
 [rpc]
 endpoint = { protocol = "http", host = "localhost", port = 57291 }
+timeout = 10000
 
 [store]
 database_filepath = "store.sqlite3"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -57,6 +57,20 @@ fn initialize_rpc_config(client_config: &mut ClientConfig) -> Result<(), String>
 
     client_config.rpc.endpoint = Endpoint::new(protocol, host, port);
 
+    println!("Rpc request timeout in ms (default: 10000):");
+    let mut timeout_ms_str: String = String::new();
+    io::stdin().read_line(&mut timeout_ms_str).expect("Should read line");
+    timeout_ms_str = timeout_ms_str.trim().to_string();
+    let timeout_ms: u64 = if !timeout_ms_str.is_empty() {
+        timeout_ms_str
+            .parse()
+            .map_err(|err| format!("Error parsing timeout ms: {err}"))?
+    } else {
+        client_config.rpc.timeout_ms
+    };
+
+    client_config.rpc.timeout_ms = timeout_ms;
+
     Ok(())
 }
 

--- a/src/cli/input_notes.rs
+++ b/src/cli/input_notes.rs
@@ -351,7 +351,7 @@ mod tests {
 
     use miden_client::{
         client::get_random_coin,
-        config::{ClientConfig, Endpoint},
+        config::{ClientConfig, Endpoint, RpcConfig},
         errors::IdPrefixFetchError,
         mock::{mock_full_chain_mmr_and_notes, mock_notes, MockClient, MockRpcApi},
         store::{sqlite_store::SqliteStore, InputNoteRecord},
@@ -371,7 +371,7 @@ mod tests {
         path.push(Uuid::new_v4().to_string());
         let client_config = ClientConfig::new(
             path.into_os_string().into_string().unwrap().try_into().unwrap(),
-            Endpoint::default().into(),
+            RpcConfig::default(),
         );
 
         let store = SqliteStore::new((&client_config).into()).unwrap();
@@ -424,7 +424,7 @@ mod tests {
         path.push(Uuid::new_v4().to_string());
         let client_config = ClientConfig::new(
             path.into_os_string().into_string().unwrap().try_into().unwrap(),
-            Endpoint::default().into(),
+            RpcConfig::default(),
         );
         let store = SqliteStore::new((&client_config).into()).unwrap();
         let executor_store = SqliteStore::new((&client_config).into()).unwrap();
@@ -456,7 +456,7 @@ mod tests {
         path.push(Uuid::new_v4().to_string());
         let client_config = ClientConfig::new(
             path.into_os_string().into_string().unwrap().try_into().unwrap(),
-            Endpoint::default().into(),
+            RpcConfig::default(),
         );
 
         let store = SqliteStore::new((&client_config).into()).unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -87,7 +87,6 @@ impl Cli {
 
         // Create the client
         let client_config = load_config(current_dir.as_path())?;
-        let rpc_endpoint = client_config.rpc.endpoint.to_string();
         let store = SqliteStore::new((&client_config).into()).map_err(ClientError::StoreError)?;
         let rng = get_random_coin();
         let executor_store =
@@ -95,7 +94,7 @@ impl Cli {
                 .map_err(ClientError::StoreError)?;
 
         let client: Client<TonicRpcClient, RpoRandomCoin, SqliteStore> = Client::new(
-            TonicRpcClient::new(&rpc_endpoint),
+            TonicRpcClient::new(&client_config.rpc),
             rng,
             store,
             executor_store,

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,7 @@ impl Default for StoreConfig {
 // RPC CONFIG
 // ================================================================================================
 
+/// Settings for the RPC client
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RpcConfig {
     /// Address of the Miden node to connect to.

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,14 +143,19 @@ impl Default for StoreConfig {
 // RPC CONFIG
 // ================================================================================================
 
-#[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RpcConfig {
     /// Address of the Miden node to connect to.
     pub endpoint: Endpoint,
+    /// Timeout for the rpc api requests
+    pub timeout_ms: u64,
 }
 
-impl From<Endpoint> for RpcConfig {
-    fn from(value: Endpoint) -> Self {
-        Self { endpoint: value }
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Endpoint::default(),
+            timeout_ms: 10000,
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,12 @@ pub struct RpcConfig {
     /// Address of the Miden node to connect to.
     pub endpoint: Endpoint,
     /// Timeout for the rpc api requests
+    #[serde(default = "default_timeout")]
     pub timeout_ms: u64,
+}
+
+const fn default_timeout() -> u64 {
+    10000
 }
 
 impl Default for RpcConfig {

--- a/tests/config/miden-client.toml
+++ b/tests/config/miden-client.toml
@@ -6,6 +6,7 @@
 #   - database_filepath: path for the sqlite's database
 [rpc]
 endpoint = { protocol = "http", host = "localhost", port = 57291 }
+timeout = 10000
 
 [store]
 # IGNORED ON INTEGRATION TESTS

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -59,11 +59,10 @@ fn create_test_client() -> TestClient {
         .try_into()
         .unwrap();
 
-    let rpc_endpoint = client_config.rpc.endpoint.to_string();
     let store = SqliteStore::new((&client_config).into()).unwrap();
     let executor_store = SqliteStore::new((&client_config).into()).unwrap();
     let rng = get_random_coin();
-    TestClient::new(TonicRpcClient::new(&rpc_endpoint), rng, store, executor_store, true)
+    TestClient::new(TonicRpcClient::new(&client_config.rpc), rng, store, executor_store, true)
 }
 
 fn create_test_store_path() -> std::path::PathBuf {


### PR DESCRIPTION
Adds a timeout config to the rpc configuration. This is a small breaking change as now `TonicRpcClient` constructor takes the full rpc config. I checked [tonic endpoint's documentation](https://docs.rs/tonic/latest/tonic/transport/channel/struct.Endpoint.html) and didn't see any other relevant settings.