### PR TITLE
fix: try to parse account id before searching on db

### DIFF
--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -170,7 +170,7 @@ impl AccountCmd {
                 let (_new_account, _account_seed) = client.new_account(client_template)?;
             },
             AccountCmd::Show { id, keys, vault, storage, code } => {
-                let account_id = parse_account_id(&client, id).map_err(|err| err.to_string())?;
+                let account_id = parse_account_id(&client, id)?;
                 show_account(client, account_id, *keys, *vault, *storage, *code)?;
             },
             AccountCmd::Import { filenames } => {

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -16,7 +16,7 @@ use miden_objects::{
 use miden_tx::utils::{bytes_to_hex_string, Deserializable, Serializable};
 use tracing::info;
 
-use super::{get_account_with_id_prefix, load_config, update_config, CLIENT_CONFIG_FILE_NAME};
+use super::{load_config, parse_account_id, update_config, CLIENT_CONFIG_FILE_NAME};
 use crate::cli::create_dynamic_table;
 
 // ACCOUNT COMMAND
@@ -170,8 +170,7 @@ impl AccountCmd {
                 let (_new_account, _account_seed) = client.new_account(client_template)?;
             },
             AccountCmd::Show { id, keys, vault, storage, code } => {
-                let account_id =
-                    get_account_with_id_prefix(&client, id).map_err(|err| err.to_string())?.id();
+                let account_id = parse_account_id(&client, id).map_err(|err| err.to_string())?;
                 show_account(client, account_id, *keys, *vault, *storage, *code)?;
             },
             AccountCmd::Import { filenames } => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,7 +17,7 @@ use miden_client::{
     store::{sqlite_store::SqliteStore, InputNoteRecord, NoteFilter as ClientNoteFilter, Store},
 };
 use miden_objects::{
-    accounts::AccountStub,
+    accounts::{AccountId, AccountStub},
     crypto::rand::{FeltRng, RpoRandomCoin},
 };
 use tracing::info;
@@ -195,7 +195,7 @@ pub(crate) fn get_note_with_id_prefix<N: NodeRpcClient, R: FeltRng, S: Store>(
 /// `account_id_prefix` is a prefix of its id.
 /// - Returns [IdPrefixFetchError::MultipleMatches] if there were more than one account found
 /// where `account_id_prefix` is a prefix of its id.
-pub(crate) fn get_account_with_id_prefix<N: NodeRpcClient, R: FeltRng, S: Store>(
+fn get_account_with_id_prefix<N: NodeRpcClient, R: FeltRng, S: Store>(
     client: &Client<N, R, S>,
     account_id_prefix: &str,
 ) -> Result<AccountStub, IdPrefixFetchError> {
@@ -230,6 +230,28 @@ pub(crate) fn get_account_with_id_prefix<N: NodeRpcClient, R: FeltRng, S: Store>
     }
 
     Ok(accounts.pop().expect("account_ids should always have one element"))
+}
+
+/// Parses a user provided account id string and returns the corresponding `AccountId`
+///
+/// `account_id` can fall into two categories:
+///
+/// - it's a prefix of an account id of an account tracked by the client
+/// - it's a full account id
+///
+/// # Errors
+///
+/// - Will return a `IdPrefixFetchError` if the provided account id string can't be parsed as an
+/// `AccountId` and does not correspond to an account tracked by the client either.
+pub(crate) fn parse_account_id<N: NodeRpcClient, R: FeltRng, S: Store>(
+    client: &Client<N, R, S>,
+    account_id: &str,
+) -> Result<AccountId, IdPrefixFetchError> {
+    if let Ok(account_id) = AccountId::from_hex(account_id) {
+        return Ok(account_id);
+    }
+
+    Ok(get_account_with_id_prefix(client, account_id)?.id())
 }
 
 pub(crate) fn update_config(config_path: &Path, client_config: ClientConfig) -> Result<(), String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -246,12 +246,15 @@ fn get_account_with_id_prefix<N: NodeRpcClient, R: FeltRng, S: Store>(
 pub(crate) fn parse_account_id<N: NodeRpcClient, R: FeltRng, S: Store>(
     client: &Client<N, R, S>,
     account_id: &str,
-) -> Result<AccountId, IdPrefixFetchError> {
+) -> Result<AccountId, String> {
     if let Ok(account_id) = AccountId::from_hex(account_id) {
         return Ok(account_id);
     }
 
-    Ok(get_account_with_id_prefix(client, account_id)?.id())
+    let account_id = get_account_with_id_prefix(client, account_id)
+        .map_err(|_err| "Input account ID {account_id} is neither a valid Account ID nor a prefix of a known Account ID")?
+        .id();
+    Ok(account_id)
 }
 
 pub(crate) fn update_config(config_path: &Path, client_config: ClientConfig) -> Result<(), String> {

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -16,7 +16,7 @@ use miden_objects::{
 };
 use tracing::info;
 
-use super::{get_account_with_id_prefix, get_note_with_id_prefix, Client, Parser};
+use super::{get_note_with_id_prefix, parse_account_id, Client, Parser};
 use crate::cli::create_dynamic_table;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -165,9 +165,7 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
             amount,
             note_type,
         } => {
-            let faucet_id = get_account_with_id_prefix(client, faucet_id)
-                .map_err(|err| err.to_string())?
-                .id();
+            let faucet_id = parse_account_id(client, faucet_id).map_err(|err| err.to_string())?;
             let fungible_asset =
                 FungibleAsset::new(faucet_id, *amount).map_err(|err| err.to_string())?.into();
 
@@ -176,12 +174,10 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
                 .clone()
                 .or(default_account_id)
                 .ok_or("Neither a sender nor a default account was provided".to_string())?;
-            let sender_account_id = get_account_with_id_prefix(client, &sender_account_id)
-                .map_err(|err| err.to_string())?
-                .id();
-            let target_account_id = get_account_with_id_prefix(client, target_account_id)
-                .map_err(|err| err.to_string())?
-                .id();
+            let sender_account_id =
+                parse_account_id(client, &sender_account_id).map_err(|err| err.to_string())?;
+            let target_account_id =
+                parse_account_id(client, target_account_id).map_err(|err| err.to_string())?;
 
             let payment_transaction =
                 PaymentTransactionData::new(fungible_asset, sender_account_id, target_account_id);
@@ -196,9 +192,7 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
             recall_height,
             note_type,
         } => {
-            let faucet_id = get_account_with_id_prefix(client, faucet_id)
-                .map_err(|err| err.to_string())?
-                .id();
+            let faucet_id = parse_account_id(client, faucet_id).map_err(|err| err.to_string())?;
             let fungible_asset =
                 FungibleAsset::new(faucet_id, *amount).map_err(|err| err.to_string())?.into();
 
@@ -207,12 +201,10 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
                 .clone()
                 .or(default_account_id)
                 .ok_or("Neither a sender nor a default account was provided".to_string())?;
-            let sender_account_id = get_account_with_id_prefix(client, &sender_account_id)
-                .map_err(|err| err.to_string())?
-                .id();
-            let target_account_id = get_account_with_id_prefix(client, target_account_id)
-                .map_err(|err| err.to_string())?
-                .id();
+            let sender_account_id =
+                parse_account_id(client, &sender_account_id).map_err(|err| err.to_string())?;
+            let target_account_id =
+                parse_account_id(client, target_account_id).map_err(|err| err.to_string())?;
 
             let payment_transaction =
                 PaymentTransactionData::new(fungible_asset, sender_account_id, target_account_id);
@@ -228,14 +220,11 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
             amount,
             note_type,
         } => {
-            let faucet_id = get_account_with_id_prefix(client, faucet_id)
-                .map_err(|err| err.to_string())?
-                .id();
+            let faucet_id = parse_account_id(client, faucet_id).map_err(|err| err.to_string())?;
             let fungible_asset =
                 FungibleAsset::new(faucet_id, *amount).map_err(|err| err.to_string())?;
-            let target_account_id = get_account_with_id_prefix(client, target_account_id)
-                .map_err(|err| err.to_string())?
-                .id();
+            let target_account_id =
+                parse_account_id(client, target_account_id).map_err(|err| err.to_string())?;
 
             Ok(TransactionTemplate::MintFungibleAsset(
                 fungible_asset,
@@ -257,9 +246,8 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
                 .clone()
                 .or(default_account_id)
                 .ok_or("Neither a sender nor a default account was provided".to_string())?;
-            let account_id = get_account_with_id_prefix(client, &account_id)
-                .map_err(|err| err.to_string())?
-                .id();
+            let account_id =
+                parse_account_id(client, &account_id).map_err(|err| err.to_string())?;
 
             Ok(TransactionTemplate::ConsumeNotes(account_id, list_of_notes))
         },

--- a/src/cli/transactions.rs
+++ b/src/cli/transactions.rs
@@ -165,7 +165,7 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
             amount,
             note_type,
         } => {
-            let faucet_id = parse_account_id(client, faucet_id).map_err(|err| err.to_string())?;
+            let faucet_id = parse_account_id(client, faucet_id)?;
             let fungible_asset =
                 FungibleAsset::new(faucet_id, *amount).map_err(|err| err.to_string())?.into();
 
@@ -174,10 +174,8 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
                 .clone()
                 .or(default_account_id)
                 .ok_or("Neither a sender nor a default account was provided".to_string())?;
-            let sender_account_id =
-                parse_account_id(client, &sender_account_id).map_err(|err| err.to_string())?;
-            let target_account_id =
-                parse_account_id(client, target_account_id).map_err(|err| err.to_string())?;
+            let sender_account_id = parse_account_id(client, &sender_account_id)?;
+            let target_account_id = parse_account_id(client, target_account_id)?;
 
             let payment_transaction =
                 PaymentTransactionData::new(fungible_asset, sender_account_id, target_account_id);
@@ -192,7 +190,7 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
             recall_height,
             note_type,
         } => {
-            let faucet_id = parse_account_id(client, faucet_id).map_err(|err| err.to_string())?;
+            let faucet_id = parse_account_id(client, faucet_id)?;
             let fungible_asset =
                 FungibleAsset::new(faucet_id, *amount).map_err(|err| err.to_string())?.into();
 
@@ -201,10 +199,8 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
                 .clone()
                 .or(default_account_id)
                 .ok_or("Neither a sender nor a default account was provided".to_string())?;
-            let sender_account_id =
-                parse_account_id(client, &sender_account_id).map_err(|err| err.to_string())?;
-            let target_account_id =
-                parse_account_id(client, target_account_id).map_err(|err| err.to_string())?;
+            let sender_account_id = parse_account_id(client, &sender_account_id)?;
+            let target_account_id = parse_account_id(client, target_account_id)?;
 
             let payment_transaction =
                 PaymentTransactionData::new(fungible_asset, sender_account_id, target_account_id);
@@ -220,11 +216,10 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
             amount,
             note_type,
         } => {
-            let faucet_id = parse_account_id(client, faucet_id).map_err(|err| err.to_string())?;
+            let faucet_id = parse_account_id(client, faucet_id)?;
             let fungible_asset =
                 FungibleAsset::new(faucet_id, *amount).map_err(|err| err.to_string())?;
-            let target_account_id =
-                parse_account_id(client, target_account_id).map_err(|err| err.to_string())?;
+            let target_account_id = parse_account_id(client, target_account_id)?;
 
             Ok(TransactionTemplate::MintFungibleAsset(
                 fungible_asset,
@@ -246,8 +241,7 @@ fn build_transaction_template<N: NodeRpcClient, R: FeltRng, S: Store>(
                 .clone()
                 .or(default_account_id)
                 .ok_or("Neither a sender nor a default account was provided".to_string())?;
-            let account_id =
-                parse_account_id(client, &account_id).map_err(|err| err.to_string())?;
+            let account_id = parse_account_id(client, &account_id)?;
 
             Ok(TransactionTemplate::ConsumeNotes(account_id, list_of_notes))
         },


### PR DESCRIPTION
on #274 we allowed partial IDs on commands, however we missed an interaction. We sometimes want to do operations against accounts not tracked by the client (e.g p2id, i don't necessarily have the target account in my client).

To overcome this we change a little bit

# Steps to reproduce

(on `next` should fail and in this branch it shouldn't)

- create a faucet account
- sync
- on a separate client, create a basic account stored offchain and copy its account id (let's call it `x`)
- go back to the starting client and do a mint transaction with `x` as the target account