### PR TITLE
feat: add advice map to transaction request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Added advice map to `TransactionRequest` and updated integration test with example using the advice map to provide more than a single `Word` as `NoteArgs` for a note.
 * Move cli tests to the `miden-cli` crate (#413).
 * Added WebTonicClient to the miden-client to support WASM-compatible RPC calls (#409).
 * Added WebStore to the miden-client to support WASM-compatible store mechanisms (#401).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-* Added advice map to `TransactionRequest` and updated integration test with example using the advice map to provide more than a single `Word` as `NoteArgs` for a note.
-* Move cli tests to the `miden-cli` crate (#413).
+* Added advice map to `TransactionRequest` and updated integration test with example using the advice map to provide more than a single `Word` as `NoteArgs` for a note (#422).
+* Moved cli tests to the `miden-cli` crate (#413).
 * Added WebTonicClient to the miden-client to support WASM-compatible RPC calls (#409).
 * Added WebStore to the miden-client to support WASM-compatible store mechanisms (#401).
 * [BREAKING] Split cli and client into workspace (#407).

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -128,7 +128,8 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
 
         let data_store = ClientDataStore::new(store.clone());
         let authenticator = Some(Rc::new(authenticator));
-        let tx_executor = TransactionExecutor::new(data_store, authenticator);
+        let tx_executor =
+            TransactionExecutor::new(data_store, authenticator).with_debug_mode(in_debug_mode);
 
         Self { store, rng, rpc_api: api, tx_executor }
     }

--- a/crates/rust-client/src/transactions/mod.rs
+++ b/crates/rust-client/src/transactions/mod.rs
@@ -198,7 +198,14 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                 let notes = notes.iter().map(|id| (*id, None)).collect();
 
                 let tx_script = self.tx_executor.compile_tx_script(program_ast, vec![], vec![])?;
-                Ok(TransactionRequest::new(account_id, notes, vec![], vec![], Some(tx_script)))
+                Ok(TransactionRequest::new(
+                    account_id,
+                    notes,
+                    vec![],
+                    vec![],
+                    Some(tx_script),
+                    None,
+                ))
             },
             TransactionTemplate::MintFungibleAsset(asset, target_account_id, note_type) => {
                 self.build_mint_tx_request(asset, target_account_id, note_type)
@@ -376,6 +383,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
             vec![created_note],
             vec![],
             Some(tx_script),
+            None,
         ))
     }
 
@@ -426,6 +434,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
             vec![created_note],
             vec![payback_note_details],
             Some(tx_script),
+            None,
         ))
     }
 
@@ -475,6 +484,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
             vec![created_note],
             vec![],
             Some(tx_script),
+            None,
         ))
     }
 }

