### PR TITLE
fix: update build-wasm target from Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Test
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    types: [opened, repoened, synchronize]
+
+jobs:
+  build:
+    name: Build Client and CLI with Rust ${{matrix.toolchain}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+      - name: Install Rust with ${{matrix.toolchain}} toolchain
+        run: rustup update --no-self-update ${{ matrix.toolchain }}
+      - name: make - build
+        run: make build
+  build-wasm:
+    name: Build Client with Rust ${{matrix.toolchain}} on ${{matrix.os}} for wasm
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+      - name: Install Rust with ${{matrix.toolchain}} toolchain
+        run: rustup update --no-self-update ${{ matrix.toolchain }}
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+      - name: make - build-wasm
+        run: make build-wasm

--- a/Makefile
+++ b/Makefile
@@ -102,4 +102,4 @@ build: ## Builds the CLI binary and client library in release mode
 	cargo build --release --features $(FEATURES_CLI)
 
 build-wasm: ## Builds the client library for wasm32
-	cargo build --target wasm32-unknown-unknown --features async,idxdb,web-tonic --no-default-features --package miden-client
+	cargo build --target wasm32-unknown-unknown --features idxdb,web-tonic --no-default-features --package miden-client

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ doc-serve: doc-deps ## Serve documentation site
 # --- Rust documentation --------------------------------------------------------------------------
 
 .PHONY: doc
-doc: ## Generates & checks rust documentation
+doc: ## Generates & checks rust documentation. You'll need `jq` in order for this to run.
 	@cd crates/rust-client && \
 	FEATURES=$$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "miden-client") | .features | keys[] | select(. != "web-tonic")' | tr '\n' ',') && \
 	RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features "$$FEATURES" --keep-going --release
@@ -102,4 +102,4 @@ build: ## Builds the CLI binary and client library in release mode
 	cargo build --release --features $(FEATURES_CLI)
 
 build-wasm: ## Builds the client library for wasm32
-	cargo build --target wasm32-unknown-unknown --features async --no-default-features --package miden-client
+	cargo build --target wasm32-unknown-unknown --features async,idxdb,web-tonic --no-default-features --package miden-client

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xPolygonMiden/miden-client/blob/main/LICENSE)
 [![test](https://github.com/0xPolygonMiden/miden-client/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-clinet/actions/workflows/test.yml)
+[![build](https://github.com/0xPolygonMiden/miden-client/actions/workflows/build.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-client/actions/workflows/build.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.78+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)
 


### PR DESCRIPTION
We missed a [comment](https://github.com/0xPolygonMiden/miden-client/pull/402#discussion_r1662964348) on #401 and currently the build for wasm is broken. This PR fixes that and introduces a `build` workflow to the CI that runs both `make build` and `make build-wasm`