### PR TITLE
refactor(transactions)!: Merge prove and submit transaction methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.5.0 (TBD)
 
+* [BREAKING] Refactored `Client` to merge submit_transaction and prove_transaction (#445)
 * [BREAKING] Refactored `TransactionRequest` to represent a generalized transaction (#438).
 * Fix `get_consumable_notes` to consider block header information for consumability (#432).
 * Ignored stale updates received during sync process (#412).

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -308,9 +308,7 @@ async fn execute_transaction<
         .map(|note| note.id())
         .collect::<Vec<_>>();
 
-    client
-        .submit_transaction(transaction_execution_result)
-        .await?;
+    client.submit_transaction(transaction_execution_result).await?;
 
     if let TransactionTemplate::Swap(swap_data, note_type) = transaction_template {
         let payback_note_tag: u32 = build_swap_tag(

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -307,7 +307,6 @@ async fn execute_transaction<
         .iter()
         .map(|note| note.id())
         .collect::<Vec<_>>();
-    println!("Proving and submitting transaction...");
 
     client
         .submit_transaction(transaction_execution_result)

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -1,4 +1,4 @@
-use std::{io, time::Instant};
+use std::io;
 
 use clap::{Parser, ValueEnum};
 use miden_client::{
@@ -307,17 +307,11 @@ async fn execute_transaction<
         .iter()
         .map(|note| note.id())
         .collect::<Vec<_>>();
-    println!("Proving transaction...");
-    let start = Instant::now();
-    let proven_transaction =
-        client.prove_transaction(transaction_execution_result.executed_transaction().clone())?;
-    println!("Proving took: {}ms", start.elapsed().as_millis());
-    println!("Submitting transaction to node and storing in database...");
-    let start = Instant::now();
+    println!("Proving and submitting transaction...");
+
     client
-        .submit_transaction(transaction_execution_result, proven_transaction)
+        .submit_transaction(transaction_execution_result)
         .await?;
-    println!("Submission and storage took: {}ms", start.elapsed().as_millis());
 
     if let TransactionTemplate::Swap(swap_data, note_type) = transaction_template {
         let payback_note_tag: u32 = build_swap_tag(

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -548,10 +548,7 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
     let transaction_request = client.build_transaction_request(transaction_template).unwrap();
     let transaction_execution_result = client.new_transaction(transaction_request).unwrap();
 
-    client
-        .submit_transaction(transaction_execution_result)
-        .await
-        .unwrap();
+    client.submit_transaction(transaction_execution_result).await.unwrap();
 }
 
 pub fn mock_fungible_faucet_account(

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -547,12 +547,9 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
 
     let transaction_request = client.build_transaction_request(transaction_template).unwrap();
     let transaction_execution_result = client.new_transaction(transaction_request).unwrap();
-    let proven_transaction = client
-        .prove_transaction(transaction_execution_result.executed_transaction().clone())
-        .unwrap();
 
     client
-        .submit_transaction(transaction_execution_result, proven_transaction)
+        .submit_transaction(transaction_execution_result)
         .await
         .unwrap();
 }

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -436,9 +436,7 @@ async fn test_get_output_notes() {
     assert!(client.get_output_notes(NoteFilter::All).unwrap().is_empty());
 
     let transaction = client.new_transaction(transaction_request).unwrap();
-    let proven_transaction =
-        client.prove_transaction(transaction.executed_transaction().clone()).unwrap();
-    client.submit_transaction(transaction, proven_transaction).await.unwrap();
+    client.submit_transaction(transaction).await.unwrap();
 
     // Check that there was an output note but it wasn't consumed
     assert!(client.get_output_notes(NoteFilter::Consumed).unwrap().is_empty());

--- a/crates/rust-client/src/transactions/mod.rs
+++ b/crates/rust-client/src/transactions/mod.rs
@@ -336,7 +336,8 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         let transaction_prover = TransactionProver::new(ProvingOptions::default());
 
         info!("Proving transaction...");
-        let proven_transaction = transaction_prover.prove_transaction(tx_result.executed_transaction().clone())?;
+        let proven_transaction =
+            transaction_prover.prove_transaction(tx_result.executed_transaction().clone())?;
         info!("Transaction proved.");
 
         info!("Submitting transaction to the network...");

--- a/crates/rust-client/src/transactions/mod.rs
+++ b/crates/rust-client/src/transactions/mod.rs
@@ -338,7 +338,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         info!("Proving transaction...");
         let proven_transaction =
             transaction_prover.prove_transaction(tx_result.executed_transaction().clone())?;
-        info!("Transaction proved.");
+        info!("Transaction proven.");
 
         info!("Submitting transaction to the network...");
         self.rpc_api.submit_proven_transaction(proven_transaction).await?;

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -96,10 +96,7 @@ pub async fn execute_tx(client: &mut TestClient, tx_request: TransactionRequest)
     let transaction_id = transaction_execution_result.executed_transaction().id();
 
     println!("Sending transaction to node");
-    client
-        .submit_transaction(transaction_execution_result)
-        .await
-        .unwrap();
+    client.submit_transaction(transaction_execution_result).await.unwrap();
 
     transaction_id
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -96,11 +96,8 @@ pub async fn execute_tx(client: &mut TestClient, tx_request: TransactionRequest)
     let transaction_id = transaction_execution_result.executed_transaction().id();
 
     println!("Sending transaction to node");
-    let proven_transaction = client
-        .prove_transaction(transaction_execution_result.executed_transaction().clone())
-        .unwrap();
     client
-        .submit_transaction(transaction_execution_result, proven_transaction)
+        .submit_transaction(transaction_execution_result)
         .await
         .unwrap();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -633,11 +633,8 @@ async fn test_multiple_transactions_can_be_committed_in_different_blocks_without
 
         println!("Sending transaction to node");
         let note_id = tx_request.expected_output_notes().next().unwrap().id();
-        let proven_transaction = client
-            .prove_transaction(transaction_execution_result.executed_transaction().clone())
-            .unwrap();
         client
-            .submit_transaction(transaction_execution_result, proven_transaction)
+            .submit_transaction(transaction_execution_result)
             .await
             .unwrap();
 
@@ -662,17 +659,13 @@ async fn test_multiple_transactions_can_be_committed_in_different_blocks_without
         let transaction_id = transaction_execution_result.executed_transaction().id();
 
         println!("Sending transaction to node");
-        let proven_transaction = client
-            .prove_transaction(transaction_execution_result.executed_transaction().clone())
-            .unwrap();
-
         // May need a few attempts until it gets included
         let note_id = tx_request.expected_output_notes().next().unwrap().id();
         while client.rpc_api().get_notes_by_id(&[first_note_id]).await.unwrap().is_empty() {
             std::thread::sleep(std::time::Duration::from_secs(3));
         }
         client
-            .submit_transaction(transaction_execution_result, proven_transaction)
+            .submit_transaction(transaction_execution_result)
             .await
             .unwrap();
 
@@ -697,17 +690,13 @@ async fn test_multiple_transactions_can_be_committed_in_different_blocks_without
         let transaction_id = transaction_execution_result.executed_transaction().id();
 
         println!("Sending transaction to node");
-        let proven_transaction = client
-            .prove_transaction(transaction_execution_result.executed_transaction().clone())
-            .unwrap();
-
         // May need a few attempts until it gets included
         let note_id = tx_request.expected_output_notes().next().unwrap().id();
         while client.rpc_api().get_notes_by_id(&[second_note_id]).await.unwrap().is_empty() {
             std::thread::sleep(std::time::Duration::from_secs(3));
         }
         client
-            .submit_transaction(transaction_execution_result, proven_transaction)
+            .submit_transaction(transaction_execution_result)
             .await
             .unwrap();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -633,10 +633,7 @@ async fn test_multiple_transactions_can_be_committed_in_different_blocks_without
 
         println!("Sending transaction to node");
         let note_id = tx_request.expected_output_notes().next().unwrap().id();
-        client
-            .submit_transaction(transaction_execution_result)
-            .await
-            .unwrap();
+        client.submit_transaction(transaction_execution_result).await.unwrap();
 
         (note_id, transaction_id)
     };
@@ -664,10 +661,7 @@ async fn test_multiple_transactions_can_be_committed_in_different_blocks_without
         while client.rpc_api().get_notes_by_id(&[first_note_id]).await.unwrap().is_empty() {
             std::thread::sleep(std::time::Duration::from_secs(3));
         }
-        client
-            .submit_transaction(transaction_execution_result)
-            .await
-            .unwrap();
+        client.submit_transaction(transaction_execution_result).await.unwrap();
 
         (note_id, transaction_id)
     };
@@ -695,10 +689,7 @@ async fn test_multiple_transactions_can_be_committed_in_different_blocks_without
         while client.rpc_api().get_notes_by_id(&[second_note_id]).await.unwrap().is_empty() {
             std::thread::sleep(std::time::Duration::from_secs(3));
         }
-        client
-            .submit_transaction(transaction_execution_result)
-            .await
-            .unwrap();
+        client.submit_transaction(transaction_execution_result).await.unwrap();
 
         (note_id, transaction_id)
     };


### PR DESCRIPTION
Closes #439 

BREAKING CHANGES: change transactions API.

As indicated in [the issue](https://github.com/0xPolygonMiden/miden-client/issues/439): merges prove and submit transaction methods into submit, logs the time that takes each step, updates method doc and update calls.