### PR TITLE
Re enable check on output notes for transactions

### DIFF
--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -479,7 +479,7 @@ fn get_transactions_to_commit(
             // https://github.com/0xPolygonMiden/miden-client/issues/144, we should be aware
             // that in the future it'll be possible to have many transactions modifying an
             // account be included in a single block. If that happens, we'll need to rewrite
-            // this check
+            // this check.
 
             t.input_note_nullifiers.iter().all(|n| nullifiers.contains(n))
                 && t.output_notes.iter().all(|n| note_ids.contains(&n.id()))

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -468,7 +468,7 @@ fn apply_mmr_changes(
 // final_account_state
 fn get_transactions_to_commit(
     uncommitted_transactions: &[TransactionRecord],
-    _note_ids: &[NoteId],
+    note_ids: &[NoteId],
     nullifiers: &[Digest],
     account_hash_updates: &[(AccountId, Digest)],
 ) -> Vec<TransactionId> {
@@ -481,10 +481,8 @@ fn get_transactions_to_commit(
             // account be included in a single block. If that happens, we'll need to rewrite
             // this check
 
-            // TODO: Review this. Because we receive note IDs based on account ID tags,
-            // we cannot base the status change on output notes alone;
             t.input_note_nullifiers.iter().all(|n| nullifiers.contains(n))
-                //&& t.output_notes.iter().all(|n| note_ids.contains(&n.id()))
+                && t.output_notes.iter().all(|n| note_ids.contains(&n.id()))
                 && account_hash_updates.iter().any(|(account_id, account_hash)| {
                     *account_id == t.account_id && *account_hash == t.final_account_state
                 })


### PR DESCRIPTION
closes #252

One of the conditions to check if a transaction was commited or not is whether it's output notes are also commited. This check was disabled because we thought it didn't work. We later discovered that it was not the case from the discussion in the issue. The previous PR (#273) was closed because of this.