### PR TITLE
refactor: Add conversions for `NoteRecordDetails`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.5.0 (TBD)
 
+* Add conversions for `NoteRecordDetails` (#392).
+
 ## v0.4.0 (2024-07-05)
 
 ### Features

--- a/crates/rust-client/src/notes/mod.rs
+++ b/crates/rust-client/src/notes/mod.rs
@@ -7,10 +7,7 @@ use winter_maybe_async::{maybe_async, maybe_await};
 
 use crate::{
     rpc::{NodeRpcClient, NoteDetails},
-    store::{
-        InputNoteRecord, NoteFilter, NoteRecordDetails, NoteStatus, OutputNoteRecord, Store,
-        StoreError,
-    },
+    store::{InputNoteRecord, NoteFilter, NoteStatus, OutputNoteRecord, Store, StoreError},
     Client, ClientError,
 };
 
@@ -171,12 +168,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                     };
 
                     // If note is not tracked, we create a new one.
-                    let details = NoteRecordDetails::new(
-                        node_note.nullifier().to_string(),
-                        node_note.script().clone(),
-                        node_note.inputs().values().to_vec(),
-                        node_note.serial_num(),
-                    );
+                    let details = node_note.clone().into();
 
                     InputNoteRecord::new(
                         node_note.id(),
@@ -207,12 +199,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                 }
             },
             NoteFile::NoteDetails(details, None) => {
-                let record_details = NoteRecordDetails::new(
-                    details.nullifier().to_string(),
-                    details.script().clone(),
-                    details.inputs().values().to_vec(),
-                    details.serial_num(),
-                );
+                let record_details = details.clone().into();
 
                 InputNoteRecord::new(
                     details.id(),
@@ -247,12 +234,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                     info!("Ignoring note with tag {}", tag);
                 }
 
-                let record_details = NoteRecordDetails::new(
-                    details.nullifier().to_string(),
-                    details.script().clone(),
-                    details.inputs().values().to_vec(),
-                    details.serial_num(),
-                );
+                let record_details = details.clone().into();
 
                 InputNoteRecord::new(
                     details.id(),
@@ -267,12 +249,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                 )
             },
             NoteFile::NoteWithProof(note, inclusion_proof) => {
-                let details = NoteRecordDetails::new(
-                    note.nullifier().to_string(),
-                    note.script().clone(),
-                    note.inputs().values().to_vec(),
-                    note.serial_num(),
-                );
+                let details = note.clone().into();
 
                 InputNoteRecord::new(
                     note.id(),

--- a/crates/rust-client/src/store/note_record/input_note_record.rs
+++ b/crates/rust-client/src/store/note_record/input_note_record.rs
@@ -207,12 +207,7 @@ impl From<Note> for InputNoteRecord {
             status: NoteStatus::Expected { created_at: 0 },
             metadata: Some(*note.metadata()),
             inclusion_proof: None,
-            details: NoteRecordDetails::new(
-                note.nullifier().to_string(),
-                note.script().clone(),
-                note.inputs().values().to_vec(),
-                note.serial_num(),
-            ),
+            details: note.into(),
             ignored: false,
             imported_tag: None,
         }
@@ -227,12 +222,7 @@ impl From<InputNote> for InputNoteRecord {
             assets: recorded_note.note().assets().clone(),
             status: NoteStatus::Expected { created_at: 0 },
             metadata: Some(*recorded_note.note().metadata()),
-            details: NoteRecordDetails::new(
-                recorded_note.note().nullifier().to_string(),
-                recorded_note.note().script().clone(),
-                recorded_note.note().inputs().values().to_vec(),
-                recorded_note.note().serial_num(),
-            ),
+            details: recorded_note.note().clone().into(),
             inclusion_proof: recorded_note.proof().cloned(),
             ignored: false,
             imported_tag: None,

--- a/crates/rust-client/src/store/note_record/mod.rs
+++ b/crates/rust-client/src/store/note_record/mod.rs
@@ -8,7 +8,7 @@ use chrono::{Local, TimeZone};
 use miden_objects::{
     accounts::AccountId,
     assembly::{Assembler, ProgramAst},
-    notes::NoteScript,
+    notes::{Note, NoteDetails, NoteScript},
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     Digest, Felt, Word,
 };
@@ -252,5 +252,27 @@ impl Deserializable for NoteRecordDetails {
         let serial_num = Word::read_from(source)?;
 
         Ok(NoteRecordDetails::new(nullifier, script, inputs, serial_num))
+    }
+}
+
+impl From<Note> for NoteRecordDetails {
+    fn from(note: Note) -> Self {
+        Self::new(
+            note.nullifier().to_string(),
+            note.script().clone(),
+            note.inputs().values().to_vec(),
+            note.serial_num(),
+        )
+    }
+}
+
+impl From<NoteDetails> for NoteRecordDetails {
+    fn from(details: NoteDetails) -> Self {
+        Self::new(
+            details.nullifier().to_string(),
+            details.script().clone(),
+            details.inputs().values().to_vec(),
+            details.serial_num(),
+        )
     }
 }

--- a/crates/rust-client/src/store/note_record/output_note_record.rs
+++ b/crates/rust-client/src/store/note_record/output_note_record.rs
@@ -102,12 +102,7 @@ impl From<Note> for OutputNoteRecord {
             status: NoteStatus::Expected { created_at: 0 },
             metadata: *note.metadata(),
             inclusion_proof: None,
-            details: Some(NoteRecordDetails::new(
-                note.nullifier().to_string(),
-                note.script().clone(),
-                note.inputs().values().to_vec(),
-                note.serial_num(),
-            )),
+            details: Some(note.into()),
         }
     }
 }


### PR DESCRIPTION
Addresses [this comment](https://github.com/0xPolygonMiden/miden-client/pull/375#discussion_r1646138611)

This PR looks to refactor the creation of `NoteRecordDetails` from `Note` and `NoteDetails` by impementing `From` conversions.