### PR TITLE
test: multiple transaction on the same block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-deps: ## Install dependencies for tests
 
 .PHONY: integration-test
 integration-test: ## Run integration tests
-	cargo nextest run --workspace --exclude miden-client-web --release --test=integration $(FEATURES_CLI) --no-default-features
+	cargo nextest run --workspace --exclude miden-client-web --release --test=integration $(FEATURES_CLI) --no-default-features -- test_multiple_tx_on_same_block
 
 .PHONY: integration-test-full
 integration-test-full: ## Run the integration test binary with ignored tests included

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-deps: ## Install dependencies for tests
 
 .PHONY: integration-test
 integration-test: ## Run integration tests
-	cargo nextest run --workspace --exclude miden-client-web --release --test=integration $(FEATURES_CLI) --no-default-features -- test_multiple_tx_on_same_block
+	cargo nextest run --workspace --exclude miden-client-web --release --test=integration $(FEATURES_CLI) --no-default-features
 
 .PHONY: integration-test-full
 integration-test-full: ## Run the integration test binary with ignored tests included

--- a/crates/rust-client/src/transactions/mod.rs
+++ b/crates/rust-client/src/transactions/mod.rs
@@ -157,7 +157,7 @@ impl TransactionRecord {
 }
 
 /// Represents the status of a transaction
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TransactionStatus {
     /// Transaction has been submitted but not yet committed
     Pending,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -48,6 +48,54 @@ async fn test_added_notes() {
 }
 
 #[tokio::test]
+async fn test_multiple_tx_on_same_block() {
+    let mut client = create_test_client();
+    wait_for_node(&mut client).await;
+
+    let (first_regular_account, second_regular_account, faucet_account_stub) =
+        setup(&mut client, AccountStorageType::OffChain).await;
+
+    let from_account_id = first_regular_account.id();
+    let to_account_id = second_regular_account.id();
+    let faucet_account_id = faucet_account_stub.id();
+
+    // First Mint necesary token
+    let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::Private).await;
+    consume_notes(&mut client, from_account_id, &[note]).await;
+    assert_account_has_single_asset(&client, from_account_id, faucet_account_id, MINT_AMOUNT).await;
+
+    // Do a transfer from first account to second account
+    let asset = FungibleAsset::new(faucet_account_id, TRANSFER_AMOUNT).unwrap();
+    let tx_template = TransactionTemplate::PayToId(
+        PaymentTransactionData::new(Asset::Fungible(asset), from_account_id, to_account_id),
+        NoteType::Private,
+    );
+    
+    println!("Running P2ID tx...");
+    let tx_request_1 = client.build_transaction_request(tx_template.clone()).unwrap();
+    let tx_request_2 = client.build_transaction_request(tx_template).unwrap();
+
+    // wait for 1 block
+    wait_for_blocks(&mut client, 1).await;
+
+    let tx_id_1 = execute_tx(&mut client, tx_request_1).await;
+    let tx_id_2 = execute_tx(&mut client, tx_request_2).await;
+
+    wait_for_tx(&mut client, tx_id_1);
+
+    let transactions = client.get_transactions(crate::TransactionFilter::All).unwrap().into_iter().filter(|tx| {
+        tx.id == tx_id_1 || tx.id == tx_id_2
+    }).collect::<Vec<_>>();
+    
+    assert_eq!(transactions.len(), 2);
+    assert_eq!(transactions[0].block_num, transactions[1].block_num);
+
+    println!("tx status 1: {:?}", transactions[0].transaction_status);
+    println!("tx status 2: {:?}", transactions[1].transaction_status);
+    assert!(false);
+}
+
+#[tokio::test]
 async fn test_p2id_transfer() {
     let mut client = create_test_client();
     wait_for_node(&mut client).await;


### PR DESCRIPTION
Adds an integration test that runs multiple transactions on the same block.

Closes #461 .