### PR TITLE
fix: rename workflow name to build instead of test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Build
 on:
   push:
     branches: [main, next]


### PR DESCRIPTION
The workflow name was wrong and thus the badge was generating incorrectly (also was annoying to differentiate workflows in the actions section of github)

<img width="228" alt="image" src="https://github.com/0xPolygonMiden/miden-client/assets/25107475/49097b14-c37d-4539-b538-6b7923397e99">
