### PR TITLE
feat: add serialization for `TransactionRequest` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.5.0 (TBD)
 
+* Added serialization for `TransactionRequest` (#471).
 * Added the Web Client Crate
 * Added validations in transaction requests (#447).
 * [BREAKING] Refactored `Client` to merge submit_transaction and prove_transaction (#445)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FEATURES_CLIENT=--features "testing, concurrent"
 FEATURES_CLI=--features "testing, concurrent"
 NODE_FEATURES_TESTING=--features "testing"
 WARNINGS=RUSTDOCFLAGS="-D warnings"
-NODE_BRANCH="next"
+NODE_BRANCH="add-note-exec-hint-to-store"
 
 # --- Linting -------------------------------------------------------------------------------------
 
@@ -96,7 +96,7 @@ clean-node: ## Clean node directory
 .PHONY: node
 node: ## Setup node directory
 	if [ -d miden-node ]; then cd miden-node ; else git clone https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi
-	cd miden-node && git checkout $(NODE_BRANCH) && git pull origin $(NODE_BRANCH) && cargo update
+	cd miden-node && git checkout $(NODE_BRANCH) && git pull origin $(NODE_BRANCH)
 	cd miden-node && rm -rf miden-store.sqlite3*
 	cd miden-node && cargo run --bin miden-node $(NODE_FEATURES_TESTING) -- make-genesis --inputs-path ../tests/config/genesis.toml --force
 

--- a/bin/miden-cli/src/commands/export.rs
+++ b/bin/miden-cli/src/commands/export.rs
@@ -67,10 +67,11 @@ pub fn export_note<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthent
             },
             None => return Err("Note does not have inclusion proof".to_string()),
         },
-        ExportType::Partial => NoteFile::NoteDetails(
-            output_note.clone().try_into()?,
-            Some(output_note.metadata().tag()),
-        ),
+        ExportType::Partial => NoteFile::NoteDetails {
+            details: output_note.clone().try_into()?,
+            tag: Some(output_note.metadata().tag()),
+            after_block_num: 0,
+        },
     };
 
     let file_path = if let Some(filename) = filename {

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -58,7 +58,7 @@ miden-objects = {default-features = false, features = ["serde", "testing"], git 
 uuid = { version = "1.9", features = ["serde", "v4"] }
 
 [build-dependencies]
-miden-rpc-proto = { git = "https://github.com/0xPolygonMiden/miden-node/", branch = "next" }
+miden-rpc-proto = { git = "https://github.com/0xPolygonMiden/miden-node/", branch = "add-note-exec-hint-to-store" }
 miette = { version = "7.2", features = ["fancy"] }
 prost = { version = "0.12", default-features = false, features = ["derive"] }
 prost-build = { version = "0.12", default-features = false }

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -21,7 +21,8 @@ use miden_objects::{
         rand::RpoRandomCoin,
     },
     notes::{
-        Note, NoteAssets, NoteExecutionHint, NoteFile, NoteId, NoteInclusionProof, NoteInputs, NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType
+        Note, NoteAssets, NoteExecutionHint, NoteFile, NoteId, NoteInclusionProof, NoteInputs,
+        NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType,
     },
     transaction::{InputNote, ProvenTransaction},
     BlockHeader, Felt, Word,
@@ -448,7 +449,14 @@ pub async fn insert_mock_data(client: &mut MockClient) -> Vec<BlockHeader> {
         let note: InputNoteRecord = note.into();
         let tag = note.metadata().unwrap().tag();
         client.add_note_tag(tag).unwrap();
-        client.import_note(NoteFile::NoteDetails{details:note.into(), tag:Some(tag), after_block_num:0}).await.unwrap();
+        client
+            .import_note(NoteFile::NoteDetails {
+                details: note.into(),
+                tag: Some(tag),
+                after_block_num: 0,
+            })
+            .await
+            .unwrap();
     }
 
     // insert account
@@ -626,8 +634,14 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
 
     // Created Notes
     const SERIAL_NUM_4: Word = [Felt::new(13), Felt::new(14), Felt::new(15), Felt::new(16)];
-    let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
+    let note_metadata = NoteMetadata::new(
+        sender,
+        NoteType::Private,
+        note_tag,
+        NoteExecutionHint::None,
+        Default::default(),
+    )
+    .unwrap();
     let note_assets = NoteAssets::new(vec![fungible_asset_1]).unwrap();
     let note_recipient =
         NoteRecipient::new(SERIAL_NUM_4, note_script.clone(), NoteInputs::new(vec![]).unwrap());
@@ -635,16 +649,28 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
     let created_note_1 = Note::new(note_assets, note_metadata, note_recipient);
 
     const SERIAL_NUM_5: Word = [Felt::new(17), Felt::new(18), Felt::new(19), Felt::new(20)];
-    let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
+    let note_metadata = NoteMetadata::new(
+        sender,
+        NoteType::Private,
+        note_tag,
+        NoteExecutionHint::None,
+        Default::default(),
+    )
+    .unwrap();
     let note_recipient =
         NoteRecipient::new(SERIAL_NUM_5, note_script.clone(), NoteInputs::new(vec![]).unwrap());
     let note_assets = NoteAssets::new(vec![fungible_asset_2]).unwrap();
     let created_note_2 = Note::new(note_assets, note_metadata, note_recipient);
 
     const SERIAL_NUM_6: Word = [Felt::new(21), Felt::new(22), Felt::new(23), Felt::new(24)];
-    let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
+    let note_metadata = NoteMetadata::new(
+        sender,
+        NoteType::Private,
+        note_tag,
+        NoteExecutionHint::None,
+        Default::default(),
+    )
+    .unwrap();
     let note_assets = NoteAssets::new(vec![fungible_asset_3]).unwrap();
     let note_recipient =
         NoteRecipient::new(SERIAL_NUM_6, note_script, NoteInputs::new(vec![Felt::new(2)]).unwrap());
@@ -708,8 +734,14 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
 
     // Consumed Notes
     const SERIAL_NUM_1: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
-    let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None, Default::default()).unwrap();
+    let note_metadata = NoteMetadata::new(
+        sender,
+        NoteType::Private,
+        note_tag,
+        NoteExecutionHint::None,
+        Default::default(),
+    )
+    .unwrap();
     let note_recipient = NoteRecipient::new(
         SERIAL_NUM_1,
         note_2_script.clone(),
@@ -719,8 +751,14 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
     let consumed_note_1 = Note::new(note_assets, note_metadata, note_recipient);
 
     const SERIAL_NUM_2: Word = [Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)];
-    let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
+    let note_metadata = NoteMetadata::new(
+        sender,
+        NoteType::Private,
+        note_tag,
+        NoteExecutionHint::None,
+        Default::default(),
+    )
+    .unwrap();
     let note_assets = NoteAssets::new(vec![fungible_asset_2, fungible_asset_3]).unwrap();
     let note_recipient = NoteRecipient::new(
         SERIAL_NUM_2,

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -21,8 +21,7 @@ use miden_objects::{
         rand::RpoRandomCoin,
     },
     notes::{
-        Note, NoteAssets, NoteFile, NoteId, NoteInclusionProof, NoteInputs, NoteMetadata,
-        NoteRecipient, NoteScript, NoteTag, NoteType,
+        Note, NoteAssets, NoteExecutionHint, NoteFile, NoteId, NoteInclusionProof, NoteInputs, NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType
     },
     transaction::{InputNote, ProvenTransaction},
     BlockHeader, Felt, Word,
@@ -285,6 +284,7 @@ fn create_mock_sync_state_request_for_account_and_notes(
         let metadata = generated::note::NoteMetadata {
             sender: Some(account.id().into()),
             note_type: NoteType::Private as u32,
+            execution_hint: NoteExecutionHint::none().into(),
             tag: NoteTag::for_local_use_case(1u16, 0u16).unwrap().into(),
             aux: Default::default(),
         };
@@ -448,7 +448,7 @@ pub async fn insert_mock_data(client: &mut MockClient) -> Vec<BlockHeader> {
         let note: InputNoteRecord = note.into();
         let tag = note.metadata().unwrap().tag();
         client.add_note_tag(tag).unwrap();
-        client.import_note(NoteFile::NoteDetails(note.into(), Some(tag))).await.unwrap();
+        client.import_note(NoteFile::NoteDetails{details:note.into(), tag:Some(tag), after_block_num:0}).await.unwrap();
     }
 
     // insert account
@@ -627,7 +627,7 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
     // Created Notes
     const SERIAL_NUM_4: Word = [Felt::new(13), Felt::new(14), Felt::new(15), Felt::new(16)];
     let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, Default::default()).unwrap();
+        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
     let note_assets = NoteAssets::new(vec![fungible_asset_1]).unwrap();
     let note_recipient =
         NoteRecipient::new(SERIAL_NUM_4, note_script.clone(), NoteInputs::new(vec![]).unwrap());
@@ -636,7 +636,7 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
 
     const SERIAL_NUM_5: Word = [Felt::new(17), Felt::new(18), Felt::new(19), Felt::new(20)];
     let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, Default::default()).unwrap();
+        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
     let note_recipient =
         NoteRecipient::new(SERIAL_NUM_5, note_script.clone(), NoteInputs::new(vec![]).unwrap());
     let note_assets = NoteAssets::new(vec![fungible_asset_2]).unwrap();
@@ -644,7 +644,7 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
 
     const SERIAL_NUM_6: Word = [Felt::new(21), Felt::new(22), Felt::new(23), Felt::new(24)];
     let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, Default::default()).unwrap();
