### PR TITLE
refactor: simplify and separate note list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Simplified and separated the `notes --list` table (#356).
+
 ## v0.3.0 (2024-05-17)
 
 * Added swap transactions and example flows on integration tests.

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -112,23 +112,11 @@ fn list_accounts<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthentic
 ) -> Result<(), String> {
     let accounts = client.get_account_stubs()?;
 
-    let mut table = create_dynamic_table(&[
-        "Account ID",
-        "Code Root",
-        "Vault Root",
-        "Storage Root",
-        "Type",
-        "Storage mode",
-        "Nonce",
-    ]);
+    let mut table = create_dynamic_table(&["Account ID", "Type", "Nonce"]);
     accounts.iter().for_each(|(acc, _acc_seed)| {
         table.add_row(vec![
             acc.id().to_string(),
-            acc.code_root().to_string(),
-            acc.vault_root().to_string(),
-            acc.storage_root().to_string(),
             account_type_display_name(&acc.id().account_type()),
-            storage_type_display_name(&acc.id()),
             acc.nonce().as_int().to_string(),
         ]);
     });

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -112,11 +112,12 @@ fn list_accounts<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthentic
 ) -> Result<(), String> {
     let accounts = client.get_account_stubs()?;
 
-    let mut table = create_dynamic_table(&["Account ID", "Type", "Nonce"]);
+    let mut table = create_dynamic_table(&["Account ID", "Type", "Storage Mode", "Nonce"]);
     accounts.iter().for_each(|(acc, _acc_seed)| {
         table.add_row(vec![
             acc.id().to_string(),
             account_type_display_name(&acc.id().account_type()),
+            storage_type_display_name(&acc.id()),
             acc.nonce().as_int().to_string(),
         ]);
     });

--- a/src/store/sqlite_store/notes.rs
+++ b/src/store/sqlite_store/notes.rs
@@ -335,18 +335,29 @@ pub fn update_note_consumer_tx_id(
     note_id: NoteId,
     consumer_tx_id: TransactionId,
 ) -> Result<(), StoreError> {
-    const QUERY: &str = "UPDATE input_notes SET consumer_transaction_id = :consumer_transaction_id WHERE note_id = :note_id;
-                         UPDATE output_notes SET consumer_transaction_id = :consumer_transaction_id WHERE note_id = :note_id;";
+    const UPDATE_INPUT_NOTES_QUERY: &str = "UPDATE input_notes SET consumer_transaction_id = :consumer_transaction_id WHERE note_id = :note_id;";
 
     tx.execute(
-        QUERY,
+        UPDATE_INPUT_NOTES_QUERY,
         named_params! {
             ":note_id": note_id.inner().to_string(),
             ":consumer_transaction_id": consumer_tx_id.to_string(),
         },
     )
-    .map_err(|err| StoreError::QueryError(err.to_string()))
-    .map(|_| ())
+    .map_err(|err| StoreError::QueryError(err.to_string()))?;
+
+    const UPDATE_OUTPUT_NOTES_QUERY: &str = "UPDATE output_notes SET consumer_transaction_id = :consumer_transaction_id WHERE note_id = :note_id;";
+
+    tx.execute(
+        UPDATE_OUTPUT_NOTES_QUERY,
+        named_params! {
+            ":note_id": note_id.inner().to_string(),
+            ":consumer_transaction_id": consumer_tx_id.to_string(),
+        },
+    )
+    .map_err(|err| StoreError::QueryError(err.to_string()))?;
+
+    Ok(())
 }
 
 /// Parse input note columns from the provided row into native types.


### PR DESCRIPTION
closes #332 

The `notes --list` command showed both input and output in the same table. The table was also a bit crowded. 
This PR fixes this by separating the notes into two side by side tables that only show the ID and status of a note. 
If the user wants to see more information about a certain note they can run `miden notes --show <id>`.

Additional fixes:
- The `miden account` table is also simplified to only show ID, type and nonce. 
- Fixed a bug where the `consumer_account_id` was only updated on input notes.

Screenshot of the new table (ignore the fact that some consumers are not known, that is the bug that was fixed):
<img width="1279" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/43424983/f8c0abed-adb6-42f2-acd5-a83b4f50bf7f">
