### PR TITLE
feat: add a way to get the consumer account of a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Added a way to retrieve the ID of the tracked account that consumed a note.
 * Renamed the cli `input-notes` command to `notes`. Now we only export notes that were created on this client as the result of a transaction.
 * Added validation using the `NoteScreener` to see if a block has relevant notes.
 * Added flags to `init` command for non-interactive environments

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -238,7 +238,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
     ///
     /// Returns a [ClientError::StoreError] with a [StoreError::NoteNotConsumed](crate::errors::StoreError::NoteNotConsumed) if the note with the provided ID
     /// is not consumed.
-    /// Returns a [StoreError::][ClientError::StoreError] with a [StoreError::NoteNotFound](crate::errors::StoreError::NoteNotFound) if the note with the provided ID
+    /// Returns a [ClientError::StoreError] with a [StoreError::NoteNotFound](crate::errors::StoreError::NoteNotFound) if the note with the provided ID
     /// is not found.
     pub fn get_consumer_account_id(
         &self,

--- a/src/client/accounts.rs
+++ b/src/client/accounts.rs
@@ -8,6 +8,7 @@ use miden_objects::{
         dsa::rpo_falcon512::SecretKey,
         rand::{FeltRng, RpoRandomCoin},
     },
+    notes::NoteId,
     Digest, Felt, Word,
 };
 