--- a/crates/rust-client/src/transactions/transaction_request.rs
+++ b/crates/rust-client/src/transactions/transaction_request.rs
@@ -37,6 +37,8 @@ pub struct TransactionRequest {
     expected_partial_notes: Vec<NoteDetails>,
     /// Optional transaction script (together with its arguments).
     tx_script: Option<TransactionScript>,
+    /// Initial state of the `AdviceMap` that provides data during runtime.
+    advice_map: AdviceMap,
 }
 
 impl TransactionRequest {
@@ -49,6 +51,7 @@ impl TransactionRequest {
         expected_output_notes: Vec<Note>,
         expected_partial_notes: Vec<NoteDetails>,
         tx_script: Option<TransactionScript>,
+        advice_map: Option<AdviceMap>,
     ) -> Self {
         Self {
             account_id,
@@ -56,6 +59,7 @@ impl TransactionRequest {
             expected_output_notes,
             expected_partial_notes,
             tx_script,
+            advice_map: advice_map.unwrap_or_default(),
         }
     }
 
@@ -97,7 +101,7 @@ impl TransactionRequest {
 impl From<TransactionRequest> for TransactionArgs {
     fn from(val: TransactionRequest) -> Self {
         let note_args = val.get_note_args();
-        let mut tx_args = TransactionArgs::new(val.tx_script, Some(note_args), AdviceMap::new());
+        let mut tx_args = TransactionArgs::new(val.tx_script, Some(note_args), val.advice_map);
 
         let output_notes = val.expected_output_notes.into_iter();
         tx_args.extend_expected_output_notes(output_notes);

--- a/tests/integration/asm/custom_p2id.masm
+++ b/tests/integration/asm/custom_p2id.masm
@@ -1,13 +1,16 @@
 # Custom P2ID note script
 #
 # This note script asserts that the note args are exactly the same as passed 
-# (currently defined as {expected_note_arg}).
+# (currently defined as {expected_note_arg_1} and {expected_note_arg_2}).
+# Since the args are too big to fit in a single note arg, we provide them via advice inputs and 
+# address them via their commitment
 # This note script is based off of the P2ID note script because notes currently need to have 
 # assets, otherwise it could have been boiled down to the assert. 
 
 use.miden::account
 use.miden::note
 use.miden::contracts::wallets::basic->wallet
+use.std::mem
 
 
 proc.add_note_assets_to_account
@@ -49,11 +52,35 @@ end
 begin
     # drop the note script root
     dropw
-    
-    # => [NOTE_ARG] 
-    push.{expected_note_arg} assert_eqw
-    # drop the note script root
+    # => [NOTE_ARG_COMMITMENT] 
+    # memory address where to write the data
+    push.{mem_address}
+    # => [target_mem_addr, NOTE_ARG_COMMITMENT]
+    # number of words
+    push.2
+    # => [number_of_words, target_mem_addr, NOTE_ARG_COMMITMENT]
+    exec.mem::pipe_preimage_to_memory
+    # => [target_mem_addr']
     dropw
+    # => []
+
+    # read first word
+    push.{mem_address}
+    # => [data_mem_address]
+    mem_loadw
+    # => [NOTE_ARG_1]
+    
+    push.{expected_note_arg_1} assert_eqw
+    # => []
+
+    # read second word
+    push.{mem_address_2}
+    # => [data_mem_address_2]
+    mem_loadw
+    # => [NOTE_ARG_2]
+    
+    push.{expected_note_arg_2} assert_eqw
+    # => []
 
     # store the note inputs to memory starting at address 0
     push.0 exec.note::get_inputs

--- a/tests/integration/asm/custom_p2id.masm
+++ b/tests/integration/asm/custom_p2id.masm
@@ -68,13 +68,13 @@ begin
     # => [target_mem_addr']
     dropw
     # => []
-
+    
     # read first word
     push.{mem_address}
     # => [data_mem_address]
     mem_loadw
     # => [NOTE_ARG_1]
-
+    
     push.{expected_note_arg_1} assert_eqw
     # => []
 

--- a/tests/integration/asm/custom_p2id.masm
+++ b/tests/integration/asm/custom_p2id.masm
@@ -3,7 +3,7 @@
 # This note script asserts that the note args are exactly the same as passed 
 # (currently defined as {expected_note_arg_1} and {expected_note_arg_2}).
 # Since the args are too big to fit in a single note arg, we provide them via advice inputs and 
-# address them via their commitment
+# address them via their commitment (noted as NOTE_ARG)
 # This note script is based off of the P2ID note script because notes currently need to have 
 # assets, otherwise it could have been boiled down to the assert. 
 
@@ -52,11 +52,11 @@ end
 begin
     # drop the note script root
     dropw
-    # => [NOTE_ARG_COMMITMENT] 
+    # => [NOTE_ARG] 
     
     # push data from the advice map into the advice stack
     adv.push_mapval
-    # => [NOTE_ARG_COMMITMENT] 
+    # => [NOTE_ARG] 
 
     # memory address where to write the data
     push.{mem_address}

--- a/tests/integration/asm/custom_p2id.masm
+++ b/tests/integration/asm/custom_p2id.masm
@@ -53,6 +53,11 @@ begin
     # drop the note script root
     dropw
     # => [NOTE_ARG_COMMITMENT] 
+    
+    # push data from the advice map into the advice stack
+    adv.push_mapval
+    # => [NOTE_ARG_COMMITMENT] 
+
     # memory address where to write the data
     push.{mem_address}
     # => [target_mem_addr, NOTE_ARG_COMMITMENT]
@@ -69,7 +74,7 @@ begin
     # => [data_mem_address]
     mem_loadw
     # => [NOTE_ARG_1]
-    
+
     push.{expected_note_arg_1} assert_eqw
     # => []
 
@@ -78,7 +83,7 @@ begin
     # => [data_mem_address_2]
     mem_loadw
     # => [NOTE_ARG_2]
-    
+
     push.{expected_note_arg_2} assert_eqw
     # => []
 

--- a/tests/integration/asm/custom_p2id.masm
+++ b/tests/integration/asm/custom_p2id.masm
@@ -82,6 +82,9 @@ begin
     push.{expected_note_arg_2} assert_eqw
     # => []
 
+    # drop the note script root
+    dropw
+
     # store the note inputs to memory starting at address 0
     push.0 exec.note::get_inputs
     # => [num_inputs, inputs_ptr]

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -242,8 +242,7 @@ fn create_custom_note(
         .replace("{expected_note_arg_1}", &expected_note_arg[0..=3].join("."))
         .replace("{expected_note_arg_2}", &expected_note_arg[4..=7].join("."))
         .replace("{mem_address}", &mem_addr.to_string())
-        .replace("{mem_address_2}", &(mem_addr + 4).to_string());
-    dbg!(&note_script);
+        .replace("{mem_address_2}", &(mem_addr + 1).to_string());
     let note_script = ProgramAst::parse(&note_script).unwrap();
     let note_script = client.compile_note_script(note_script, vec![]).unwrap();
 


### PR DESCRIPTION
addresses: #398 

note: when I tried debugging the note script I noticed we were never creating the `TransactionExecutor` in debug mode and so debug statements weren't being executed. I think we previously had it and deleted it by mistake. [7793881](https://github.com/0xPolygonMiden/miden-client/pull/422/commits/7793881ea426703062d9bf735f3e18cdde9453c1) restores it