### PR TITLE
feat: add a way to get the consumer account of a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Add `consumer_account_id` to `InputNoteRecord` with an implementation for sqlite store.
 * Renamed the cli `input-notes` command to `notes`. Now we only export notes that were created on this client as the result of a transaction.
 * Added validation using the `NoteScreener` to see if a block has relevant notes.
 * Added flags to `init` command for non-interactive environments

--- a/src/client/notes.rs
+++ b/src/client/notes.rs
@@ -154,6 +154,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
                 note.metadata().copied(),
                 Some(inclusion_proof),
                 note.details().clone(),
+                None,
             );
         }
 

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -39,14 +39,20 @@ pub struct TransactionResult {
     executed_transaction: ExecutedTransaction,
     output_notes: Vec<Note>,
     relevant_notes: Option<BTreeMap<usize, Vec<(AccountId, NoteRelevance)>>>,
+    consumed_notes: Vec<NoteId>,
 }
 
 impl TransactionResult {
-    pub fn new(executed_transaction: ExecutedTransaction, created_notes: Vec<Note>) -> Self {
+    pub fn new(
+        executed_transaction: ExecutedTransaction,
+        created_notes: Vec<Note>,
+        consumed_notes: Vec<NoteId>,
+    ) -> Self {
         Self {
             executed_transaction,
             output_notes: created_notes,
             relevant_notes: None,
+            consumed_notes,
         }
     }
 
@@ -86,6 +92,10 @@ impl TransactionResult {
 
     pub fn account_delta(&self) -> &AccountDelta {
         self.executed_transaction.account_delta()
+    }
+
+    pub fn consumed_notes(&self) -> &Vec<NoteId> {
+        &self.consumed_notes
     }
 }
 
@@ -245,7 +255,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
             return Err(ClientError::MissingOutputNotes(missing_note_ids));
         }
 
-        Ok(TransactionResult::new(executed_transaction, output_notes))
+        Ok(TransactionResult::new(executed_transaction, output_notes, note_ids))
     }
 
     /// Proves the specified transaction witness, submits it to the node, and stores the transaction in

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -8,8 +8,8 @@ use miden_objects::{
     crypto::rand::RpoRandomCoin,
     notes::{Note, NoteId, NoteType},
     transaction::{
-        ExecutedTransaction, OutputNotes, ProvenTransaction, TransactionArgs, TransactionId,
-        TransactionScript,
+        ExecutedTransaction, InputNotes, OutputNotes, ProvenTransaction, TransactionArgs,
+        TransactionId, TransactionScript,
     },
     Digest, Felt, Word,
 };
