### PR TITLE
fix: replace known note script in note_scripts if exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-* Replace instead of ignoring note scripts when inserting input/output notes.
+* Replace instead of ignore note scripts with when inserting input/output notes with a previously-existing note script root to support adding debug statements.
 * Add offchain account support for the tonic client method `get_account_update`.
 * Refactorized `get_account` to create the account from a single query.
 * Admit partial account IDs for the commands that need them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Replace instead of ignoring note scripts when inserting input/output notes.
 * Add offchain account support for the tonic client method `get_account_update`.
 * Refactorized `get_account` to create the account from a single query.
 * Admit partial account IDs for the commands that need them.

--- a/src/store/sqlite_store/notes.rs
+++ b/src/store/sqlite_store/notes.rs
@@ -217,7 +217,7 @@ pub(super) fn insert_input_note_tx(
     .map(|_| ())?;
 
     const QUERY: &str =
-        "INSERT OR IGNORE INTO notes_scripts (script_hash, serialized_note_script) VALUES (?, ?)";
+        "INSERT OR REPLACE INTO notes_scripts (script_hash, serialized_note_script) VALUES (?, ?)";
     tx.execute(QUERY, params![note_script_hash, serialized_note_script,])
         .map_err(|err| StoreError::QueryError(err.to_string()))
         .map(|_| ())
@@ -256,7 +256,7 @@ pub fn insert_output_note_tx(
     .map(|_| ())?;
 
     const QUERY: &str =
-        "INSERT OR IGNORE INTO notes_scripts (script_hash, serialized_note_script) VALUES (?, ?)";
+        "INSERT OR REPLACE INTO notes_scripts (script_hash, serialized_note_script) VALUES (?, ?)";
     tx.execute(QUERY, params![note_script_hash, serialized_note_script,])
         .map_err(|err| StoreError::QueryError(err.to_string()))
         .map(|_| ())


### PR DESCRIPTION
Currently, we ignore note scripts if they already exist in the `note_scripts` table. This isn't necessarily wrong, but it makes it akward to debug notes because if you want to add a `debug.stack` instruction for example, the note script hash doesn't change and thus if you already had the note script on the db the change won't go through. Because of that, you end up needing to clear the db (or at least the existing row) on each change and it slows down the debug process