### PR TITLE
fix: don't update generated files in docs.rs

### DIFF
--- a/crates/rust-client/build.rs
+++ b/crates/rust-client/build.rs
@@ -15,9 +15,13 @@ fn main() -> miette::Result<()> {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR should be set");
     let dest_path = PathBuf::from(out_dir);
 
-    write_proto(&dest_path).unwrap();
-    compile_tonic_client_proto(&dest_path)?;
-    replace_no_std_types();
+    // updates the generated files from protobuf. Only do so when this is not docs.rs building the
+    // documentation.
+    if env::var("DOCS_RS").is_err() {
+        write_proto(&dest_path).unwrap();
+        compile_tonic_client_proto(&dest_path)?;
+        replace_no_std_types();
+    }
 
     Ok(())
 }


### PR DESCRIPTION
closes #429 

The `build.rs` had problems when executing inside `docs.rs`. This PR looks to skip the update of generated files if the env var `DOCS_RS` is set which means it is currently building the docs.