@@ -39,20 +39,14 @@ pub struct TransactionResult {
     executed_transaction: ExecutedTransaction,
     output_notes: Vec<Note>,
     relevant_notes: Option<BTreeMap<usize, Vec<(AccountId, NoteRelevance)>>>,
-    consumed_notes: Vec<NoteId>,
 }
 
 impl TransactionResult {
-    pub fn new(
-        executed_transaction: ExecutedTransaction,
-        created_notes: Vec<Note>,
-        consumed_notes: Vec<NoteId>,
-    ) -> Self {
+    pub fn new(executed_transaction: ExecutedTransaction, created_notes: Vec<Note>) -> Self {
         Self {
             executed_transaction,
             output_notes: created_notes,
             relevant_notes: None,
-            consumed_notes,
         }
     }
 
@@ -94,8 +88,8 @@ impl TransactionResult {
         self.executed_transaction.account_delta()
     }
 
-    pub fn consumed_notes(&self) -> &Vec<NoteId> {
-        &self.consumed_notes
+    pub fn consumed_notes(&self) -> &InputNotes {
+        self.executed_transaction.tx_inputs().input_notes()
     }
 }
 
@@ -255,7 +249,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store> Client<N, R, S> {
             return Err(ClientError::MissingOutputNotes(missing_note_ids));
         }
 
-        Ok(TransactionResult::new(executed_transaction, output_notes, note_ids))
+        Ok(TransactionResult::new(executed_transaction, output_notes))
     }
 
     /// Proves the specified transaction witness, submits it to the node, and stores the transaction in

--- a/src/store/note_record/input_note_record.rs
+++ b/src/store/note_record/input_note_record.rs
@@ -1,4 +1,5 @@
 use miden_objects::{
+    accounts::AccountId,
     notes::{
         Note, NoteAssets, NoteId, NoteInclusionProof, NoteInputs, NoteMetadata, NoteRecipient,
     },
@@ -34,6 +35,7 @@ pub struct InputNoteRecord {
     metadata: Option<NoteMetadata>,
     recipient: Digest,
     status: NoteStatus,
+    consumer_account_id: Option<AccountId>,
 }
 
 impl InputNoteRecord {
@@ -45,6 +47,7 @@ impl InputNoteRecord {
         metadata: Option<NoteMetadata>,
         inclusion_proof: Option<NoteInclusionProof>,
         details: NoteRecordDetails,
+        consumer_account_id: Option<AccountId>,
     ) -> InputNoteRecord {
         InputNoteRecord {
             id,
@@ -54,6 +57,7 @@ impl InputNoteRecord {
             metadata,
             inclusion_proof,
             details,
+            consumer_account_id,
         }
     }
 
@@ -88,6 +92,10 @@ impl InputNoteRecord {
     pub fn details(&self) -> &NoteRecordDetails {
         &self.details
     }
+
+    pub fn consumer_account_id(&self) -> Option<AccountId> {
+        self.consumer_account_id
+    }
 }
 
 impl Serializable for InputNoteRecord {
@@ -120,6 +128,7 @@ impl Deserializable for InputNoteRecord {
             metadata,
             inclusion_proof,
             details,
+            consumer_account_id: None,
         })
     }
 }
@@ -139,6 +148,7 @@ impl From<Note> for InputNoteRecord {
                 note.inputs().to_vec(),
                 note.serial_num(),
             ),
+            consumer_account_id: None,
         }
     }
 }
@@ -158,6 +168,7 @@ impl From<InputNote> for InputNoteRecord {
                 recorded_note.note().serial_num(),
             ),
             inclusion_proof: Some(recorded_note.proof().clone()),
+            consumer_account_id: None,
         }
     }
 }