@@ -228,6 +229,22 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
     /// not correspond to an existing account.
     pub fn get_account_auth(&self, account_id: AccountId) -> Result<AuthInfo, ClientError> {
         self.store.get_account_auth(account_id).map_err(|err| err.into())
+    }
+
+    /// Retrieves (if possible) the [AccountId] of the consumer of the note with the provided ID.
+    /// If the note was consumed but the consumer account is not tracked, `None` is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [ClientError::StoreError] with a [StoreError::NoteNotConsumed](crate::errors::StoreError::NoteNotConsumed) if the note with the provided ID
+    /// is not consumed.
+    /// Returns a [StoreError::][ClientError::StoreError] with a [StoreError::NoteNotFound](crate::errors::StoreError::NoteNotFound) if the note with the provided ID
+    /// is not found.
+    pub fn get_consumer_account_id(
+        &self,
+        note_id: NoteId,
+    ) -> Result<Option<AccountId>, ClientError> {
+        self.store.get_consumer_account_id(note_id).map_err(|err| err.into())
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -161,6 +161,7 @@ pub enum StoreError {
     DatabaseError(String),
     DataDeserializationError(DeserializationError),
     HexParseError(HexParseError),
+    NoteNotConsumed(NoteId),
     NoteNotFound(NoteId),
     InputSerializationError(serde_json::Error),
     JsonDataDeserializationError(serde_json::Error),
@@ -276,6 +277,9 @@ impl fmt::Display for StoreError {
             },
             NoteNotFound(note_id) => {
                 write!(f, "note with note id {} not found", note_id.inner())
+            },
+            NoteNotConsumed(note_id) => {
+                write!(f, "note with note id {} isn't consumed", note_id.inner())
             },
             InputSerializationError(err) => {
                 write!(f, "error trying to serialize inputs for the store: {err}")

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -196,6 +196,8 @@ pub trait Store {
     /// Retrieves (if possible) the [AccountId] of the consumer of the note with the provided ID.
     /// If the note was consumed but the consumer account is not tracked, `None` is returned.
     ///
+    /// The default implementation of this method uses [Store::get_input_notes] and [Store::get_transactions].
+    ///
     /// # Errors
     ///
     /// Returns a [StoreError::NoteNotConsumed] if the note with the provided ID is not consumed.

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -137,7 +137,6 @@ async fn test_p2idr_transfer_consumed_by_target() {
     assert_account_has_single_asset(&client, from_account_id, faucet_account_id, MINT_AMOUNT).await;
 
     // Check that the note is consumed by the target account
-    assert!(client.get_consumer_account_id(note.id()).unwrap().is_some());
     assert_eq!(client.get_consumer_account_id(note.id()).unwrap().unwrap(), from_account_id);
 
     // Do a transfer from first account to second account with Recall. In this situation we'll do

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -130,7 +130,7 @@ async fn test_p2idr_transfer_consumed_by_target() {
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::OffChain).await;
     println!("about to consume");
 
-    //Check that the note is not consumed by the target account
+    // Check that the note is not consumed by the target account
     assert!(client.get_consumer_account_id(note.id()).is_err());
 
     consume_notes(&mut client, from_account_id, &[note.clone()]).await;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -5,7 +5,7 @@ use miden_client::{
         transactions::transaction_request::{PaymentTransactionData, TransactionTemplate},
         NoteRelevance,
     },
-    errors::ClientError,
+    errors::{ClientError, StoreError},
     store::NoteFilter,
 };
 use miden_objects::{
@@ -130,8 +130,11 @@ async fn test_p2idr_transfer_consumed_by_target() {
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::OffChain).await;
     println!("about to consume");
 
-    // Check that the note is not consumed by the target account
-    assert!(client.get_consumer_account_id(note.id()).is_err());
+    //Check that the note is not consumed by the target account
+    assert!(matches!(
+        client.get_consumer_account_id(note.id()),
+        Err(ClientError::StoreError(StoreError::NoteNotConsumed(_)))
+    ));
 
     consume_notes(&mut client, from_account_id, &[note.clone()]).await;
     assert_account_has_single_asset(&client, from_account_id, faucet_account_id, MINT_AMOUNT).await;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -130,8 +130,15 @@ async fn test_p2idr_transfer_consumed_by_target() {
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::OffChain).await;
     println!("about to consume");
 
-    consume_notes(&mut client, from_account_id, &[note]).await;
+    //Check that the note is not consumed by the target account
+    assert!(client.get_consumer_account_id(note.id()).is_err());
+
+    consume_notes(&mut client, from_account_id, &[note.clone()]).await;
     assert_account_has_single_asset(&client, from_account_id, faucet_account_id, MINT_AMOUNT).await;
+
+    // Check that the note is consumed by the target account
+    assert!(client.get_consumer_account_id(note.id()).unwrap().is_some());
+    assert_eq!(client.get_consumer_account_id(note.id()).unwrap().unwrap(), from_account_id);
 
     // Do a transfer from first account to second account with Recall. In this situation we'll do
     // the happy path where the `to_account_id` consumes the note

--- a/tests/integration/onchain_tests.rs
+++ b/tests/integration/onchain_tests.rs
@@ -214,6 +214,9 @@ async fn test_onchain_accounts() {
     client_2.sync_state().await.unwrap();
     let notes = client_2.get_input_notes(NoteFilter::Committed).unwrap();
 
+    //Import the note on the first client so that we can later check its consumer account
+    client_1.import_input_note(notes[0].clone(), false).await.unwrap();
+
     // Consume the note
     println!("Consuming note con second client...");
     let tx_template = TransactionTemplate::ConsumeNotes(to_account_id, vec![notes[0].id()]);
@@ -223,6 +226,9 @@ async fn test_onchain_accounts() {
     // sync on first client
     println!("Syncing on first client...");
     client_1.sync_state().await.unwrap();
+
+    // Check that the client doesn't know who consumed the note
+    assert!(client_1.get_consumer_account_id(notes[0].id()).unwrap().is_none());
 
     let new_from_account_balance = client_1
         .get_account(from_account_id)


### PR DESCRIPTION
One of the changes requested in #314 is:

> show input note status (`pending`, `committed (height)`, `consumed(account_id_that_consumed_the_note)`) on `input-notes list`.

But we didn't have a way to get the account ID of the consumer of a note. This PR adds a new method to `Store` and `Client` that does just that.