### PR TITLE
Fix install command in docs

### DIFF
--- a/docs/install-and-run.md
+++ b/docs/install-and-run.md
@@ -13,7 +13,7 @@ We currently recommend installing and running the client with the [`testing`](#t
 Run the following command to install the miden-client:
 
 ```sh
-cargo install miden-client --features concurrent,executable,testing
+cargo install miden-cli --features concurrent,executable,testing
 ```
 
 This installs the `miden` binary (at `~/.cargo/bin/miden`) with the [`testing`](#testing-feature) and [`concurrent`](#concurrent-feature) features.


### PR DESCRIPTION
The actual binary package is called 'miden-cli', whilst 'miden-client' is just the library. Therefore trying to run 'cargo install miden-client --features concurrent,executable,testing' returns an error that miden-client is a library and has no binaries.