### PR TITLE
feat: set created/imported account as default if none is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Added a new check on account creation / import on the CLI to set the account as the default one if none is set.
 * Fixed bug when exporting a note into a file
 * Simplified and separated the `notes --list` table (#356).
 * [BREAKING] Separate `prove_transaction` from `submit_transaction` in `Client`. (#339)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-* Added a new check on account creation / import on the CLI to set the account as the default one if none is set.
-* Fixed bug when exporting a note into a file
+* Added a new check on account creation / import on the CLI to set the account as the default one if none is set (#372).
+* Fixed bug when exporting a note into a file (#368).
 * Simplified and separated the `notes --list` table (#356).
 * [BREAKING] Separate `prove_transaction` from `submit_transaction` in `Client`. (#339)
 * [BREAKING] Updated CLI commands so assets are now passed as `<AMOUNT>::<FAUCET_ACCOUNT_ID>` (#349)

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -298,21 +298,20 @@ pub(crate) fn set_default_account(account_id: Option<AccountId>) -> Result<(), S
     update_config(&config_path, current_config)
 }
 
-/// Sets the provided account ID as the default account, if not set already.
+/// Sets the provided account ID as the default account and updates the config file, if not set already.
 pub(crate) fn maybe_set_default_account(
-    current_config: &ClientConfig,
+    current_config: &mut ClientConfig,
     account_id: AccountId,
 ) -> Result<(), String> {
-    if current_config
-        .cli
-        .as_ref()
-        .is_some_and(|cli_config| cli_config.default_account_id.is_some())
-    {
-        set_default_account(Some(account_id))?;
-        let account_id = account_id.to_hex();
-        println!("Setting account {account_id} as the default account ID.");
-        println!("You can unset it with `{CLIENT_BINARY_NAME} account --default none`.");
+    if let Some(CliConfig { default_account_id: Some(_) }) = current_config.cli {
+        return Ok(());
     }
+
+    set_default_account(Some(account_id))?;
+    let account_id = account_id.to_hex();
+    println!("Setting account {account_id} as the default account ID.");
+    println!("You can unset it with `{CLIENT_BINARY_NAME} account --default none`.");
+    current_config.cli = Some(CliConfig { default_account_id: Some(account_id) });
 
     Ok(())
 }

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -8,9 +8,8 @@ use miden_objects::crypto::rand::FeltRng;
 use miden_tx::{utils::Serializable, TransactionAuthenticator};
 use tracing::info;
 
-use crate::cli::get_output_note_with_id_prefix;
-
 use super::Parser;
+use crate::cli::get_output_note_with_id_prefix;
 
 #[derive(Debug, Parser, Clone)]
 #[clap(about = "Export client output notes")]

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -17,7 +17,8 @@ use miden_objects::{
 use miden_tx::TransactionAuthenticator;
 use tracing::info;
 
-use super::Parser;
+use super::{utils::load_config_file, Parser};
+use crate::cli::account::maybe_set_default_account;
 
 #[derive(Debug, Parser, Clone)]
 #[clap(about = "Import client objects such as accounts and notes")]
@@ -36,6 +37,7 @@ impl ImportCmd {
         mut client: Client<N, R, S, A>,
     ) -> Result<(), String> {
         validate_paths(&self.filenames)?;
+        let (current_config, _) = load_config_file()?;
         for filename in &self.filenames {
             let note_id = import_note(&mut client, filename.clone(), !self.no_verify).await;
             if note_id.is_ok() {
@@ -45,6 +47,10 @@ impl ImportCmd {
             let account_id = import_account(&mut client, filename)
                 .map_err(|_| format!("Failed to parse file {}", filename.to_string_lossy()))?;
             println!("Succesfully imported account {}", account_id);
+
+            if account_id.is_regular_account() {
+                maybe_set_default_account(&current_config, account_id)?;
+            }
         }
         Ok(())
     }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -37,7 +37,7 @@ impl ImportCmd {
         mut client: Client<N, R, S, A>,
     ) -> Result<(), String> {
         validate_paths(&self.filenames)?;
-        let (current_config, _) = load_config_file()?;
+        let (mut current_config, _) = load_config_file()?;
         for filename in &self.filenames {
             let note_id = import_note(&mut client, filename.clone(), !self.no_verify).await;
             if note_id.is_ok() {
@@ -49,7 +49,7 @@ impl ImportCmd {
             println!("Succesfully imported account {}", account_id);
 
             if account_id.is_regular_account() {
-                maybe_set_default_account(&current_config, account_id)?;
+                maybe_set_default_account(&mut current_config, account_id)?;
             }
         }
         Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,7 +29,7 @@ use self::{
     new_transactions::{ConsumeNotesCmd, MintCmd, SendCmd, SwapCmd},
     notes::NotesCmd,
     tags::TagsCmd,
-    utils::load_config,
+    utils::load_config_file,
 };
 
 mod account;
@@ -110,7 +110,7 @@ impl Cli {
         };
 
         // Create the client
-        let client_config = load_config(current_dir.as_path())?;
+        let (client_config, _config_path) = load_config_file()?;
         let store = SqliteStore::new((&client_config).into()).map_err(ClientError::StoreError)?;
         let store = Rc::new(store);
 

--- a/src/cli/new_account.rs
+++ b/src/cli/new_account.rs
@@ -92,8 +92,8 @@ impl NewWalletCmd {
             new_account.id()
         );
 
-        let (current_config, _) = load_config_file()?;
-        maybe_set_default_account(&current_config, new_account.id())?;
+        let (mut current_config, _) = load_config_file()?;
+        maybe_set_default_account(&mut current_config, new_account.id())?;
 
         Ok(())
     }

--- a/src/cli/new_account.rs
+++ b/src/cli/new_account.rs
@@ -6,7 +6,7 @@ use miden_client::{
 use miden_objects::{accounts::AccountStorageType, assets::TokenSymbol, crypto::rand::FeltRng};
 use miden_tx::TransactionAuthenticator;
 
-use crate::cli::CLIENT_BINARY_NAME;
+use crate::cli::{account::maybe_set_default_account, utils::load_config_file, CLIENT_BINARY_NAME};
 
 #[derive(Debug, Parser, Clone)]
 /// Create a new faucet account
@@ -91,6 +91,9 @@ impl NewWalletCmd {
             "To view account details execute `{CLIENT_BINARY_NAME} account -s {}`",
             new_account.id()
         );
+
+        let (current_config, _) = load_config_file()?;
+        maybe_set_default_account(&current_config, new_account.id())?;
 
         Ok(())
     }

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -153,7 +153,7 @@ pub(super) fn load_config_file() -> Result<(ClientConfig, PathBuf), String> {
 }
 
 /// Loads the client configuration.
-pub(super) fn load_config(config_file: &Path) -> Result<ClientConfig, String> {
+fn load_config(config_file: &Path) -> Result<ClientConfig, String> {
     Figment::from(Toml::file(config_file))
         .extract()
         .map_err(|err| format!("Failed to load {} config file: {err}", config_file.display()))


### PR DESCRIPTION
closes #351 

Now when creating a new wallet account or importing a wallet account, if no account is set as the default one the created / imported will be set as the default one.

I also noticed we were using `load_config_file` much more than `load_config` so I kept the last one private and changed to `load_config_file` on main.