@@ -218,6 +229,7 @@ impl TryFrom<OutputNoteRecord> for InputNoteRecord {
                 metadata: Some(*output_note.metadata()),
                 recipient: output_note.recipient(),
                 status: output_note.status(),
+                consumer_account_id: output_note.consumer_account_id(),
             }),
             None => Err(ClientError::NoteError(miden_objects::NoteError::invalid_origin_index(
                 "Output Note Record contains no details".to_string(),

--- a/src/store/note_record/input_note_record.rs
+++ b/src/store/note_record/input_note_record.rs
@@ -22,6 +22,10 @@ use crate::errors::ClientError;
 /// Once the proof is set, the [InputNoteRecord] can be transformed into an [InputNote] and used as
 /// input for transactions.
 ///
+/// The `consumer_account_id` field is used to keep track of the account that consumed the note. It
+/// is only valid if the `status` is [NoteStatus::Consumed]. If the note is consumed but the field
+/// is [None] it means that the note was consumed by an untracked account.
+///
 /// It is also possible to convert [Note] and [InputNote] into [InputNoteRecord] (we fill the
 /// `metadata` and `inclusion_proof` fields if possible)
 #[derive(Clone, Debug, PartialEq)]

--- a/src/store/note_record/output_note_record.rs
+++ b/src/store/note_record/output_note_record.rs
@@ -19,6 +19,10 @@ use crate::errors::ClientError;
 ///
 /// It is also possible to convert [Note] into [OutputNoteRecord] (we fill the `details` and
 /// `inclusion_proof` fields if possible)
+///
+/// The `consumer_account_id` field is used to keep track of the account that consumed the note. It
+/// is only valid if the `status` is [NoteStatus::Consumed]. If the note is consumed but the field
+/// is [None] it means that the note was consumed by an untracked account.
 #[derive(Clone, Debug, PartialEq)]
 pub struct OutputNoteRecord {
     assets: NoteAssets,

--- a/src/store/note_record/output_note_record.rs
+++ b/src/store/note_record/output_note_record.rs
@@ -1,4 +1,5 @@
 use miden_objects::{
+    accounts::AccountId,
     notes::{Note, NoteAssets, NoteId, NoteInclusionProof, NoteMetadata},
     Digest,
 };
@@ -27,6 +28,7 @@ pub struct OutputNoteRecord {
     metadata: NoteMetadata,
     recipient: Digest,
     status: NoteStatus,
+    consumer_account_id: Option<AccountId>,
 }
 
 impl OutputNoteRecord {
@@ -38,6 +40,7 @@ impl OutputNoteRecord {
         metadata: NoteMetadata,
         inclusion_proof: Option<NoteInclusionProof>,
         details: Option<NoteRecordDetails>,
+        consumer_account_id: Option<AccountId>,
     ) -> OutputNoteRecord {
         OutputNoteRecord {
             id,
@@ -47,6 +50,7 @@ impl OutputNoteRecord {
             metadata,
             inclusion_proof,
             details,
+            consumer_account_id,
         }
     }
 
@@ -77,6 +81,10 @@ impl OutputNoteRecord {
     pub fn details(&self) -> Option<&NoteRecordDetails> {
         self.details.as_ref()
     }
+
+    pub fn consumer_account_id(&self) -> Option<AccountId> {
+        self.consumer_account_id
+    }
 }
 
 impl From<Note> for OutputNoteRecord {
@@ -94,6 +102,7 @@ impl From<Note> for OutputNoteRecord {
                 note.inputs().to_vec(),
                 note.serial_num(),
             )),
+            consumer_account_id: None,
         }
     }
 }
@@ -111,6 +120,7 @@ impl TryFrom<InputNoteRecord> for OutputNoteRecord {
                 metadata: *metadata,
                 recipient: input_note.recipient(),
                 status: input_note.status(),
+                consumer_account_id: input_note.consumer_account_id(),
             }),
             None => Err(ClientError::NoteError(miden_objects::NoteError::invalid_origin_index(
                 "Input Note Record contains no metadata".to_string(),

--- a/src/store/sqlite_store/notes.rs
+++ b/src/store/sqlite_store/notes.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 use clap::error::Result;
 use miden_objects::{
+    accounts::AccountId,
     crypto::utils::{Deserializable, Serializable},
     notes::{NoteAssets, NoteId, NoteInclusionProof, NoteMetadata, NoteScript, Nullifier},
     Digest,
@@ -18,8 +19,9 @@ use crate::{
 fn insert_note_query(table_name: NoteTable) -> String {
     format!("\
     INSERT INTO {table_name}
-        (note_id, assets, recipient, status, metadata, details, inclusion_proof) 
-     VALUES (:note_id, :assets, :recipient, :status, json(:metadata), json(:details), json(:inclusion_proof))")
+        (note_id, assets, recipient, status, metadata, details, inclusion_proof, consumer_transaction_id) 
+     VALUES (:note_id, :assets, :recipient, :status, json(:metadata), json(:details), json(:inclusion_proof), :consumer_transaction_id)",
+            table_name = table_name)
 }
 
 // TYPES
@@ -48,10 +50,26 @@ type SerializedOutputNoteData = (
     Option<String>,
 );
 
-type SerializedInputNoteParts =
-    (Vec<u8>, String, String, String, Option<String>, Option<String>, Vec<u8>);
-type SerializedOutputNoteParts =
-    (Vec<u8>, Option<String>, String, String, String, Option<String>, Option<Vec<u8>>);
+type SerializedInputNoteParts = (
+    Vec<u8>,
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    Vec<u8>,
+    Option<i64>,
+);
+type SerializedOutputNoteParts = (
+    Vec<u8>,
+    Option<String>,
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<Vec<u8>>,
+    Option<i64>,
+);
 
 // NOTE TABLE
 // ================================================================================================
@@ -85,11 +103,15 @@ impl<'a> NoteFilter<'a> {
                     note.status,
                     note.metadata,
                     note.inclusion_proof,
-                    script.serialized_note_script
+                    script.serialized_note_script,
+                    tx.account_id
                     from {notes_table} AS note 
                     LEFT OUTER JOIN notes_scripts AS script
                         ON note.details IS NOT NULL AND 
-                        json_extract(note.details, '$.script_hash') = script.script_hash"
+                        json_extract(note.details, '$.script_hash') = script.script_hash
+                    LEFT OUTER JOIN transactions AS tx
+                        ON note.consumer_transaction_id IS NOT NULL AND
+                        note.consumer_transaction_id = tx.id"
         );
 
         match self {
@@ -255,6 +277,7 @@ pub(super) fn insert_input_note_tx(
             ":metadata": metadata,
             ":details": details,
             ":inclusion_proof": inclusion_proof,
+            ":consumer_transaction_id": None::<String>,
         },
     )
     .map_err(|err| StoreError::QueryError(err.to_string()))
@@ -317,6 +340,7 @@ fn parse_input_note_columns(
     let metadata: Option<String> = row.get(4)?;
     let inclusion_proof: Option<String> = row.get(5)?;
     let serialized_note_script: Vec<u8> = row.get(6)?;
+    let consumer_account_id: Option<i64> = row.get(7)?;
 
     Ok((
         assets,
@@ -326,6 +350,7 @@ fn parse_input_note_columns(
         metadata,
         inclusion_proof,
         serialized_note_script,
+        consumer_account_id,
     ))
 }
 
@@ -341,6 +366,7 @@ fn parse_input_note(
         note_metadata,
         note_inclusion_proof,
         serialized_note_script,
+        consumer_account_id,
     ) = serialized_input_note_parts;
 
     // Merge the info that comes from the input notes table and the notes script table
@@ -380,7 +406,10 @@ fn parse_input_note(
     let id = NoteId::new(recipient, note_assets.commitment());
     let status: NoteStatus = serde_json::from_str(&format!("\"{status}\""))
         .map_err(StoreError::JsonDataDeserializationError)?;
-
+    let consumer_account_id: Option<AccountId> = match consumer_account_id {
+        Some(account_id) => Some(AccountId::try_from(account_id as u64)?),
+        None => None,
+    };
     Ok(InputNoteRecord::new(
         id,
         recipient,
@@ -389,6 +418,7 @@ fn parse_input_note(
         note_metadata,
         inclusion_proof,
         note_details,
+        consumer_account_id,
     ))
 }
 
@@ -465,6 +495,7 @@ fn parse_output_note_columns(
     let metadata: String = row.get(4)?;
     let inclusion_proof: Option<String> = row.get(5)?;
     let serialized_note_script: Option<Vec<u8>> = row.get(6)?;
+    let consumer_account_id: Option<i64> = row.get(7)?;
 
     Ok((
         assets,
@@ -474,6 +505,7 @@ fn parse_output_note_columns(
         metadata,
         inclusion_proof,
         serialized_note_script,
+        consumer_account_id,
     ))
 }
 
@@ -489,6 +521,7 @@ fn parse_output_note(
         note_metadata,
         note_inclusion_proof,
         serialized_note_script,
+        consumer_account_id,
     ) = serialized_output_note_parts;
 
     let note_details: Option<NoteRecordDetails> = if let Some(details_as_json_str) = note_details {
@@ -531,6 +564,11 @@ fn parse_output_note(
     let status: NoteStatus = serde_json::from_str(&format!("\"{status}\""))
         .map_err(StoreError::JsonDataDeserializationError)?;
 
+    let consumer_account_id: Option<AccountId> = match consumer_account_id {
+        Some(account_id) => Some(AccountId::try_from(account_id as u64)?),
+        None => None,
+    };
+
     Ok(OutputNoteRecord::new(
         id,
         recipient,
@@ -539,6 +577,7 @@ fn parse_output_note(
         note_metadata,
         inclusion_proof,
         note_details,
+        consumer_account_id,
     ))
 }
 

--- a/src/store/sqlite_store/store.sql
+++ b/src/store/sqlite_store/store.sql
@@ -92,6 +92,8 @@ CREATE TABLE input_notes (
     -- script_hash                                                 -- the note's script hash
     -- inputs                                                 -- the serialized NoteInputs, including inputs hash and list of inputs
     -- serial_num                                             -- the note serial number
+    consumer_transaction_id BLOB NULL,                      -- the transaction ID of the transaction that consumed the note
+    FOREIGN KEY (consumer_transaction_id) REFERENCES transactions(id) NULL,
     PRIMARY KEY (note_id)
 
     CONSTRAINT check_valid_inclusion_proof_json CHECK (
@@ -104,6 +106,7 @@ CREATE TABLE input_notes (
         json_extract(inclusion_proof, '$.note_path') IS NOT NULL
       ))
     CONSTRAINT check_valid_metadata_json CHECK (metadata IS NULL OR (json_extract(metadata, '$.sender') IS NOT NULL AND json_extract(metadata, '$.tag') IS NOT NULL))
+    CONSTRAINT check_valid_consumer_transaction_id CHECK (consumer_transaction_id IS NULL OR status = 'Consumed')
 );
 
 -- Create output notes table
@@ -131,6 +134,8 @@ CREATE TABLE output_notes (
     -- script                                                 -- the note's script hash
     -- inputs                                                 -- the serialized NoteInputs, including inputs hash and list of inputs
     -- serial_num                                             -- the note serial number
+    consumer_transaction_id BLOB NULL,                      -- the transaction ID of the transaction that consumed the note
+    FOREIGN KEY (consumer_transaction_id) REFERENCES transactions(id) NULL,
     PRIMARY KEY (note_id)
 
     CONSTRAINT check_valid_inclusion_proof_json CHECK (
@@ -150,7 +155,7 @@ CREATE TABLE output_notes (
         json_extract(details, '$.inputs') IS NOT NULL AND
         json_extract(details, '$.serial_num') IS NOT NULL
       ))
-
+    CONSTRAINT check_valid_consumer_transaction_id CHECK (consumer_transaction_id IS NULL OR status = 'Consumed')
 );
 
 -- Create note's scripts table, used for both input and output notes

--- a/src/store/sqlite_store/store.sql
+++ b/src/store/sqlite_store/store.sql
@@ -93,7 +93,7 @@ CREATE TABLE input_notes (
     -- inputs                                                 -- the serialized NoteInputs, including inputs hash and list of inputs
     -- serial_num                                             -- the note serial number
     consumer_transaction_id BLOB NULL,                      -- the transaction ID of the transaction that consumed the note
-    FOREIGN KEY (consumer_transaction_id) REFERENCES transactions(id) NULL,
+    FOREIGN KEY (consumer_transaction_id) REFERENCES transactions(id)
     PRIMARY KEY (note_id)
 
     CONSTRAINT check_valid_inclusion_proof_json CHECK (
@@ -106,7 +106,7 @@ CREATE TABLE input_notes (
         json_extract(inclusion_proof, '$.note_path') IS NOT NULL
       ))
     CONSTRAINT check_valid_metadata_json CHECK (metadata IS NULL OR (json_extract(metadata, '$.sender') IS NOT NULL AND json_extract(metadata, '$.tag') IS NOT NULL))
-    CONSTRAINT check_valid_consumer_transaction_id CHECK (consumer_transaction_id IS NULL OR status = 'Consumed')
+    CONSTRAINT check_valid_consumer_transaction_id CHECK (consumer_transaction_id IS NULL OR status != 'Pending')
 );
 
 -- Create output notes table
@@ -135,7 +135,7 @@ CREATE TABLE output_notes (
     -- inputs                                                 -- the serialized NoteInputs, including inputs hash and list of inputs
     -- serial_num                                             -- the note serial number
     consumer_transaction_id BLOB NULL,                      -- the transaction ID of the transaction that consumed the note
-    FOREIGN KEY (consumer_transaction_id) REFERENCES transactions(id) NULL,
+    FOREIGN KEY (consumer_transaction_id) REFERENCES transactions(id)
     PRIMARY KEY (note_id)
 
     CONSTRAINT check_valid_inclusion_proof_json CHECK (
@@ -155,7 +155,7 @@ CREATE TABLE output_notes (
         json_extract(details, '$.inputs') IS NOT NULL AND
         json_extract(details, '$.serial_num') IS NOT NULL
       ))
-    CONSTRAINT check_valid_consumer_transaction_id CHECK (consumer_transaction_id IS NULL OR status = 'Consumed')
+    CONSTRAINT check_valid_consumer_transaction_id CHECK (consumer_transaction_id IS NULL OR status != 'Pending')
 );
 
 -- Create note's scripts table, used for both input and output notes

--- a/src/store/sqlite_store/transactions.rs
+++ b/src/store/sqlite_store/transactions.rs
@@ -99,7 +99,8 @@ impl SqliteStore {
             .map(|note| OutputNoteRecord::from(note.clone()))
             .collect::<Vec<_>>();
 
-        let consumed_note_ids = tx_result.consumed_notes().clone();
+        let consumed_note_ids =
+            tx_result.consumed_notes().iter().map(|note| note.id()).collect::<Vec<_>>();
 
         let mut db = self.db();
         let tx = db.transaction()?;

--- a/src/store/sqlite_store/transactions.rs
+++ b/src/store/sqlite_store/transactions.rs
@@ -12,7 +12,7 @@ use tracing::info;
 
 use super::{
     accounts::update_account,
-    notes::{insert_input_note_tx, insert_output_note_tx},
+    notes::{insert_input_note_tx, insert_output_note_tx, update_note_consumer_tx_id},
     SqliteStore,
 };
 use crate::{
@@ -79,6 +79,7 @@ impl SqliteStore {
 
     /// Inserts a transaction and updates the current state based on the `tx_result` changes
     pub fn apply_transaction(&self, tx_result: TransactionResult) -> Result<(), StoreError> {
+        let transaction_id = tx_result.executed_transaction().id();
         let account_id = tx_result.executed_transaction().account_id();
         let account_delta = tx_result.account_delta();
 
@@ -97,6 +98,8 @@ impl SqliteStore {
             .iter()
             .map(|note| OutputNoteRecord::from(note.clone()))
             .collect::<Vec<_>>();
+
+        let consumed_note_ids = tx_result.consumed_notes().clone();
 
         let mut db = self.db();
         let tx = db.transaction()?;
@@ -117,6 +120,10 @@ impl SqliteStore {
 
         for note in &created_output_notes {
             insert_output_note_tx(&tx, note)?;
+        }
+
+        for note_id in consumed_note_ids {
+            update_note_consumer_tx_id(&tx, note_id, transaction_id)?;
         }
 
         tx.commit()?;

--- a/tests/integration/onchain_tests.rs
+++ b/tests/integration/onchain_tests.rs
@@ -3,7 +3,7 @@ use miden_client::{
         accounts::{AccountStorageMode, AccountTemplate},
         transactions::transaction_request::{PaymentTransactionData, TransactionTemplate},
     },
-    store::NoteFilter,
+    store::{NoteFilter, NoteStatus},
 };
 use miden_objects::{
     accounts::AccountId,
@@ -214,6 +214,9 @@ async fn test_onchain_accounts() {
     client_2.sync_state().await.unwrap();
     let notes = client_2.get_input_notes(NoteFilter::Committed).unwrap();
 
+    //Import the note on the first client so that we can later check its consumer account
+    client_1.import_input_note(notes[0].clone(), false).await.unwrap();
+
     // Consume the note
     println!("Consuming note con second client...");
     let tx_template = TransactionTemplate::ConsumeNotes(to_account_id, vec![notes[0].id()]);
@@ -223,6 +226,11 @@ async fn test_onchain_accounts() {
     // sync on first client
     println!("Syncing on first client...");
     client_1.sync_state().await.unwrap();
+
+    // Check that the client doesn't know who consumed the note
+    let input_note = client_1.get_input_note(notes[0].id()).unwrap();
+    assert!(matches!(input_note.status(), NoteStatus::Consumed));
+    assert!(input_note.consumer_account_id().is_none());
 
     let new_from_account_balance = client_1
         .get_account(from_account_id)


### PR DESCRIPTION
This is a better implementation for the problem addressed in PR #325 using the ideas proposed in [this discussion](https://github.com/0xPolygonMiden/miden-client/pull/325#issuecomment-2099305918).