+        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
     let note_assets = NoteAssets::new(vec![fungible_asset_3]).unwrap();
     let note_recipient =
         NoteRecipient::new(SERIAL_NUM_6, note_script, NoteInputs::new(vec![Felt::new(2)]).unwrap());
@@ -709,7 +709,7 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
     // Consumed Notes
     const SERIAL_NUM_1: Word = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
     let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, Default::default()).unwrap();
+        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None, Default::default()).unwrap();
     let note_recipient = NoteRecipient::new(
         SERIAL_NUM_1,
         note_2_script.clone(),
@@ -720,7 +720,7 @@ pub fn mock_notes(assembler: &Assembler) -> (Vec<Note>, Vec<Note>) {
 
     const SERIAL_NUM_2: Word = [Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)];
     let note_metadata =
-        NoteMetadata::new(sender, NoteType::Private, note_tag, Default::default()).unwrap();
+        NoteMetadata::new(sender, NoteType::Private, note_tag, NoteExecutionHint::None,Default::default()).unwrap();
     let note_assets = NoteAssets::new(vec![fungible_asset_2, fungible_asset_3]).unwrap();
     let note_recipient = NoteRecipient::new(
         SERIAL_NUM_2,

--- a/crates/rust-client/src/notes/mod.rs
+++ b/crates/rust-client/src/notes/mod.rs
@@ -200,7 +200,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                     return Ok(tracked_note.id());
                 }
             },
