### PR TITLE
testfix: flaky tests fix attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.5.0 (TBD)
 
+* Fix flaky integration tests (#410).
 * Add conversions for `NoteRecordDetails` (#392).
 
 ## v0.4.0 (2024-07-05)

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -841,16 +841,22 @@ async fn test_update_ignored_tag() {
         .unwrap();
 
     // Ignored notes are only retrieved for "Ignored" or "All" filters
-    assert_eq!(client_2.get_input_notes(NoteFilter::All).unwrap().len(), 1);
-    assert_eq!(client_2.get_input_notes(NoteFilter::Ignored).unwrap().len(), 1);
-    assert_eq!(client_2.get_input_notes(NoteFilter::Expected).unwrap().len(), 0);
+    let all_notes = client_2.get_input_notes(NoteFilter::All).unwrap();
+    let ignored_notes = client_2.get_input_notes(NoteFilter::Ignored).unwrap();
+    let expected_notes = client_2.get_input_notes(NoteFilter::Expected).unwrap();
+    assert!(all_notes.iter().any(|candidate_note| candidate_note.id() == note.id()));
+    assert!(ignored_notes.iter().any(|candidate_note| candidate_note.id() == note.id()));
+    assert!(expected_notes.iter().all(|candidate_note| candidate_note.id() != note.id()));
 
     client_2.add_note_tag(untracked_tag).unwrap();
 
     // After adding tag, the note stops being ignored
-    assert_eq!(client_2.get_input_notes(NoteFilter::All).unwrap().len(), 1);
-    assert_eq!(client_2.get_input_notes(NoteFilter::Ignored).unwrap().len(), 0);
-    assert_eq!(client_2.get_input_notes(NoteFilter::Expected).unwrap().len(), 1);
+    let all_notes = client_2.get_input_notes(NoteFilter::All).unwrap();
+    let ignored_notes = client_2.get_input_notes(NoteFilter::Ignored).unwrap();
+    let expected_notes = client_2.get_input_notes(NoteFilter::Expected).unwrap();
+    assert!(all_notes.iter().any(|candidate_note| candidate_note.id() == note.id()));
+    assert!(ignored_notes.iter().all(|candidate_note| candidate_note.id() != note.id()));
+    assert!(expected_notes.iter().any(|candidate_note| candidate_note.id() == note.id()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
addresses #391. (The PR is already reviewable but I think this will be included in the following release).

In some tests we do some assertions with `client.get_input_notes(filter).unwrap()` and checking the length of it. While in most cases that is enough, it will sporadically fail If the node running the integration test has public notes belonging to another account with the same account id prefix (the one used to create the note tag). In order to mitigate it, we do a filter by account_id to ensure the note we want is there (there might be others, we won't care too much). In the case of swap tests, I also used `get_consumable_notes` since in that situation we wanted to consume the notes anyways.