### PR TITLE
refactor: get account from a single store query

### DIFF
--- a/src/store/sqlite_store/accounts.rs
+++ b/src/store/sqlite_store/accounts.rs
@@ -86,7 +86,7 @@ impl SqliteStore {
                             FROM accounts \
                             JOIN account_code ON accounts.code_root = account_code.root \
                             JOIN account_storage ON accounts.storage_root = account_storage.root \
-                            JOIN account_vaults ON accounts.vault_root = aaccount_vaults.root \
+                            JOIN account_vaults ON accounts.vault_root = account_vaults.root \
                             WHERE accounts.id = ? \
                             ORDER BY accounts.nonce DESC \
                             LIMIT 1";


### PR DESCRIPTION
closes #286

Refactored the `get_account` function to build the account from a single big query instead of multiple small ones.