### PR TITLE
feat: split proving and submitting message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* [BREAKING] Separate `prove_transaction` from `submit_transaction` in `Client`.
+
 ## v0.3.0 (2024-05-17)
 
 * Added swap transactions and example flows on integration tests.

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -184,7 +184,10 @@ mod tests {
         let transaction_request = client.build_transaction_request(transaction_template).unwrap();
         let transaction = client.new_transaction(transaction_request).unwrap();
         let created_note = transaction.created_notes().get_note(0).clone();
-        client.submit_transaction(transaction).await.unwrap();
+        let proven_transaction =
+            client.prove_transaction(transaction.executed_transaction().clone()).unwrap();
+
+        client.submit_transaction(transaction, proven_transaction).await.unwrap();
 
         // Ensure client has no input notes and one output note
         assert!(client.get_input_notes(NoteFilter::All).unwrap().is_empty());

--- a/src/cli/new_transactions.rs
+++ b/src/cli/new_transactions.rs
@@ -323,12 +323,12 @@ async fn execute_transaction<
     let proven_transaction =
         client.prove_transaction(transaction_execution_result.executed_transaction().clone())?;
     println!("Proving took: {}ms", start.elapsed().as_millis());
-    println!("Submitting transaction to node...");
+    println!("Submitting transaction to node and storing in database...");
     let start = Instant::now();
     client
         .submit_transaction(transaction_execution_result, proven_transaction)
         .await?;
-    println!("Submission took: {}ms", start.elapsed().as_millis());
+    println!("Submission and storage took: {}ms", start.elapsed().as_millis());
 
     if let TransactionTemplate::Swap(swap_data, note_type) = transaction_template {
         let payback_note_tag: u32 = build_swap_tag(

--- a/src/cli/new_transactions.rs
+++ b/src/cli/new_transactions.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, time::Instant};
 
 use clap::{Parser, ValueEnum};
 use miden_client::{
@@ -318,7 +318,17 @@ async fn execute_transaction<
         .iter()
         .map(|note| note.id())
         .collect::<Vec<_>>();
-    client.submit_transaction(transaction_execution_result).await?;
+    println!("Proving transaction...");
+    let start = Instant::now();
+    let proven_transaction =
+        client.prove_transaction(transaction_execution_result.executed_transaction().clone())?;
+    println!("Proving took: {}ms", start.elapsed().as_millis());
+    println!("Submitting transaction to node...");
+    let start = Instant::now();
+    client
+        .submit_transaction(transaction_execution_result, proven_transaction)
+        .await?;
+    println!("Submission took: {}ms", start.elapsed().as_millis());
 
     if let TransactionTemplate::Swap(swap_data, note_type) = transaction_template {
         let payback_note_tag: u32 = build_swap_tag(

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -593,7 +593,9 @@ mod tests {
         let transaction_request = client.build_transaction_request(transaction_template).unwrap();
         let transaction = client.new_transaction(transaction_request).unwrap();
         let created_note = transaction.created_notes().get_note(0).clone();
-        client.submit_transaction(transaction).await.unwrap();
+        let proven_transaction =
+            client.prove_transaction(transaction.executed_transaction().clone()).unwrap();
+        client.submit_transaction(transaction, proven_transaction).await.unwrap();
 
         // Ensure client has no input notes and one output note
         assert!(client.get_input_notes(NoteFilter::All).unwrap().is_empty());

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -272,6 +272,8 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         TransactionResult::new(executed_transaction, screener, partial_notes)
     }
 
+    /// Proves the specified transaction witness, and returns a [ProvenTransaction] that can be
+    /// submitted to the node.
     pub fn prove_transaction(
         &mut self,
         executed_transaction: ExecutedTransaction,
@@ -283,7 +285,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         Ok(proven_transaction)
     }
 
-    /// Proves the specified transaction witness, submits it to the node, and stores the transaction in
+    /// Submits a [ProvenTransaction] to the node, and stores the transaction in
     /// the local database for tracking.
     pub async fn submit_transaction(
         &mut self,

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -281,7 +281,6 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         let transaction_prover = TransactionProver::new(ProvingOptions::default());
 
         let proven_transaction = transaction_prover.prove_transaction(executed_transaction)?;
-        info!("Transaction proved");
         Ok(proven_transaction)
     }
 

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -317,13 +317,6 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
             .map_err(ClientError::TransactionExecutorError)
     }
 
-    async fn submit_proven_transaction_request(
-        &mut self,
-        proven_transaction: ProvenTransaction,
-    ) -> Result<(), ClientError> {
-        Ok(self.rpc_api.submit_proven_transaction(proven_transaction).await?)
-    }
-
     // HELPERS
     // --------------------------------------------------------------------------------------------
 

--- a/src/client/transactions/mod.rs
+++ b/src/client/transactions/mod.rs
@@ -292,7 +292,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         tx_result: TransactionResult,
         proven_transaction: ProvenTransaction,
     ) -> Result<(), ClientError> {
-        self.submit_proven_transaction_request(proven_transaction).await?;
+        self.rpc_api.submit_proven_transaction(proven_transaction).await?;
         info!("Transaction submitted");
 
         // Transaction was proven and submitted to the node correctly, persist note details and update account

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -523,8 +523,14 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
 
     let transaction_request = client.build_transaction_request(transaction_template).unwrap();
     let transaction_execution_result = client.new_transaction(transaction_request).unwrap();
+    let proven_transaction = client
+        .prove_transaction(transaction_execution_result.executed_transaction().clone())
+        .unwrap();
 
-    client.submit_transaction(transaction_execution_result).await.unwrap();
+    client
+        .submit_transaction(transaction_execution_result, proven_transaction)
+        .await
+        .unwrap();
 }
 
 pub fn mock_fungible_faucet_account(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -431,7 +431,9 @@ async fn test_get_output_notes() {
     assert!(client.get_output_notes(NoteFilter::All).unwrap().is_empty());
 
     let transaction = client.new_transaction(transaction_request).unwrap();
-    client.submit_transaction(transaction).await.unwrap();
+    let proven_transaction =
+        client.prove_transaction(transaction.executed_transaction().clone()).unwrap();
+    client.submit_transaction(transaction, proven_transaction).await.unwrap();
 
     // Check that there was an output note but it wasn't consumed
     assert!(client.get_output_notes(NoteFilter::Consumed).unwrap().is_empty());

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -84,7 +84,13 @@ pub async fn execute_tx_and_sync(client: &mut TestClient, tx_request: Transactio
     let transaction_id = transaction_execution_result.executed_transaction().id();
 
     println!("Sending transaction to node");
-    client.submit_transaction(transaction_execution_result).await.unwrap();
+    let proven_transaction = client
+        .prove_transaction(transaction_execution_result.executed_transaction().clone())
+        .unwrap();
+    client
+        .submit_transaction(transaction_execution_result, proven_transaction)
+        .await
+        .unwrap();
 
     // wait until tx is committed
     loop {


### PR DESCRIPTION
Closes #330 

**This is a breaking change.**
This PR separates the proving from the submition of a new transaction in the client. This lets us have separate messages in the cli with the duration of each step.

<img width="1280" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/43424983/82380395-4de2-4155-8f7c-c4cf78e625b4">
