### PR TITLE
fix: mark txs as committed

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    env,
-    rc::Rc,
-};
+use std::{env, rc::Rc};
 
 use clap::Parser;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};

--- a/src/client/sync.rs
+++ b/src/client/sync.rs
@@ -760,16 +760,16 @@ fn get_transactions_to_commit(
         uncommitted_transaction_by_end_hash.insert(tx.final_account_state, tx);
     }
 
-    let mut transitive_commited_transactions = Vec::new();
+    let mut transitive_committed_transactions = Vec::new();
     for committed_tx in committed_transactions_from_update {
         let mut current_tx = committed_tx;
-        transitive_commited_transactions.push(current_tx.id);
+        transitive_committed_transactions.push(current_tx.id);
 
         while uncommitted_transaction_by_end_hash.contains_key(&current_tx.init_account_state) {
             current_tx = uncommitted_transaction_by_end_hash[&current_tx.init_account_state];
-            transitive_commited_transactions.push(current_tx.id);
+            transitive_committed_transactions.push(current_tx.id);
         }
     }
 
-    transitive_commited_transactions
+    transitive_committed_transactions
 }


### PR DESCRIPTION
While debugging #360 we found a way to have transactions getting committed but not appearing so in the client. This is probably the issue that was reported on #314.

## How to reproduce

The issue happens when we execute more than 1 transaction against the same account (which get included in different blocks). Then when we perform a sync we end up with the last of those in a committed state while the others do not. An easy way of reproducing it is by:

- creating a wallet and a fungible faucet
- mint 2 or more times
- wait for a bit and then sync
- then run `miden tx` and you'll see only the last one being committed

## The cause

The cause of this is somewhat rooted in the sync_state protocol. Whenever we do a sync we get account hash updates corresponding to the account ids from the `SyncStateRequest` we made. However, updates on account hashes only get included if they're the current account hash of that account. That means that if account A was changed on blocks 2, 4 and 6, our local chain tip points to 0, and we do a sync (while trakcing A in our client). The whole process would span 3 requests (first we get a response for block 2, then we do a new request and get 4 and lastly block 6), and the account hash update for A would only come in the last response.

Changing the protocol isn't as easy though since the node only tracks a single row per account and discards the history, so unless we change that (there might be some storage limitations there) it won't be possible to send all account hash updates.

## What this PR does

In this PR I extend the commitment check on transactions to do the following:

- If the current check said it's committed => it's committed
- If an uncommitted TX A with init_account_hash = X gets committed and there is a second uncommitted TX B with final_account_hash = X, then that gets committed as well
- This last property describes a transitive relation so what we end up doing is computing the transitive closure (that is: get the txs we commit, and go to previous txs via prev.final_account_hash == current.init_account_hash and mark them as committed)

### Current solution's limitations

This solution works fine and get's the transactions that previously ended up pending to be committed. However, with this check we lose track of the block height at which some TXs get committed. We might end with something like this:

<img width="1421" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/25107475/59eaf5cc-1841-4a33-b9df-d4ae450dbbfb">

Which does not reflect what actually happened (each one of those in the image happened in a different block). One way of "hiding" this is not showing the block height or showing `(Block <= 446)` but still we'd be storing false info.

### Some alternatives

1. As @igamigo suggested in #360, we could replace the commitment check from `all nullifiers came in the update && all output notes came in the update && the change in account hash came in the update` to `all nullifiers came in the update && (all output notes came in the update || the change in account hash came in the update)`
  - This comes at a cost where TXs that change the account hash but do not produce/consume notes would be committed instantly. Also, once the node gets decentralized it might be a bit unsafe since someone could consume the same note as you and you'd see your tx getting committed while it could happen that the other user got it first
  - At first I thought of combining the solution from this PR and this change in the commitment check, but tbh changing the commitment check will "eat" all cases this PR change handles and I don't see too much sense in having code that won't be executed (despite it being valuable in the future)
2. We could change the protocol and send all account hash updates instead of the last one, but that would require bigger changes to the node