### PR TITLE
feat: import committed notes from older blocks that current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added serialization for `TransactionRequest` (#471).
 * Added support for decimal values in the CLI (#454).
+* Added support for importing committed notes from older blocks than current (#472).
 * Added the Web Client Crate
 * Added validations in transaction requests (#447).
 * [BREAKING] Refactored `Client` to merge submit_transaction and prove_transaction (#445)

--- a/bin/miden-cli/src/commands/export.rs
+++ b/bin/miden-cli/src/commands/export.rs
@@ -74,7 +74,9 @@ pub fn export_note<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthent
         },
         ExportType::Partial => NoteFile::NoteDetails {
             details: output_note.clone().try_into()?,
-            after_block_num: client.get_sync_height().expect("Client should sync at least once"),
+            // TODO: This MUST be changed to the correct block number
+            // https://github.com/0xPolygonMiden/miden-client/issues/480
+            after_block_num: 0,
             tag: Some(output_note.metadata().tag()),
         },
     };

--- a/bin/miden-cli/src/commands/export.rs
+++ b/bin/miden-cli/src/commands/export.rs
@@ -74,9 +74,7 @@ pub fn export_note<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthent
         },
         ExportType::Partial => NoteFile::NoteDetails {
             details: output_note.clone().try_into()?,
-            after_block_num: client
-                .get_sync_height()
-                .expect("Client should sync at least once"),
+            after_block_num: client.get_sync_height().expect("Client should sync at least once"),
             tag: Some(output_note.metadata().tag()),
         },
     };

--- a/bin/miden-cli/src/commands/export.rs
+++ b/bin/miden-cli/src/commands/export.rs
@@ -75,7 +75,6 @@ pub fn export_note<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthent
         ExportType::Partial => NoteFile::NoteDetails {
             details: output_note.clone().try_into()?,
             after_block_num: client
-                .store()
                 .get_sync_height()
                 .expect("Client should sync at least once"),
             tag: Some(output_note.metadata().tag()),

--- a/bin/miden-cli/src/commands/import.rs
+++ b/bin/miden-cli/src/commands/import.rs
@@ -36,6 +36,11 @@ impl ImportCmd {
         for filename in &self.filenames {
             let note_id = import_note(&mut client, filename.clone()).await;
 
+            if note_id.is_err() {
+                println!("Failed to import note from file {}", filename.to_string_lossy());
+                println!("With error: {:?}", note_id.clone().err().unwrap());
+            };
+
             if let Ok(note_id) = note_id {
                 println!("Succesfully imported note {}", note_id.inner());
             } else {

--- a/bin/miden-cli/src/commands/import.rs
+++ b/bin/miden-cli/src/commands/import.rs
@@ -36,11 +36,6 @@ impl ImportCmd {
         for filename in &self.filenames {
             let note_id = import_note(&mut client, filename.clone()).await;
 
-            if note_id.is_err() {
-                println!("Failed to import note from file {}", filename.to_string_lossy());
-                println!("With error: {:?}", note_id.clone().err().unwrap());
-            };
-
             if let Ok(note_id) = note_id {
                 println!("Succesfully imported note {}", note_id.inner());
             } else {

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -109,6 +109,13 @@ impl MockRpcApi {
 }
 
 impl NodeRpcClient for MockRpcApi {
+    async fn sync_notes(
+        &mut self,
+        _block_num: u32,
+        _note_tags: &[NoteTag],
+    ) -> Result<crate::rpc::NoteSyncInfo, RpcError> {
+        todo!("sync_notes")
+    }
     /// Executes the specified sync state request and returns the response.
     async fn sync_state(
         &mut self,

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -97,7 +97,7 @@ impl Default for MockRpcApi {
         let sync_note_request = SyncNoteResponse {
             chain_tip: 10,
             notes: vec![],
-            block_header: None,
+            block_header: Some(BlockHeader::mock(1, None, None, &[]).into()),
             mmr_path: None,
         };
 

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -41,7 +41,9 @@ use crate::{
             note::NoteSyncRecord,
             requests::SyncStateRequest,
             responses::{NullifierUpdate, SyncNoteResponse, SyncStateResponse},
-        }, AccountDetails, NodeRpcClient, NodeRpcClientEndpoint, NoteDetails, NoteInclusionDetails, RpcError, StateSyncInfo
+        },
+        AccountDetails, NodeRpcClient, NodeRpcClientEndpoint, NoteDetails, NoteInclusionDetails,
+        RpcError, StateSyncInfo,
     },
     store::{
         sqlite_store::{config::SqliteStoreConfig, SqliteStore},

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -98,7 +98,7 @@ impl Default for MockRpcApi {
             chain_tip: 10,
             notes: vec![],
             block_header: Some(BlockHeader::mock(1, None, None, &[]).into()),
-            mmr_path: None,
+            mmr_path: Some(Default::default()),
         };
 
         Self {

--- a/crates/rust-client/src/notes/mod.rs
+++ b/crates/rust-client/src/notes/mod.rs
@@ -241,7 +241,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                 let record_details = details.clone().into();
 
                 if let (NoteStatus::Committed { block_height }, Some(input_note)) =
-                    self.sync_note(after_block_num, tag, &details).await?
+                    self.check_expected_note(after_block_num, tag, &details).await?
                 {
                     let mut current_partial_mmr =
                         maybe_await!(self.build_current_partial_mmr(true))?;
@@ -310,7 +310,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     // ===============================================================================================
 
     /// Synchronizes a note with the chain.
-    async fn sync_note(
+    async fn check_expected_note(
         &mut self,
         mut request_block_num: u32,
         tag: NoteTag,

--- a/crates/rust-client/src/notes/mod.rs
+++ b/crates/rust-client/src/notes/mod.rs
@@ -242,11 +242,17 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
 
                 let record_details = details.clone().into();
 
-                let (note_status, metadata, note_inclusion_proof) = self.sync_note(1, tag, &details).await?;
+                let (note_status, metadata, note_inclusion_proof) =
+                    self.sync_note(1, tag, &details).await?;
 
                 if let NoteStatus::Committed { block_height } = note_status {
-                    let mut current_partial_mmr = maybe_await!(self.build_current_partial_mmr(true))?;
-                    self.get_and_store_authenticated_block(block_height.try_into().unwrap(), &mut current_partial_mmr).await?;
+                    let mut current_partial_mmr =
+                        maybe_await!(self.build_current_partial_mmr(true))?;
+                    self.get_and_store_authenticated_block(
+                        block_height.try_into().unwrap(),
+                        &mut current_partial_mmr,
+                    )
+                    .await?;
                 };
 
                 InputNoteRecord::new(
@@ -336,7 +342,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                         // Block header can't be None since we check that already in the if statement.
                         block_height: sync_notes.block_header.as_ref().unwrap().block_num() as u64,
                     },
-                    Some(note.metadata().clone()),
+                    Some(note.metadata()),
                     Some(note_inclusion_proof),
                 ));
             } else {

--- a/crates/rust-client/src/notes/mod.rs
+++ b/crates/rust-client/src/notes/mod.rs
@@ -311,7 +311,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         expected_note: &miden_objects::notes::NoteDetails,
     ) -> Result<(NoteStatus, Option<NoteMetadata>, Option<NoteInclusionProof>), ClientError> {
         loop {
-            let current_block_num = maybe_await!(self.store.get_sync_height())?;
+            let current_block_num = maybe_await!(self.get_sync_height())?;
             if block_num >= current_block_num {
                 return Ok((NoteStatus::Expected { created_at: 0 }, None, None));
             };

--- a/crates/rust-client/src/notes/mod.rs
+++ b/crates/rust-client/src/notes/mod.rs
@@ -242,7 +242,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
 
                 let record_details = details.clone().into();
 
-                let (note_status, note_inclusion_proof) = self.sync_note(0, tag, &details).await?;
+                let (note_status, note_inclusion_proof) = self.sync_note(1, tag, &details).await?;
 
                 InputNoteRecord::new(
                     details.id(),

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -168,6 +168,33 @@ pub trait NodeRpcClient {
         &mut self,
         account_id: AccountId,
     ) -> Result<AccountDetails, RpcError>;
+
+    async fn sync_notes(
+        &mut self,
+        block_num: u32,
+        note_tags: &[NoteTag],
+    ) -> Result<NoteSyncInfo, RpcError>;
+}
+
+// SYNC NOTE
+// ================================================================================================
+
+/// Represents a `SyncNoteResponse` with fields converted into domain types
+#[derive(Debug)]
+pub struct NoteSyncInfo {
+    /// Number of the latest block in the chain
+    pub chain_tip: u32,
+    /// Block header of the block with the first note matching the specified criteria
+    pub block_header: Option<BlockHeader>,
+    /// Proof for block header's MMR with respect to the chain tip.
+    ///
+    /// More specifically, the full proof consists of `forest`, `position` and `path` components. This
+    /// value constitutes the `path`. The other two components can be obtained as follows:
+    ///    - `position` is simply `resopnse.block_header.block_num`
+    ///    - `forest` is the same as `response.chain_tip + 1`
+    pub mmr_path: Option<MerklePath>,
+    /// List of all notes together with the Merkle paths from `response.block_header.note_root`
+    pub notes: Vec<CommittedNote>,
 }
 
 // STATE SYNC INFO
@@ -269,6 +296,7 @@ pub enum NodeRpcClientEndpoint {
     GetBlockHeaderByNumber,
     SyncState,
     SubmitProvenTx,
+    SyncNotes,
 }
 
 impl fmt::Display for NodeRpcClientEndpoint {
@@ -280,6 +308,7 @@ impl fmt::Display for NodeRpcClientEndpoint {
             },
             NodeRpcClientEndpoint::SyncState => write!(f, "sync_state"),
             NodeRpcClientEndpoint::SubmitProvenTx => write!(f, "submit_proven_transaction"),
+            NodeRpcClientEndpoint::SyncNotes => write!(f, "sync_notes"),
         }
     }
 }

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -243,7 +243,7 @@ pub struct NullifierUpdate {
 // ================================================================================================
 
 /// Represents a committed note, returned as part of a `SyncStateResponse`
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommittedNote {
     /// Note ID of the committed note
     note_id: NoteId,

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -192,7 +192,7 @@ pub struct NoteSyncInfo {
     /// value constitutes the `path`. The other two components can be obtained as follows:
     ///    - `position` is simply `resopnse.block_header.block_num`
     ///    - `forest` is the same as `response.chain_tip + 1`
-    pub mmr_path: Option<MerklePath>,
+    pub mmr_path: MerklePath,
     /// List of all notes together with the Merkle paths from `response.block_header.note_root`
     pub notes: Vec<CommittedNote>,
 }

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -185,7 +185,7 @@ pub struct NoteSyncInfo {
     /// Number of the latest block in the chain
     pub chain_tip: u32,
     /// Block header of the block with the first note matching the specified criteria
-    pub block_header: Option<BlockHeader>,
+    pub block_header: BlockHeader,
     /// Proof for block header's MMR with respect to the chain tip.
     ///
     /// More specifically, the full proof consists of `forest`, `position` and `path` components. This

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -307,7 +307,10 @@ impl TryFrom<SyncNoteResponse> for NoteSyncInfo {
             .ok_or(RpcError::ExpectedFieldMissing("BlockHeader".into()))?
             .try_into()?;
 
-        let mmr_path = value.mmr_path.map(|mmr_path| mmr_path.try_into()).transpose()?;
+        let mmr_path = value
+            .mmr_path
+            .ok_or(RpcError::ExpectedFieldMissing("MmrPath".into()))?
+            .try_into()?;
 
         // Validate and convert account note inclusions into an (AccountId, Digest) tuple
         let mut notes = vec![];

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -302,8 +302,10 @@ impl TryFrom<SyncNoteResponse> for NoteSyncInfo {
         let chain_tip = value.chain_tip;
 
         // Validate and convert block header
-        let block_header =
-            value.block_header.map(|block_header| block_header.try_into()).transpose()?;
+        let block_header = value
+            .block_header
+            .ok_or(RpcError::ExpectedFieldMissing("BlockHeader".into()))?
+            .try_into()?;
 
         let mmr_path = value.mmr_path.map(|mmr_path| mmr_path.try_into()).transpose()?;
 

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 use generated::{
     requests::{
         GetAccountDetailsRequest, GetBlockHeaderByNumberRequest, GetNotesByIdRequest,
-        SubmitProvenTransactionRequest, SyncStateRequest,
+        SubmitProvenTransactionRequest, SyncNoteRequest, SyncStateRequest,
     },
-    responses::SyncStateResponse,
+    responses::{SyncNoteResponse, SyncStateResponse},
     rpc::api_client::ApiClient,
 };
 use miden_objects::{
@@ -26,7 +26,8 @@ use tracing::info;
 
 use super::{
     AccountDetails, AccountUpdateSummary, CommittedNote, NodeRpcClient, NodeRpcClientEndpoint,
-    NoteDetails, NoteInclusionDetails, NullifierUpdate, StateSyncInfo, TransactionUpdate,
+    NoteDetails, NoteInclusionDetails, NoteSyncInfo, NullifierUpdate, StateSyncInfo,
+    TransactionUpdate,
 };
 use crate::{config::RpcConfig, rpc::RpcError};
 
@@ -270,6 +271,69 @@ impl NodeRpcClient for TonicRpcClient {
         } else {
             Ok(AccountDetails::OffChain(account_id, update_summary))
         }
+    }
+
+    async fn sync_notes(
+        &mut self,
+        block_num: u32,
+        note_tags: &[NoteTag],
+    ) -> Result<super::NoteSyncInfo, RpcError> {
+        let note_tags = note_tags.iter().map(|&note_tag| note_tag.into()).collect();
+
+        let request = SyncNoteRequest { block_num, note_tags };
+
+        let rpc_api = self.rpc_api().await?;
+
+        let response = rpc_api.sync_notes(request).await.map_err(|err| {
+            RpcError::RequestError(NodeRpcClientEndpoint::SyncNotes.to_string(), err.to_string())
+        })?;
+
+        response.into_inner().try_into()
+    }
+}
+
+// NOTE SYNC INFO CONVERSION
+// ================================================================================================
+
+impl TryFrom<SyncNoteResponse> for NoteSyncInfo {
+    type Error = RpcError;
+
+    fn try_from(value: SyncNoteResponse) -> Result<Self, Self::Error> {
+        let chain_tip = value.chain_tip;
+
+        // Validate and convert block header
+        let block_header =
+            value.block_header.map(|block_header| block_header.try_into()).transpose()?;
+
+        let mmr_path = value.mmr_path.map(|mmr_path| mmr_path.try_into()).transpose()?;
+
+        // Validate and convert account note inclusions into an (AccountId, Digest) tuple
+        let mut notes = vec![];
+        for note in value.notes {
+            let note_id: Digest = note
+                .note_id
+                .ok_or(RpcError::ExpectedFieldMissing("Notes.Id".into()))?
+                .try_into()?;
+
+            let note_id: NoteId = note_id.into();
+
+            let merkle_path = note
+                .merkle_path
+                .ok_or(RpcError::ExpectedFieldMissing("Notes.MerklePath".into()))?
+                .try_into()?;
+
+            let metadata = note
+                .metadata
+                .ok_or(RpcError::ExpectedFieldMissing("Metadata".into()))?
+                .try_into()?;
+
+            let committed_note =
+                CommittedNote::new(note_id, note.note_index, merkle_path, metadata);
+
+            notes.push(committed_note);
+        }
+
+        Ok(NoteSyncInfo { chain_tip, block_header, mmr_path, notes })
     }
 }
 

--- a/crates/rust-client/src/rpc/web_tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/mod.rs
@@ -281,8 +281,11 @@ impl TryFrom<SyncNoteResponse> for NoteSyncInfo {
         let chain_tip = value.chain_tip;
 
         // Validate and convert block header
-        let block_header =
-            value.block_header.map(|block_header| block_header.try_into()).transpose()?;
+        // Validate and convert block header
+        let block_header = value
+            .block_header
+            .ok_or(RpcError::ExpectedFieldMissing("BlockHeader".into()))?
+            .try_into()?;
 
         let mmr_path = value.mmr_path.map(|mmr_path| mmr_path.try_into()).transpose()?;
 

--- a/crates/rust-client/src/rpc/web_tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/mod.rs
@@ -6,9 +6,9 @@ use alloc::{
 use generated::{
     requests::{
         GetAccountDetailsRequest, GetBlockHeaderByNumberRequest, GetNotesByIdRequest,
-        SubmitProvenTransactionRequest, SyncStateRequest,
+        SubmitProvenTransactionRequest, SyncNoteRequest, SyncStateRequest,
     },
-    responses::SyncStateResponse,
+    responses::{SyncNoteResponse, SyncStateResponse},
     rpc::api_client::ApiClient,
 };
 use miden_objects::{
@@ -22,6 +22,7 @@ use miden_objects::{
 use miden_tx::utils::Serializable;
 use tonic_web_wasm_client::Client;
 
+use super::NoteSyncInfo;
 use crate::rpc::{
     AccountDetails, AccountUpdateSummary, CommittedNote, NodeRpcClient, NodeRpcClientEndpoint,
     NoteDetails, NoteInclusionDetails, NullifierUpdate, RpcError, StateSyncInfo, TransactionUpdate,
@@ -196,6 +197,23 @@ impl NodeRpcClient for WebTonicRpcClient {
         response.into_inner().try_into()
     }
 
+    async fn sync_notes(
+        &mut self,
+        block_num: u32,
+        note_tags: &[NoteTag],
+    ) -> Result<NoteSyncInfo, RpcError> {
+        let mut query_client = self.build_api_client();
+
+        let note_tags = note_tags.iter().map(|&note_tag| note_tag.into()).collect();
+
+        let request = SyncNoteRequest { block_num, note_tags };
+
+        let response = query_client.sync_notes(request).await.map_err(|err| {
+            RpcError::RequestError(NodeRpcClientEndpoint::SyncState.to_string(), err.to_string())
+        })?;
+        response.into_inner().try_into()
+    }
+
     /// Sends a [GetAccountDetailsRequest] to the Miden node, and extracts an [Account] from the
     /// `GetAccountDetailsResponse` response.
     ///
@@ -250,6 +268,51 @@ impl NodeRpcClient for WebTonicRpcClient {
         } else {
             Ok(AccountDetails::OffChain(account_id, update_summary))
         }
+    }
+}
+
+// NOTE SYNC INFO CONVERSION
+// ================================================================================================
+
+impl TryFrom<SyncNoteResponse> for NoteSyncInfo {
+    type Error = RpcError;
+
+    fn try_from(value: SyncNoteResponse) -> Result<Self, Self::Error> {
+        let chain_tip = value.chain_tip;
+
+        // Validate and convert block header
+        let block_header =
+            value.block_header.map(|block_header| block_header.try_into()).transpose()?;
+
+        let mmr_path = value.mmr_path.map(|mmr_path| mmr_path.try_into()).transpose()?;
+
+        // Validate and convert account note inclusions into an (AccountId, Digest) tuple
+        let mut notes = vec![];
+        for note in value.notes {
+            let note_id: Digest = note
+                .note_id
+                .ok_or(RpcError::ExpectedFieldMissing("Notes.Id".into()))?
+                .try_into()?;
+
+            let note_id: NoteId = note_id.into();
+
+            let merkle_path = note
+                .merkle_path
+                .ok_or(RpcError::ExpectedFieldMissing("Notes.MerklePath".into()))?
+                .try_into()?;
+
+            let metadata = note
+                .metadata
+                .ok_or(RpcError::ExpectedFieldMissing("Metadata".into()))?
+                .try_into()?;
+
+            let committed_note =
+                CommittedNote::new(note_id, note.note_index, merkle_path, metadata);
+
+            notes.push(committed_note);
+        }
+
+        Ok(NoteSyncInfo { chain_tip, block_header, mmr_path, notes })
     }
 }
 

--- a/crates/rust-client/src/rpc/web_tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/mod.rs
@@ -287,7 +287,10 @@ impl TryFrom<SyncNoteResponse> for NoteSyncInfo {
             .ok_or(RpcError::ExpectedFieldMissing("BlockHeader".into()))?
             .try_into()?;
 
-        let mmr_path = value.mmr_path.map(|mmr_path| mmr_path.try_into()).transpose()?;
+        let mmr_path = value
+            .mmr_path
+            .ok_or(RpcError::ExpectedFieldMissing("MmrPath".into()))?
+            .try_into()?;
 
         // Validate and convert account note inclusions into an (AccountId, Digest) tuple
         let mut notes = vec![];

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -466,8 +466,8 @@ async fn test_import_note_validation() {
     client
         .import_note(NoteFile::NoteDetails {
             details: committed_note.clone().into(),
-            tag: None,
             after_block_num: 0,
+            tag: None,
         })
         .await
         .unwrap();
@@ -475,8 +475,8 @@ async fn test_import_note_validation() {
     client
         .import_note(NoteFile::NoteDetails {
             details: expected_note.clone().into(),
-            tag: None,
             after_block_num: 0,
+            tag: None,
         })
         .await
         .unwrap();

--- a/crates/web-client/src/export.rs
+++ b/crates/web-client/src/export.rs
@@ -1,5 +1,5 @@
 use miden_client::{
-    store::{NoteFilter, Store},
+    store::NoteFilter,
     utils::Serializable,
 };
 use miden_objects::{notes::NoteFile, Digest};
@@ -61,7 +61,7 @@ impl WebClient {
                     after_block_num: client
                         .get_sync_height()
                         .await
-                        .map_err(|err| JsValue::from_str(&format!("Store error: {}", err)))?,
+                        .map_err(|err| JsValue::from_str(&format!("Failed to get sync height: {}", err)))?,
                     tag: Some(output_note.metadata().tag()),
                 },
             };

--- a/crates/web-client/src/export.rs
+++ b/crates/web-client/src/export.rs
@@ -1,4 +1,7 @@
-use miden_client::{store::NoteFilter, utils::Serializable};
+use miden_client::{
+    store::{NoteFilter, Store},
+    utils::Serializable,
+};
 use miden_objects::{notes::NoteFile, Digest};
 use wasm_bindgen::prelude::*;
 
@@ -55,8 +58,12 @@ impl WebClient {
                     details: output_note.clone().try_into().map_err(|err| {
                         JsValue::from_str(&format!("Failed to convert output note: {}", err))
                     })?,
+                    after_block_num: client
+                        .store()
+                        .get_sync_height()
+                        .await
+                        .map_err(|err| JsValue::from_str(&format!("Store error: {}", err)))?,
                     tag: Some(output_note.metadata().tag()),
-                    after_block_num: 0,
                 },
             };
 

--- a/crates/web-client/src/export.rs
+++ b/crates/web-client/src/export.rs
@@ -59,7 +59,6 @@ impl WebClient {
                         JsValue::from_str(&format!("Failed to convert output note: {}", err))
                     })?,
                     after_block_num: client
-                        .store()
                         .get_sync_height()
                         .await
                         .map_err(|err| JsValue::from_str(&format!("Store error: {}", err)))?,

--- a/crates/web-client/src/export.rs
+++ b/crates/web-client/src/export.rs
@@ -1,7 +1,4 @@
-use miden_client::{
-    store::NoteFilter,
-    utils::Serializable,
-};
+use miden_client::{store::NoteFilter, utils::Serializable};
 use miden_objects::{notes::NoteFile, Digest};
 use wasm_bindgen::prelude::*;
 
@@ -58,10 +55,9 @@ impl WebClient {
                     details: output_note.clone().try_into().map_err(|err| {
                         JsValue::from_str(&format!("Failed to convert output note: {}", err))
                     })?,
-                    after_block_num: client
-                        .get_sync_height()
-                        .await
-                        .map_err(|err| JsValue::from_str(&format!("Failed to get sync height: {}", err)))?,
+                    after_block_num: client.get_sync_height().await.map_err(|err| {
+                        JsValue::from_str(&format!("Failed to get sync height: {}", err))
+                    })?,
                     tag: Some(output_note.metadata().tag()),
                 },
             };

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -578,7 +578,7 @@ async fn test_import_expected_notes() {
     client_2
         .import_note(NoteFile::NoteDetails {
             details: note.clone().into(),
-            after_block_num: client_1.store().get_sync_height().unwrap(),
+            after_block_num: client_1.get_sync_height().unwrap(),
             tag: Some(note.metadata().unwrap().tag()),
         })
         .await
@@ -624,7 +624,7 @@ async fn test_import_expected_notes_from_the_past_as_committed() {
     let tx_request = client_1.build_transaction_request(tx_template).unwrap();
     let note: InputNoteRecord = tx_request.expected_output_notes().next().unwrap().clone().into();
 
-    let block_height_before = client_1.store().get_sync_height().unwrap();
+    let block_height_before = client_1.get_sync_height().unwrap();
 
     execute_tx_and_sync(&mut client_1, tx_request).await;
 
@@ -901,7 +901,7 @@ async fn test_import_ignored_notes() {
     let tx_request = client_1.build_transaction_request(tx_template).unwrap();
     let note: InputNoteRecord = tx_request.expected_output_notes().next().unwrap().clone().into();
 
-    let block_height_before = client_1.store().get_sync_height().unwrap();
+    let block_height_before = client_1.get_sync_height().unwrap();
 
     execute_tx_and_sync(&mut client_1, tx_request).await;
 
@@ -966,7 +966,7 @@ async fn test_update_ignored_tag() {
 
     let tx_request = client_1.build_transaction_request(tx_template).unwrap();
     let note: InputNoteRecord = tx_request.expected_output_notes().next().unwrap().clone().into();
-    let block_height_before = client_1.store().get_sync_height().unwrap();
+    let block_height_before = client_1.get_sync_height().unwrap();
     execute_tx_and_sync(&mut client_1, tx_request).await;
 
     client_2.sync_state().await.unwrap();

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -2,7 +2,7 @@ use miden_client::{
     accounts::AccountTemplate,
     notes::NoteRelevance,
     rpc::{AccountDetails, NodeRpcClient, TonicRpcClient},
-    store::{InputNoteRecord, NoteFilter, NoteStatus, Store, TransactionFilter},
+    store::{InputNoteRecord, NoteFilter, NoteStatus, TransactionFilter},
     transactions::{
         request::{PaymentTransactionData, TransactionTemplate},
         TransactionExecutorError, TransactionStatus,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,6 +1,6 @@
 use miden_client::{
     accounts::AccountTemplate,
-    notes::{NoteInputs, NoteRecipient, NoteRelevance},
+    notes::NoteRelevance,
     rpc::{AccountDetails, NodeRpcClient, TonicRpcClient},
     store::{InputNoteRecord, NoteFilter, NoteStatus, TransactionFilter},
     transactions::{
@@ -12,7 +12,7 @@ use miden_client::{
 use miden_objects::{
     accounts::{AccountId, AccountStorageType},
     assets::{Asset, FungibleAsset},
-    notes::{NoteDetails, NoteFile, NoteTag, NoteType},
+    notes::{NoteFile, NoteTag, NoteType},
 };
 
 mod common;
@@ -628,14 +628,7 @@ async fn test_import_expected_note_uncommitted() {
     // If the verification is requested before execution then the import should fail
     let imported_note_id = client_2
         .import_note(NoteFile::NoteDetails {
-            details: NoteDetails::new(
-                note.assets().clone(),
-                NoteRecipient::new(
-                    note.details().serial_num(),
-                    note.details().script().clone(),
-                    NoteInputs::new(note.details().inputs().to_vec()).unwrap(),
-                ),
-            ),
+            details: note.clone().into(),
             after_block_num: 0,
             tag: None,
         })

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -360,7 +360,7 @@ async fn test_swap_offchain() {
     client2
         .import_note(NoteFile::NoteDetails {
             details: exported_note.into(),
-            after_block_num: client1.store().get_sync_height().unwrap(),
+            after_block_num: client1.get_sync_height().unwrap(),
             tag: Some(tag),
         })
         .await

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -1,7 +1,7 @@
 use miden_client::{
     accounts::AccountTemplate,
     notes::Note,
-    store::InputNoteRecord,
+    store::{InputNoteRecord, Store},
     transactions::request::{SwapTransactionData, TransactionTemplate},
 };
 use miden_objects::{
@@ -360,8 +360,8 @@ async fn test_swap_offchain() {
     client2
         .import_note(NoteFile::NoteDetails {
             details: exported_note.into(),
+            after_block_num: client1.store().get_sync_height().unwrap(),
             tag: Some(tag),
-            after_block_num: 0,
         })
         .await
         .unwrap();

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -1,7 +1,7 @@
 use miden_client::{
     accounts::AccountTemplate,
     notes::Note,
-    store::{InputNoteRecord, Store},
+    store::InputNoteRecord,
     transactions::request::{SwapTransactionData, TransactionTemplate},
 };
 use miden_objects::{


### PR DESCRIPTION
Follows up #405 

~~**_### Do not merge until https://github.com/0xPolygonMiden/miden-base/pull/823 is merged._**~~

This PR adds support for committed notes from "the past" (in the client's perspective).

TO DOs:
- [x] Add `after_block_num` field in `NoteFile::NoteDetails` as [explained here](https://github.com/0xPolygonMiden/miden-client/issues/405#issuecomment-2241365540).
  - [x]   The PR is open: https://github.com/0xPolygonMiden/miden-base/pull/823
- [x] Sync from that block instead of the block 0.
- [x] Add tests.