### PR TITLE
feat: add extra cli output for certain commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-* Added more feedback information to commands `account new`, `input-notes import`, `tx new` and `sync`.
+* Added more feedback information to commands `info`, `notes list`, `notes show`, `account new`, `notes import`, `tx new` and `sync`.
 * Renamed the cli `input-notes` command to `notes`. Now we only export notes that were created on this client as the result of a transaction.
 * Added validation using the `NoteScreener` to see if a block has relevant notes.
 * Added flags to `init` command for non-interactive environments

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -11,7 +11,7 @@ pub fn print_client_info<N: NodeRpcClient, R: FeltRng, S: Store>(
     client: &Client<N, R, S>,
     config: &ClientConfig,
 ) -> Result<(), String> {
-    println!("client version: {}", env!("CARGO_PKG_VERSION"));
+    println!("Client version: {}", env!("CARGO_PKG_VERSION"));
     print_config_stats(config)?;
     print_client_stats(client)
 }
@@ -21,26 +21,26 @@ pub fn print_client_info<N: NodeRpcClient, R: FeltRng, S: Store>(
 fn print_client_stats<N: NodeRpcClient, R: FeltRng, S: Store>(
     client: &Client<N, R, S>,
 ) -> Result<(), String> {
-    println!("block number: {}", client.get_sync_height().map_err(|e| e.to_string())?);
+    println!("Block number: {}", client.get_sync_height().map_err(|e| e.to_string())?);
     println!(
-        "tracked accounts: {}",
+        "Tracked accounts: {}",
         client.get_account_stubs().map_err(|e| e.to_string())?.len()
     );
     println!(
-        "pending notes: {}",
+        "Pending notes: {}",
         client.get_input_notes(NoteFilter::Pending).map_err(|e| e.to_string())?.len()
     );
     Ok(())
 }
 
 fn print_config_stats(config: &ClientConfig) -> Result<(), String> {
-    println!("node address: {}", config.rpc.endpoint.host());
+    println!("Node address: {}", config.rpc.endpoint.host());
     let store_len = fs::metadata(config.store.database_filepath.clone())
         .map_err(|e| e.to_string())?
         .len();
-    println!("store size: {} kB", store_len / 1024);
+    println!("Store size: {} kB", store_len / 1024);
     println!(
-        "default account: {}",
+        "Default account: {}",
         config
             .cli
             .as_ref()

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -1,21 +1,51 @@
+use std::fs;
+
 use miden_client::{
     client::{rpc::NodeRpcClient, Client},
-    store::Store,
+    config::ClientConfig,
+    store::{NoteFilter, Store},
 };
 use miden_objects::crypto::rand::FeltRng;
 
 pub fn print_client_info<N: NodeRpcClient, R: FeltRng, S: Store>(
     client: &Client<N, R, S>,
+    config: &ClientConfig,
 ) -> Result<(), String> {
-    print_block_number(client)
+    println!("client version: {}", env!("CARGO_PKG_VERSION"));
+    print_config_stats(config)?;
+    print_client_stats(client)
 }
 
 // HELPERS
 // ================================================================================================
-
-fn print_block_number<N: NodeRpcClient, R: FeltRng, S: Store>(
+fn print_client_stats<N: NodeRpcClient, R: FeltRng, S: Store>(
     client: &Client<N, R, S>,
 ) -> Result<(), String> {
     println!("block number: {}", client.get_sync_height().map_err(|e| e.to_string())?);
+    println!(
+        "tracked accounts: {}",
+        client.get_account_stubs().map_err(|e| e.to_string())?.len()
+    );
+    println!(
+        "pending notes: {}",
+        client.get_input_notes(NoteFilter::Pending).map_err(|e| e.to_string())?.len()
+    );
+    Ok(())
+}
+
+fn print_config_stats(config: &ClientConfig) -> Result<(), String> {
+    println!("node address: {}", config.rpc.endpoint.host());
+    let store_len = fs::metadata(config.store.database_filepath.clone())
+        .map_err(|e| e.to_string())?
+        .len();
+    println!("store size: {} kB", store_len / 1024);
+    println!(
+        "default account: {}",
+        config
+            .cli
+            .as_ref()
+            .and_then(|cli| cli.default_account_id.as_ref())
+            .unwrap_or(&"-".to_string())
+    );
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -131,7 +131,7 @@ impl Cli {
             },
             Command::Import(import) => import.execute(client).await,
             Command::Init(_) => Ok(()),
-            Command::Info => info::print_client_info(&client),
+            Command::Info => info::print_client_info(&client, &client_config),
             Command::Notes { cmd: notes_cmd } => {
                 let notes_cmd = notes_cmd.clone().unwrap_or_default();
                 notes_cmd.execute(client).await

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -3,7 +3,9 @@ use std::collections::{HashMap, HashSet};
 use clap::ValueEnum;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::{
-    client::{rpc::NodeRpcClient, ConsumableNote},
+    client::{
+        rpc::NodeRpcClient, transactions::transaction_request::KnownScriptHash, ConsumableNote,
+    },
     errors::{ClientError, IdPrefixFetchError},
     store::{InputNoteRecord, NoteFilter as ClientNoteFilter, NoteStatus, OutputNoteRecord, Store},
 };
@@ -186,7 +188,7 @@ fn show_note<N: NodeRpcClient, R: FeltRng, S: Store>(
 
     let CliNoteSummary {
         note_id,
-        script_hash,
+        mut script_hash,
         assets_hash,
         inputs_commitment,
         serial_num,
@@ -196,6 +198,13 @@ fn show_note<N: NodeRpcClient, R: FeltRng, S: Store>(
 
     table.add_row(vec![Cell::new("Note Information").add_attribute(Attribute::Bold)]);
     table.add_row(vec![Cell::new("ID"), Cell::new(note_id)]);
+    match script_hash.clone().as_str() {
+        KnownScriptHash::P2ID => script_hash += " (P2ID)",
+        KnownScriptHash::P2IDR => script_hash += " (P2IDR)",
+        KnownScriptHash::SWAP => script_hash += " (SWAP)",
+        _ => {},
+    };
+
     table.add_row(vec![Cell::new("Script Hash"), Cell::new(script_hash)]);
     table.add_row(vec![Cell::new("Assets Hash"), Cell::new(assets_hash)]);
     table.add_row(vec![Cell::new("Inputs Hash"), Cell::new(inputs_commitment)]);

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -4,7 +4,9 @@ use clap::ValueEnum;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement};
 use miden_client::{
     client::{
-        rpc::NodeRpcClient, transactions::transaction_request::KnownScriptHash, ConsumableNote,
+        rpc::NodeRpcClient,
+        transactions::transaction_request::known_script_hashs::{P2ID, P2IDR, SWAP},
+        ConsumableNote,
     },
     errors::{ClientError, IdPrefixFetchError},
     store::{InputNoteRecord, NoteFilter as ClientNoteFilter, NoteStatus, OutputNoteRecord, Store},
@@ -190,9 +192,9 @@ fn show_note<N: NodeRpcClient, R: FeltRng, S: Store>(
 
     table.add_row(vec![Cell::new("ID"), Cell::new(id)]);
     match script_hash.clone().as_str() {
-        KnownScriptHash::P2ID => script_hash += " (P2ID)",
-        KnownScriptHash::P2IDR => script_hash += " (P2IDR)",
-        KnownScriptHash::SWAP => script_hash += " (SWAP)",
+        P2ID => script_hash += " (P2ID)",
+        P2IDR => script_hash += " (P2IDR)",
+        SWAP => script_hash += " (SWAP)",
         _ => {},
     };
 

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -460,9 +460,23 @@ fn note_summary(
         .map(|record| record.status())
         .or(output_note_record.map(|record| record.status()))
         .expect("One of the two records should be Some");
+
+    let note_consumer = input_note_record
+        .map(|record| record.consumer_account_id())
+        .or(output_note_record.map(|record| record.consumer_account_id()))
+        .expect("One of the two records should be Some");
+
     let note_status = match note_status {
         NoteStatus::Committed => {
             note_status.to_string() + format!(" (height {})", commit_height).as_str()
+        },
+        NoteStatus::Consumed => {
+            note_status.to_string()
+                + format!(
+                    " (by {})",
+                    note_consumer.map(|id| id.to_string()).unwrap_or("?".to_string())
+                )
+                .as_str()
         },
         _ => note_status.to_string(),
     };

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -283,6 +283,11 @@ fn show_note<N: NodeRpcClient, R: FeltRng, S: Store>(
         table
             .load_preset(presets::UTF8_HORIZONTAL_ONLY)
             .set_content_arrangement(ContentArrangement::DynamicFullWidth);
+        table.add_row(vec![
+            Cell::new("Index").add_attribute(Attribute::Bold),
+            Cell::new("Value").add_attribute(Attribute::Bold),
+        ]);
+
         inputs.values().iter().enumerate().for_each(|(idx, input)| {
             table.add_row(vec![Cell::new(idx).add_attribute(Attribute::Bold), Cell::new(input)]);
         });

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -112,6 +112,7 @@ struct CliNoteSummary {
     status: String,
     tag: String,
     sender: String,
+    exportable: bool,
 }
 
 // LIST NOTES
@@ -199,6 +200,7 @@ fn show_note<N: NodeRpcClient, R: FeltRng, S: Store>(
         status,
         tag,
         sender,
+        exportable,
     } = note_summary(input_note_record.as_ref(), output_note_record.as_ref())?;
 
     table.add_row(vec![Cell::new("ID"), Cell::new(id)]);
@@ -217,6 +219,7 @@ fn show_note<N: NodeRpcClient, R: FeltRng, S: Store>(
     table.add_row(vec![Cell::new("Status"), Cell::new(status)]);
     table.add_row(vec![Cell::new("Tag"), Cell::new(tag)]);
     table.add_row(vec![Cell::new("Sender"), Cell::new(sender)]);
+    table.add_row(vec![Cell::new("Exportable"), Cell::new(if exportable { "✔" } else { "✘" })]);
 
     println!("{table}");
 
@@ -346,9 +349,10 @@ where
             status,
             tag: _tag,
             sender: _sender,
+            exportable,
         } = note_summary(input_note_record, output_note_record)?;
 
-        let exportable = if output_note_record.is_some() { "✔" } else { "✘" };
+        let exportable = if exportable { "✔" } else { "✘" };
 
         table.add_row(vec![
             id,
@@ -512,6 +516,7 @@ fn note_summary(
         status,
         tag: note_tag_str,
         sender: note_sender_str,
+        exportable: output_note_record.is_some(),
     })
 }
 

--- a/src/client/note_screener.rs
+++ b/src/client/note_screener.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 use miden_objects::{accounts::AccountId, assets::Asset, notes::Note, Word};
 
-use super::transactions::transaction_request::KnownScriptHash;
+use super::transactions::transaction_request::known_script_hashs::{P2ID, P2IDR, SWAP};
 use crate::{
     errors::{InvalidNoteInputsError, ScreenerError},
     store::Store,
@@ -49,9 +49,9 @@ impl<'a, S: Store> NoteScreener<'a, S> {
 
         let script_hash = note.script().hash().to_string();
         let note_relevance = match script_hash.as_str() {
-            KnownScriptHash::P2ID => Self::check_p2id_relevance(note, &account_ids)?,
-            KnownScriptHash::P2IDR => Self::check_p2idr_relevance(note, &account_ids)?,
-            KnownScriptHash::SWAP => self.check_swap_relevance(note, &account_ids)?,
+            P2ID => Self::check_p2id_relevance(note, &account_ids)?,
+            P2IDR => Self::check_p2idr_relevance(note, &account_ids)?,
+            SWAP => self.check_swap_relevance(note, &account_ids)?,
             _ => self.check_script_relevance(note, &account_ids)?,
         };
 
@@ -194,7 +194,7 @@ mod tests {
         notes::NoteType,
     };
 
-    use crate::client::transactions::transaction_request::KnownScriptHash;
+    use crate::client::transactions::transaction_request::known_script_hashs::{P2ID, P2IDR, SWAP};
 
     // We need to make sure the script roots we use for filters are in line with the note scripts
     // coming from Miden objects
@@ -232,8 +232,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(p2id_note.script().hash().to_string(), KnownScriptHash::P2ID);
-        assert_eq!(p2idr_note.script().hash().to_string(), KnownScriptHash::P2IDR);
-        assert_eq!(swap_note.script().hash().to_string(), KnownScriptHash::SWAP);
+        assert_eq!(p2id_note.script().hash().to_string(), P2ID);
+        assert_eq!(p2idr_note.script().hash().to_string(), P2IDR);
+        assert_eq!(swap_note.script().hash().to_string(), SWAP);
     }
 }

--- a/src/client/note_screener.rs
+++ b/src/client/note_screener.rs
@@ -3,19 +3,11 @@ use core::fmt;
 
 use miden_objects::{accounts::AccountId, assets::Asset, notes::Note, Word};
 
+use super::transactions::transaction_request::KnownScriptHash;
 use crate::{
     errors::{InvalidNoteInputsError, ScreenerError},
     store::Store,
 };
-
-// KNOWN SCRIPT ROOTS
-// --------------------------------------------------------------------------------------------
-pub(crate) const P2ID_NOTE_SCRIPT_ROOT: &str =
-    "0xcdfd70344b952980272119bc02b837d14c07bbfc54f86a254422f39391b77b35";
-pub(crate) const P2IDR_NOTE_SCRIPT_ROOT: &str =
-    "0x41e5727b99a12b36066c09854d39d64dd09d9265c442a9be3626897572bf1745";
-pub(crate) const SWAP_NOTE_SCRIPT_ROOT: &str =
-    "0x5852920f88985b651cf7ef5e48623f898b6c292f4a2c25dd788ff8b46dd90417";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum NoteRelevance {
@@ -57,9 +49,9 @@ impl<'a, S: Store> NoteScreener<'a, S> {
 
         let script_hash = note.script().hash().to_string();
         let note_relevance = match script_hash.as_str() {
-            P2ID_NOTE_SCRIPT_ROOT => Self::check_p2id_relevance(note, &account_ids)?,
-            P2IDR_NOTE_SCRIPT_ROOT => Self::check_p2idr_relevance(note, &account_ids)?,
-            SWAP_NOTE_SCRIPT_ROOT => self.check_swap_relevance(note, &account_ids)?,
+            KnownScriptHash::P2ID => Self::check_p2id_relevance(note, &account_ids)?,
+            KnownScriptHash::P2IDR => Self::check_p2idr_relevance(note, &account_ids)?,
+            KnownScriptHash::SWAP => self.check_swap_relevance(note, &account_ids)?,
             _ => self.check_script_relevance(note, &account_ids)?,
         };
 
@@ -202,9 +194,7 @@ mod tests {
         notes::NoteType,
     };
 
-    use crate::client::note_screener::{
-        P2IDR_NOTE_SCRIPT_ROOT, P2ID_NOTE_SCRIPT_ROOT, SWAP_NOTE_SCRIPT_ROOT,
-    };
+    use crate::client::transactions::transaction_request::KnownScriptHash;
 
     // We need to make sure the script roots we use for filters are in line with the note scripts
     // coming from Miden objects
@@ -242,8 +232,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(p2id_note.script().hash().to_string(), P2ID_NOTE_SCRIPT_ROOT);
-        assert_eq!(p2idr_note.script().hash().to_string(), P2IDR_NOTE_SCRIPT_ROOT);
-        assert_eq!(swap_note.script().hash().to_string(), SWAP_NOTE_SCRIPT_ROOT);
+        assert_eq!(p2id_note.script().hash().to_string(), KnownScriptHash::P2ID);
+        assert_eq!(p2idr_note.script().hash().to_string(), KnownScriptHash::P2IDR);
+        assert_eq!(swap_note.script().hash().to_string(), KnownScriptHash::SWAP);
     }
 }

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -346,8 +346,13 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
         );
 
         let num_new_notes = new_note_details.new_public_notes.len();
-        let num_new_inclusion_proofs = new_note_details.updated_input_notes.len()
-            + new_note_details.updated_output_notes.len();
+        let updated_ids: BTreeSet<NoteId> = new_note_details
+            .updated_input_notes
+            .iter()
+            .map(|n| n.note().id())
+            .chain(new_note_details.updated_output_notes.iter().map(|(id, _)| *id))
+            .collect();
+        let num_new_inclusion_proofs = updated_ids.len();
         let num_new_nullifiers = new_nullifiers.len();
         let state_sync_update = StateSyncUpdate {
             block_header: response.block_header,

--- a/src/client/transactions/transaction_request.rs
+++ b/src/client/transactions/transaction_request.rs
@@ -168,3 +168,16 @@ impl PaymentTransactionData {
         self.asset
     }
 }
+
+// KNOWN SCRIPT HASHES
+// --------------------------------------------------------------------------------------------
+pub struct KnownScriptHash;
+
+impl KnownScriptHash {
+    pub const P2ID: &'static str =
+        "0xcdfd70344b952980272119bc02b837d14c07bbfc54f86a254422f39391b77b35";
+    pub const P2IDR: &'static str =
+        "0x41e5727b99a12b36066c09854d39d64dd09d9265c442a9be3626897572bf1745";
+    pub const SWAP: &'static str =
+        "0x5852920f88985b651cf7ef5e48623f898b6c292f4a2c25dd788ff8b46dd90417";
+}

--- a/src/client/transactions/transaction_request.rs
+++ b/src/client/transactions/transaction_request.rs
@@ -173,11 +173,8 @@ impl PaymentTransactionData {
 // --------------------------------------------------------------------------------------------
 pub struct KnownScriptHash;
 
-impl KnownScriptHash {
-    pub const P2ID: &'static str =
-        "0xcdfd70344b952980272119bc02b837d14c07bbfc54f86a254422f39391b77b35";
-    pub const P2IDR: &'static str =
-        "0x41e5727b99a12b36066c09854d39d64dd09d9265c442a9be3626897572bf1745";
-    pub const SWAP: &'static str =
-        "0x5852920f88985b651cf7ef5e48623f898b6c292f4a2c25dd788ff8b46dd90417";
+pub mod known_script_hashs {
+    pub const P2ID: &str = "0xcdfd70344b952980272119bc02b837d14c07bbfc54f86a254422f39391b77b35";
+    pub const P2IDR: &str = "0x41e5727b99a12b36066c09854d39d64dd09d9265c442a9be3626897572bf1745";
+    pub const SWAP: &str = "0x5852920f88985b651cf7ef5e48623f898b6c292f4a2c25dd788ff8b46dd90417";
 }

--- a/src/store/note_record/mod.rs
+++ b/src/store/note_record/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use miden_objects::{
     assembly::{Assembler, ProgramAst},
     notes::NoteScript,
@@ -83,6 +85,16 @@ impl Deserializable for NoteStatus {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let enum_byte = u8::read_from(source)?;
         enum_byte.try_into()
+    }
+}
+
+impl Display for NoteStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NoteStatus::Pending => write!(f, "Pending"),
+            NoteStatus::Committed => write!(f, "Committed"),
+            NoteStatus::Consumed => write!(f, "Consumed"),
+        }
     }
 }
 


### PR DESCRIPTION
closes #314 

This PR focuses on the last commands that needed improved output. Specifically:
- `info` now prints more information abount the client.
- `notes list` now shows the note status with additional information like commit height and consumer account.
- `notes show` is better styled and shows the information in a clearer manner.

Some screenshots:
`info` command
<img width="565" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/43424983/571f4171-c797-4918-b82f-c219c598bf58">

`notes list` command
<img width="1277" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/43424983/28870a94-4726-4bf1-a7bd-7d18ef4fdfd7">

`notes show` command (with all flags)
<img width="1277" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/43424983/58493bcf-1f6d-48f0-88a7-4b1a71ecb8d4">
<img width="1277" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/43424983/4a60ceca-83e0-4ee4-9330-ebd0f87d0ab0">
<img width="1277" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/43424983/df765753-ab00-4a09-83a1-f2bb74428262">
 