### PR TITLE
feat: add re exports from base used in public api

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,13 +3,14 @@ use std::{env, rc::Rc};
 use clap::Parser;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::{
+    auth::StoreAuthenticator,
     errors::{ClientError, IdPrefixFetchError},
     rpc::{NodeRpcClient, TonicRpcClient},
     store::{
         sqlite_store::SqliteStore, InputNoteRecord, NoteFilter as ClientNoteFilter,
         OutputNoteRecord, Store,
     },
-    Client, StoreAuthenticator,
+    Client,
 };
 use miden_objects::{
     accounts::AccountStub,

--- a/src/cli/new_account.rs
+++ b/src/cli/new_account.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, ValueEnum};
-use miden_client::{rpc::NodeRpcClient, store::Store, AccountTemplate, Client};
+use miden_client::{accounts::AccountTemplate, rpc::NodeRpcClient, store::Store, Client};
 use miden_objects::{accounts::AccountStorageType, assets::TokenSymbol, crypto::rand::FeltRng};
 use miden_tx::auth::TransactionAuthenticator;
 

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -2,10 +2,11 @@ use clap::ValueEnum;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::{
     errors::{ClientError, IdPrefixFetchError},
+    notes::NoteConsumability,
     rpc::NodeRpcClient,
     store::{InputNoteRecord, NoteFilter as ClientNoteFilter, OutputNoteRecord, Store},
     transactions::transaction_request::known_script_roots::{P2ID, P2IDR, SWAP},
-    Client, NoteConsumability,
+    Client,
 };
 use miden_objects::{
     accounts::AccountId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,7 @@
 extern crate alloc;
 
 mod client;
-pub use client::{
-    accounts::AccountTemplate, rpc, store_authenticator::StoreAuthenticator, sync::SyncSummary,
-    Client, NoteConsumability, NoteRelevance,
-};
+pub use client::{rpc, sync::SyncSummary, Client};
 
 pub mod config;
 pub mod errors;
@@ -16,13 +13,10 @@ pub mod store;
 pub mod accounts {
     pub use miden_objects::accounts::{
         Account, AccountCode, AccountData, AccountId, AccountStorage, AccountStorageType,
-        AccountStub, AuthSecretKey,
+        AccountStub,
     };
 
-    #[cfg(feature = "testing")]
-    pub mod testing {
-        pub use miden_objects::accounts::account_id::testing::*;
-    }
+    pub use super::client::accounts::AccountTemplate;
 }
 
 pub mod assembly {
@@ -33,36 +27,60 @@ pub mod assets {
     pub use miden_objects::assets::{Asset, AssetVault, FungibleAsset, TokenSymbol};
 }
 
+pub mod auth {
+    pub use miden_objects::accounts::AuthSecretKey;
+    pub use miden_tx::auth::TransactionAuthenticator;
+
+    pub use super::client::store_authenticator::StoreAuthenticator;
+}
+
+pub mod blocks {
+    pub use miden_objects::BlockHeader;
+}
+
 pub mod crypto {
-    pub use miden_objects::crypto::{
-        merkle::{
-            InOrderIndex, LeafIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof, SmtLeaf, SmtProof,
+    pub use miden_objects::{
+        crypto::{
+            merkle::{
+                InOrderIndex, LeafIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof, SmtLeaf,
+                SmtProof,
+            },
+            rand::{FeltRng, RpoRandomCoin},
         },
-        rand::{FeltRng, RpoRandomCoin},
+        Digest,
     };
 }
+
+pub use miden_objects::{Felt, StarkField, Word};
 
 pub mod notes {
     pub use miden_objects::notes::{
         Note, NoteAssets, NoteExecutionHint, NoteId, NoteInclusionProof, NoteInputs, NoteMetadata,
         NoteRecipient, NoteScript, NoteTag, NoteType, Nullifier,
     };
-}
 
-pub use miden_objects::{BlockHeader, Digest, Felt, StarkField, Word};
+    pub use super::client::{NoteConsumability, NoteRelevance};
+}
 
 pub mod transactions {
     pub use miden_objects::transaction::{
         ExecutedTransaction, InputNote, OutputNote, OutputNotes, ProvenTransaction, TransactionId,
         TransactionScript,
     };
-    pub use miden_tx::{
-        auth::TransactionAuthenticator,
-        utils::{Deserializable, Serializable},
-        DataStoreError, ScriptTarget, TransactionExecutorError,
-    };
+    pub use miden_tx::{DataStoreError, ScriptTarget, TransactionExecutorError};
 
     pub use super::client::transactions::*;
+}
+
+pub mod utils {
+    pub use miden_tx::utils::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    };
+}
+
+#[cfg(feature = "testing")]
+pub mod testing {
+    pub use miden_objects::accounts::account_id::testing::*;
 }
 
 #[cfg(all(test, feature = "executable"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,37 +3,20 @@ extern crate alloc;
 mod client;
 pub use client::{
     accounts::AccountTemplate, rpc, store_authenticator::StoreAuthenticator, sync::SyncSummary,
-    transactions, Client, NoteConsumability, NoteRelevance,
+    Client, NoteConsumability, NoteRelevance,
 };
 
 pub mod config;
 pub mod errors;
 pub mod store;
 
-/// Miden Base re-exports
-pub mod objects {
-    pub use miden_objects::{
-        accounts::{
-            Account, AccountCode, AccountData, AccountId, AccountStorage, AccountStorageType,
-            AccountStub, AuthSecretKey,
-        },
-        assembly::{AstSerdeOptions, ModuleAst, ProgramAst},
-        assets::{Asset, AssetVault, FungibleAsset, TokenSymbol},
-        crypto::{
-            merkle::{
-                InOrderIndex, LeafIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof, SmtLeaf,
-                SmtProof,
-            },
-            rand::{FeltRng, RpoRandomCoin},
-        },
-        notes::{
-            Note, NoteAssets, NoteExecutionHint, NoteId, NoteInclusionProof, NoteInputs,
-            NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType, Nullifier,
-        },
-        transaction::{
-            InputNote, OutputNotes, ProvenTransaction, TransactionId, TransactionScript,
-        },
-        BlockHeader, Digest, Felt, StarkField, Word,
+// MIDEN BASE RE-EXPORTS
+// ================================================================================================
+
+pub mod accounts {
+    pub use miden_objects::accounts::{
+        Account, AccountCode, AccountData, AccountId, AccountStorage, AccountStorageType,
+        AccountStub, AuthSecretKey,
     };
 
     #[cfg(feature = "testing")]
@@ -42,12 +25,44 @@ pub mod objects {
     }
 }
 
-pub mod tx {
+pub mod assembly {
+    pub use miden_objects::assembly::{AstSerdeOptions, ModuleAst, ProgramAst};
+}
+
+pub mod assets {
+    pub use miden_objects::assets::{Asset, AssetVault, FungibleAsset, TokenSymbol};
+}
+
+pub mod crypto {
+    pub use miden_objects::crypto::{
+        merkle::{
+            InOrderIndex, LeafIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof, SmtLeaf, SmtProof,
+        },
+        rand::{FeltRng, RpoRandomCoin},
+    };
+}
+
+pub mod notes {
+    pub use miden_objects::notes::{
+        Note, NoteAssets, NoteExecutionHint, NoteId, NoteInclusionProof, NoteInputs, NoteMetadata,
+        NoteRecipient, NoteScript, NoteTag, NoteType, Nullifier,
+    };
+}
+
+pub use miden_objects::{BlockHeader, Digest, Felt, StarkField, Word};
+
+pub mod transactions {
+    pub use miden_objects::transaction::{
+        ExecutedTransaction, InputNote, OutputNote, OutputNotes, ProvenTransaction, TransactionId,
+        TransactionScript,
+    };
     pub use miden_tx::{
         auth::TransactionAuthenticator,
         utils::{Deserializable, Serializable},
         DataStoreError, ScriptTarget, TransactionExecutorError,
     };
+
+    pub use super::client::transactions::*;
 }
 
 #[cfg(all(test, feature = "executable"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,15 +16,30 @@ pub mod objects {
         accounts::{Account, AccountData, AccountId, AccountStorageType, AuthSecretKey},
         assembly::ProgramAst,
         assets::{Asset, FungibleAsset, TokenSymbol},
-        crypto::merkle::{InOrderIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof},
-        notes::{NoteId, NoteMetadata, NoteScript, NoteTag, NoteType},
-        transaction::{ProvenTransaction, TransactionId},
+        crypto::{
+            merkle::{InOrderIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof},
+            rand::{FeltRng, RpoRandomCoin},
+        },
+        notes::{
+            Note, NoteAssets, NoteExecutionHint, NoteId, NoteInputs, NoteMetadata, NoteRecipient,
+            NoteScript, NoteTag, NoteType,
+        },
+        transaction::{InputNote, ProvenTransaction, TransactionId},
         BlockHeader, Digest, Felt, Word,
     };
+
+    #[cfg(feature = "testing")]
+    pub mod testing {
+        pub use miden_objects::accounts::account_id::testing::*;
+    }
 }
 
 pub mod tx {
-    pub use miden_tx::{auth::TransactionAuthenticator, ScriptTarget};
+    pub use miden_tx::{
+        auth::TransactionAuthenticator,
+        utils::{Deserializable, Serializable},
+        DataStoreError, ScriptTarget, TransactionExecutorError,
+    };
 }
 
 #[cfg(all(test, feature = "executable"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,19 +13,27 @@ pub mod store;
 /// Miden Base re-exports
 pub mod objects {
     pub use miden_objects::{
-        accounts::{Account, AccountData, AccountId, AccountStorageType, AuthSecretKey},
-        assembly::ProgramAst,
-        assets::{Asset, FungibleAsset, TokenSymbol},
+        accounts::{
+            Account, AccountCode, AccountData, AccountId, AccountStorage, AccountStorageType,
+            AccountStub, AuthSecretKey,
+        },
+        assembly::{AstSerdeOptions, ModuleAst, ProgramAst},
+        assets::{Asset, AssetVault, FungibleAsset, TokenSymbol},
         crypto::{
-            merkle::{InOrderIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof},
+            merkle::{
+                InOrderIndex, LeafIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof, SmtLeaf,
+                SmtProof,
+            },
             rand::{FeltRng, RpoRandomCoin},
         },
         notes::{
-            Note, NoteAssets, NoteExecutionHint, NoteId, NoteInputs, NoteMetadata, NoteRecipient,
-            NoteScript, NoteTag, NoteType,
+            Note, NoteAssets, NoteExecutionHint, NoteId, NoteInclusionProof, NoteInputs,
+            NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType, Nullifier,
         },
-        transaction::{InputNote, ProvenTransaction, TransactionId},
-        BlockHeader, Digest, Felt, Word,
+        transaction::{
+            InputNote, OutputNotes, ProvenTransaction, TransactionId, TransactionScript,
+        },
+        BlockHeader, Digest, Felt, StarkField, Word,
     };
 
     #[cfg(feature = "testing")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,23 @@ pub mod config;
 pub mod errors;
 pub mod store;
 
+/// Miden Base re-exports
+pub mod objects {
+    pub use miden_objects::{
+        accounts::{Account, AccountData, AccountId, AccountStorageType, AuthSecretKey},
+        assembly::ProgramAst,
+        assets::{Asset, FungibleAsset, TokenSymbol},
+        crypto::merkle::{InOrderIndex, MerklePath, MmrDelta, MmrPeaks, MmrProof},
+        notes::{NoteId, NoteMetadata, NoteScript, NoteTag, NoteType},
+        transaction::{ProvenTransaction, TransactionId},
+        BlockHeader, Digest, Felt, Word,
+    };
+}
+
+pub mod tx {
+    pub use miden_tx::{auth::TransactionAuthenticator, ScriptTarget};
+}
+
 #[cfg(all(test, feature = "executable"))]
 pub mod mock;
 

--- a/tests/integration/cli_tests.rs
+++ b/tests/integration/cli_tests.rs
@@ -2,13 +2,14 @@ use std::{env::temp_dir, fs::File, io::Read, path::Path, rc::Rc};
 
 use assert_cmd::Command;
 use miden_client::{
+    accounts::AccountTemplate,
+    auth::StoreAuthenticator,
     config::RpcConfig,
     rpc::TonicRpcClient,
     store::{
         sqlite_store::{config::SqliteStoreConfig, SqliteStore},
         NoteFilter,
     },
-    AccountTemplate, StoreAuthenticator,
 };
 use miden_objects::{accounts::AccountStorageType, crypto::rand::RpoRandomCoin, Felt};
 use rand::Rng;

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -5,6 +5,8 @@ use figment::{
     Figment,
 };
 use miden_client::{
+    accounts::AccountTemplate,
+    auth::StoreAuthenticator,
     config::RpcConfig,
     errors::{ClientError, RpcError},
     rpc::TonicRpcClient,
@@ -13,7 +15,7 @@ use miden_client::{
         NoteFilter, TransactionFilter,
     },
     transactions::transaction_request::{TransactionRequest, TransactionTemplate},
-    AccountTemplate, Client, StoreAuthenticator, SyncSummary,
+    Client, SyncSummary,
 };
 use miden_objects::{
     accounts::{

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 
-use miden_client::{transactions::transaction_request::TransactionRequest, AccountTemplate};
+use miden_client::{
+    accounts::AccountTemplate, transactions::transaction_request::TransactionRequest,
+};
 use miden_objects::{
     accounts::{AccountId, AccountStorageType, AuthSecretKey},
     assembly::ProgramAst,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,12 +1,13 @@
 use miden_client::{
+    accounts::AccountTemplate,
     errors::ClientError,
+    notes::NoteRelevance,
     rpc::{AccountDetails, NodeRpcClient, TonicRpcClient},
     store::{InputNoteRecord, NoteFilter, NoteStatus, TransactionFilter},
     transactions::{
         transaction_request::{PaymentTransactionData, TransactionTemplate},
         TransactionStatus,
     },
-    AccountTemplate, NoteRelevance,
 };
 use miden_objects::{
     accounts::{AccountId, AccountStorageType},

--- a/tests/integration/onchain_tests.rs
+++ b/tests/integration/onchain_tests.rs
@@ -1,7 +1,7 @@
 use miden_client::{
+    accounts::AccountTemplate,
     store::{NoteFilter, NoteStatus},
     transactions::transaction_request::{PaymentTransactionData, TransactionTemplate},
-    AccountTemplate,
 };
 use miden_objects::{
     accounts::{AccountId, AccountStorageType},

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -1,7 +1,7 @@
 use miden_client::{
+    accounts::AccountTemplate,
     store::InputNoteRecord,
     transactions::transaction_request::{SwapTransactionData, TransactionTemplate},
-    AccountTemplate,
 };
 use miden_objects::{
     accounts::{AccountId, AccountStorageType},


### PR DESCRIPTION
closes #280 

Tested with:

- [X] branch `mFragaBA-workspace-refactor` which refactors the single crate structure into a miden-cli, miden-client and tests subcrates. This made it easier to test the usage of the client library as a dependency of the integration tests. I added it as a dependency (and didn't add miden-objects nor miden-tx) and added missing re-exports if any until it compiled.
- [x] wasm fork of the miden-client.

I think testing against real use cases instead of just looking at the api will avoid some missing re-exports problems. We can still iterate on this as users of the crate can decide when they remove the dependency and just use the re-exports instead.