### PR TITLE
fix: fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ FEATURES_INTEGRATION_TESTING="integration"
 FEATURES_CLI="testing, executable, concurrent"
 NODE_FEATURES_TESTING="testing"
 WARNINGS=RUSTDOCFLAGS="-D warnings"
-NODE_BRANCH="polydez-future-notes"
+NODE_BRANCH="next"
 
 # --- Linting -------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ FEATURES_INTEGRATION_TESTING="integration"
 FEATURES_CLI="testing, executable, concurrent"
 NODE_FEATURES_TESTING="testing"
 WARNINGS=RUSTDOCFLAGS="-D warnings"
-NODE_BRANCH="next"
+NODE_BRANCH="polydez-future-notes"
 
 # --- Linting -------------------------------------------------------------------------------------
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -29,7 +29,7 @@ async fn test_added_notes() {
     wait_for_node(&mut client).await;
 
     let (_, _, faucet_account_stub) = setup(&mut client, AccountStorageType::OffChain).await;
-    
+
     // Mint some asset for an account not tracked by the client. It should not be stored as an
     // input note afterwards since it is not being tracked by the client
     let fungible_asset = FungibleAsset::new(faucet_account_stub.id(), MINT_AMOUNT).unwrap();


### PR DESCRIPTION
Github Actions is having some issues
<img width="1012" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/6981132/2744c193-20bb-44b9-aacb-6ea9e1f28d6b">


As a consequence of this, I merged #375  because I saw the green checkmark but it turns out the CI had not run. This PR fixes a lint problem.