-            NoteFile::NoteDetails(details, None) => {
+            NoteFile::NoteDetails { details, after_block_num: _, tag: None } => {
                 let record_details = details.clone().into();
 
                 InputNoteRecord::new(
@@ -215,7 +215,11 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                     None,
                 )
             },
-            NoteFile::NoteDetails(details, Some(tag)) => {
+            NoteFile::NoteDetails {
+                details,
+                after_block_num: _,
+                tag: Some(tag),
+            } => {
                 let tracked_tags = maybe_await!(self.get_note_tags())?;
 
                 let account_tags = maybe_await!(self.get_account_stubs())?

--- a/crates/rust-client/src/rpc/domain/notes.rs
+++ b/crates/rust-client/src/rpc/domain/notes.rs
@@ -1,5 +1,5 @@
 use miden_objects::{
-    notes::{NoteMetadata, NoteTag, NoteType},
+    notes::{NoteExecutionHint, NoteMetadata, NoteTag, NoteType},
     Felt,
 };
 
@@ -20,8 +20,13 @@ impl TryFrom<ProtoNoteMetadata> for NoteMetadata {
             .try_into()?;
         let note_type = NoteType::try_from(value.note_type as u64)?;
         let tag = NoteTag::from(value.tag);
+        let execution_hint_tag = (value.execution_hint & 0xFF) as u8;
+        let execution_hint_payload = ((value.execution_hint >> 8) & 0xFFFFFF) as u32;
+        let execution_hint =
+            NoteExecutionHint::from_parts(execution_hint_tag, execution_hint_payload)?;
+
         let aux = Felt::try_from(value.aux).map_err(|_| RpcConversionError::NotAValidFelt)?;
 
-        Ok(NoteMetadata::new(sender, note_type, tag, aux)?)
+        Ok(NoteMetadata::new(sender, note_type, tag, execution_hint, aux)?)
     }
 }

--- a/crates/rust-client/src/rpc/tonic_client/generated/account.rs
+++ b/crates/rust-client/src/rpc/tonic_client/generated/account.rs
@@ -5,7 +5,7 @@
 pub struct AccountId {
     /// A miden account is defined with a little bit of proof-of-work, the id itself is defined as
     /// the first word of a hash digest. For this reason account ids can be considered as random
-    /// values, because of that the encoding bellow uses fixed 64 bits, instead of zig-zag encoding.
+    /// values, because of that the encoding below uses fixed 64 bits, instead of zig-zag encoding.
     #[prost(fixed64, tag = "1")]
     pub id: u64,
 }

--- a/crates/rust-client/src/rpc/tonic_client/generated/note.rs
+++ b/crates/rust-client/src/rpc/tonic_client/generated/note.rs
@@ -9,6 +9,8 @@ pub struct NoteMetadata {
     #[prost(fixed32, tag = "3")]
     pub tag: u32,
     #[prost(fixed64, tag = "4")]
+    pub execution_hint: u64,
+    #[prost(fixed64, tag = "5")]
     pub aux: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/crates/rust-client/src/rpc/web_tonic_client/generated/account.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/generated/account.rs
@@ -5,7 +5,7 @@
 pub struct AccountId {
     /// A miden account is defined with a little bit of proof-of-work, the id itself is defined as
     /// the first word of a hash digest. For this reason account ids can be considered as random
-    /// values, because of that the encoding bellow uses fixed 64 bits, instead of zig-zag encoding.
+    /// values, because of that the encoding below uses fixed 64 bits, instead of zig-zag encoding.
     #[prost(fixed64, tag = "1")]
     pub id: u64,
 }

--- a/crates/rust-client/src/rpc/web_tonic_client/generated/note.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/generated/note.rs
@@ -9,6 +9,8 @@ pub struct NoteMetadata {
     #[prost(fixed32, tag = "3")]
     pub tag: u32,
     #[prost(fixed64, tag = "4")]
+    pub execution_hint: u64,
+    #[prost(fixed64, tag = "5")]
     pub aux: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -69,7 +69,7 @@ async fn test_get_input_note() {
 
     // insert Note into database
     let note: InputNoteRecord = created_notes.first().unwrap().clone().into();
-    client.import_note(NoteFile::NoteDetails(note.into(), None)).await.unwrap();
+    client.import_note(NoteFile::NoteDetails{details:note.into(), tag:None, after_block_num:0}).await.unwrap();
 
     // retrieve note from database
     let retrieved_note =
@@ -457,12 +457,12 @@ async fn test_import_note_validation() {
     let expected_note = InputNoteRecord::from(created_notes.first().unwrap().clone());
 
     client
-        .import_note(NoteFile::NoteDetails(committed_note.clone().into(), None))
+        .import_note(NoteFile::NoteDetails{details: committed_note.clone().into(), tag:None, after_block_num:0})
         .await
         .unwrap();
     assert!(client.import_note(NoteFile::NoteId(expected_note.id())).await.is_err());
     client
-        .import_note(NoteFile::NoteDetails(expected_note.clone().into(), None))
+        .import_note(NoteFile::NoteDetails{details:expected_note.clone().into(), tag:None, after_block_num:0})
         .await
         .unwrap();
     assert!(expected_note.inclusion_proof().is_none());

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -69,7 +69,14 @@ async fn test_get_input_note() {
 
     // insert Note into database
     let note: InputNoteRecord = created_notes.first().unwrap().clone().into();
-    client.import_note(NoteFile::NoteDetails{details:note.into(), tag:None, after_block_num:0}).await.unwrap();
+    client
+        .import_note(NoteFile::NoteDetails {
+            details: note.into(),
+            tag: None,
+            after_block_num: 0,
+        })
+        .await
+        .unwrap();
 
     // retrieve note from database
     let retrieved_note =
@@ -457,12 +464,20 @@ async fn test_import_note_validation() {
     let expected_note = InputNoteRecord::from(created_notes.first().unwrap().clone());
 
     client
-        .import_note(NoteFile::NoteDetails{details: committed_note.clone().into(), tag:None, after_block_num:0})
+        .import_note(NoteFile::NoteDetails {
+            details: committed_note.clone().into(),
+            tag: None,
+            after_block_num: 0,
+        })
         .await
         .unwrap();
     assert!(client.import_note(NoteFile::NoteId(expected_note.id())).await.is_err());
     client
-        .import_note(NoteFile::NoteDetails{details:expected_note.clone().into(), tag:None, after_block_num:0})
+        .import_note(NoteFile::NoteDetails {
+            details: expected_note.clone().into(),
+            tag: None,
+            after_block_num: 0,
+        })
         .await
         .unwrap();
     assert!(expected_note.inclusion_proof().is_none());

--- a/crates/rust-client/src/transactions/request.rs
+++ b/crates/rust-client/src/transactions/request.rs
@@ -357,6 +357,10 @@ impl PartialEq for TransactionRequest {
         let same_script_template = match &self.script_template {
             Some(TransactionScriptTemplate::CustomScript(script)) => match &other.script_template {
                 Some(TransactionScriptTemplate::CustomScript(other_script)) => {
+                    // TODO: We should also compare the source code. However, the ProgramAst
+                    // serialization has a small bug that makes the end program a bit different.
+                    // We should add the comparison of the source code once we start using the
+                    // v0.10 `miden-vm`.
                     script.hash() == other_script.hash() && script.inputs() == other_script.inputs()
                 },
                 _ => false,

--- a/crates/rust-client/src/transactions/request.rs
+++ b/crates/rust-client/src/transactions/request.rs
@@ -500,7 +500,7 @@ impl SwapTransactionData {
 pub mod known_script_roots {
     pub const P2ID: &str = "0x07db8e6726c0859648a4f0ad38376440c01d98674b7d5a03d7ad729ae2a21d8f";
     pub const P2IDR: &str = "0xd43b69d65bbc22abf64dbae53ad22e3a4f6d5bfac8e47497b69c116824b46427";
-    pub const SWAP: &str = "0x9270b8c89303cf7a05340351d7f9962a9722c4f35d30b7d4980929b381e5d695";
+    pub const SWAP: &str = "0x216ed058cf9f98e8ca423321d67688dce65b7e7771f7ecbb0958bd99e326b009";
 }
 
 // TESTS

--- a/crates/rust-client/src/transactions/script_builder.rs
+++ b/crates/rust-client/src/transactions/script_builder.rs
@@ -84,7 +84,7 @@ impl AccountInterface {
                     body.push_str(&format!(
                         "
                         push.{amount}
-                        call.faucet::distribute dropw dropw
+                        call.faucet::distribute dropw dropw drop
                         ",
                         amount = asset.unwrap_fungible().amount()
                     ));
@@ -93,7 +93,7 @@ impl AccountInterface {
                     body.push_str(&format!(
                         "
                         push.{asset}
-                        call.wallet::send_asset dropw dropw dropw dropw
+                        call.wallet::send_asset dropw dropw dropw dropw drop
                         ",
                         asset = prepare_word(&asset.into())
                     ));

--- a/crates/rust-client/src/transactions/script_builder.rs
+++ b/crates/rust-client/src/transactions/script_builder.rs
@@ -63,12 +63,14 @@ impl AccountInterface {
             body.push_str(&format!(
                 "
                 push.{recipient}
+                push.{execution_hint}
                 push.{note_type}
                 push.{aux}
                 push.{tag}
                 ",
                 recipient = prepare_word(&partial_note.recipient_digest()),
                 note_type = Felt::from(partial_note.metadata().note_type()),
+                execution_hint = Felt::from(partial_note.metadata().execution_hint()),
                 aux = partial_note.metadata().aux(),
                 tag = Felt::from(partial_note.metadata().tag()),
             ));

--- a/crates/web-client/src/export.rs
+++ b/crates/web-client/src/export.rs
@@ -51,12 +51,13 @@ impl WebClient {
                     ),
                     None => return Err(JsValue::from_str("Note does not have inclusion proof")),
                 },
-                ExportType::Partial => NoteFile::NoteDetails(
-                    output_note.clone().try_into().map_err(|err| {
+                ExportType::Partial => NoteFile::NoteDetails {
+                    details: output_note.clone().try_into().map_err(|err| {
                         JsValue::from_str(&format!("Failed to convert output note: {}", err))
                     })?,
-                    Some(output_note.metadata().tag()),
-                ),
+                    tag: Some(output_note.metadata().tag()),
+                    after_block_num: 0,
+                },
             };
 
             let input_note_bytes = note_file.to_bytes();

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -1,8 +1,5 @@
 use miden_client::{
-    accounts::AccountTemplate,
-    transactions::request::TransactionRequest,
-    utils::{Deserializable, Serializable},
-    ZERO,
+    accounts::AccountTemplate, notes::NoteExecutionHint, transactions::request::TransactionRequest, utils::{Deserializable, Serializable}, ZERO
 };
 use miden_objects::{
     accounts::{AccountId, AccountStorageType, AuthSecretKey},
@@ -312,6 +309,7 @@ fn create_custom_note(
         faucet_account_id,
         NoteType::Private,
         NoteTag::from_account_id(target_account_id, NoteExecutionMode::Local).unwrap(),
+        NoteExecutionHint::None,
         Default::default(),
     )
     .unwrap();

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -1,5 +1,9 @@
 use miden_client::{
-    accounts::AccountTemplate, notes::NoteExecutionHint, transactions::request::TransactionRequest, utils::{Deserializable, Serializable}, ZERO
+    accounts::AccountTemplate,
+    notes::NoteExecutionHint,
+    transactions::request::TransactionRequest,
+    utils::{Deserializable, Serializable},
+    ZERO,
 };
 use miden_objects::{
     accounts::{AccountId, AccountStorageType, AuthSecretKey},

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -1,5 +1,8 @@
 use miden_client::{
-    accounts::AccountTemplate, transactions::request::TransactionRequest, utils::Serializable, ZERO,
+    accounts::AccountTemplate,
+    transactions::request::TransactionRequest,
+    utils::{Deserializable, Serializable},
+    ZERO,
 };
 use miden_objects::{
     accounts::{AccountId, AccountStorageType, AuthSecretKey},
@@ -148,6 +151,13 @@ async fn test_transaction_request() {
         .with_custom_script(tx_script)
         .unwrap()
         .extend_advice_map(advice_map);
+
+    // TEST CUSTOM SCRIPT SERIALIZATION
+    let mut buffer = Vec::new();
+    transaction_request.write_into(&mut buffer);
+
+    let deserialized_transaction_request = TransactionRequest::read_from_bytes(&buffer).unwrap();
+    assert_eq!(transaction_request, deserialized_transaction_request);
 
     execute_tx_and_sync(&mut client, transaction_request).await;
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -515,7 +515,7 @@ async fn test_import_expected_notes() {
     // Import an uncommited note without verification
     client_2.add_note_tag(note.metadata().unwrap().tag()).unwrap();
     client_2
-        .import_note(NoteFile::NoteDetails{
+        .import_note(NoteFile::NoteDetails {
             details: note.clone().into(),
             tag: Some(note.metadata().unwrap().tag()),
             after_block_num: 0,
@@ -794,7 +794,11 @@ async fn test_import_ignored_notes() {
 
     // Import note details without tag so the note is ignored
     client_2
-        .import_note(NoteFile::NoteDetails{details: note.clone().into(), tag:None, after_block_num:0})
+        .import_note(NoteFile::NoteDetails {
+            details: note.clone().into(),
+            tag: None,
+            after_block_num: 0,
+        })
         .await
         .unwrap();
 
@@ -854,7 +858,11 @@ async fn test_update_ignored_tag() {
     // Import note details with untracked tag so the note is ignored
     let untracked_tag = NoteTag::from(123);
     client_2
-        .import_note(NoteFile::NoteDetails{details:note.clone().into(), tag:Some(untracked_tag), after_block_num:0})
+        .import_note(NoteFile::NoteDetails {
+            details: note.clone().into(),
+            tag: Some(untracked_tag),
+            after_block_num: 0,
+        })
         .await
         .unwrap();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -515,10 +515,11 @@ async fn test_import_expected_notes() {
     // Import an uncommited note without verification
     client_2.add_note_tag(note.metadata().unwrap().tag()).unwrap();
     client_2
-        .import_note(NoteFile::NoteDetails(
-            note.clone().into(),
-            Some(note.metadata().unwrap().tag()),
-        ))
+        .import_note(NoteFile::NoteDetails{
+            details: note.clone().into(),
+            tag: Some(note.metadata().unwrap().tag()),
+            after_block_num: 0,
+        })
         .await
         .unwrap();
     let input_note = client_2.get_input_note(note.id()).unwrap();
@@ -793,7 +794,7 @@ async fn test_import_ignored_notes() {
 
     // Import note details without tag so the note is ignored
     client_2
-        .import_note(NoteFile::NoteDetails(note.clone().into(), None))
+        .import_note(NoteFile::NoteDetails{details: note.clone().into(), tag:None, after_block_num:0})
         .await
         .unwrap();
 
@@ -853,7 +854,7 @@ async fn test_update_ignored_tag() {
     // Import note details with untracked tag so the note is ignored
     let untracked_tag = NoteTag::from(123);
     client_2
-        .import_note(NoteFile::NoteDetails(note.clone().into(), Some(untracked_tag)))
+        .import_note(NoteFile::NoteDetails{details:note.clone().into(), tag:Some(untracked_tag), after_block_num:0})
         .await
         .unwrap();
 

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -358,7 +358,7 @@ async fn test_swap_offchain() {
         build_swap_tag(NoteType::Private, offered_asset.faucet_id(), requested_asset.faucet_id());
     client2.add_note_tag(tag).unwrap();
     client2
-        .import_note(NoteFile::NoteDetails(exported_note.into(), Some(tag)))
+        .import_note(NoteFile::NoteDetails{ details: exported_note.into(), tag: Some(tag), after_block_num: 0})
         .await
         .unwrap();
 

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -358,7 +358,11 @@ async fn test_swap_offchain() {
         build_swap_tag(NoteType::Private, offered_asset.faucet_id(), requested_asset.faucet_id());
     client2.add_note_tag(tag).unwrap();
     client2
-        .import_note(NoteFile::NoteDetails{ details: exported_note.into(), tag: Some(tag), after_block_num: 0})
+        .import_note(NoteFile::NoteDetails {
+            details: exported_note.into(),
+            tag: Some(tag),
+            after_block_num: 0,
+        })
         .await
         .unwrap();
 


### PR DESCRIPTION
closes #466 

This PR implements serialization to and from bytes for `TransactionRequest`. Some tests are also added to verify a correct serialization.

When comparing if the deserialized `TransactionRequest` is the same, we are ommitting the `ProgramAst` code as we found that they were not the same. The difference was mentioned by [a comment](https://github.com/0xPolygonMiden/miden-vm/blob/9abd8d17483dc7a3b23ebb72ab30b86426ddf19d/assembly/src/ast/imports.rs#L175-L176) in `miden-vm`, which was later removed in v0.10. Once the client is updated to the new vm version we can add back the check to see if the problem persists.