### PR TITLE
Revisit client docs sections organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Miden Client
+# Contributing to Miden client
 
 #### First off, thanks for taking the time to contribute!
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The Miden client is still under heavy development and the project can be conside
 
 The Miden client currently consists of two components:
 
-- `miden-client` library, which can be used by other project to programmatically interact with the Miden rollup. You can find more information about the library in the [Rust Client Library](./crates/rust-client/README.md) section.
-- _Miden CLI_, which is a wrapper around the library exposing its functionality via a simple command-line interface (CLI). You can find more information about the CLI in the [Miden Client CLI](./bin/miden-cli/README.md) section.
+- `miden-client` library, which can be used by other project to programmatically interact with the Miden rollup. You can find more information about the library in the [Rust client Library](./crates/rust-client/README.md) section.
+- _Miden CLI_, which is a wrapper around the library exposing its functionality via a simple command-line interface (CLI). You can find more information about the CLI in the [Miden client CLI](./bin/miden-cli/README.md) section.
 
 The client's main responsibility is to maintain a partial view of the blockchain which allows for locally executing and proving transactions. It keeps a local store of various entities that periodically get updated by syncing with the node.
 

--- a/bin/miden-cli/README.md
+++ b/bin/miden-cli/README.md
@@ -1,4 +1,4 @@
-# Miden Client CLI
+# Miden client CLI
 
 This binary allows the user to interact with the Miden rollup via a simple command-line interface (CLI). It's a wrapper around the [Miden client](https://crates.io/crates/miden-client) library exposing its functionality in order to create accounts, create and consume notes, all executed and proved using the Miden VM.
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1,2 +1,2 @@
-!!! example "Miden Client API docs"
-    The latest and complete reference for the Miden Client API can be found at [`Miden client docs.rs`](https://docs.rs/miden-client/latest/miden_client/).
+!!! example "Miden client API docs"
+    The latest and complete reference for the Miden client API can be found at [`Miden client docs.rs`](https://docs.rs/miden-client/latest/miden_client/).

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -1,0 +1,2 @@
+!!! example "Miden Client API docs"
+    The latest and complete reference for the Miden Client API can be found at [`Miden client docs.rs`](https://docs.rs/miden-client/latest/miden_client/).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,2 +1,2 @@
 !!! example "Executing, proving, and submitting transactions to the Miden node"
-    For a complete example on how to run the client and submit transactions to the Miden node, refer to the [`Getting started documentation`](https://0xpolygonmiden.github.io/miden-base/introduction/getting-started.html).
+    For a complete example on how to run the client and submit transactions to the Miden node, refer to the [`Getting started documentation`](https://docs.polygon.technology/miden/miden-base/introduction/get-started/prerequisites/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
   - Miden CLI:
       - Configuration: 'cli-config.md'
       - Reference: 'cli-reference.md'
-  - Install and run: install-and-run.md
+  - Install and run: install-and-run.md'
   - Examples: 'examples.md'
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,16 +22,17 @@ theme:
 
 
 nav:
-  - Overview: 
+  - Overview:
       - Overview: index.md
       - Features: features.md
-  - Get started:
-      - Design: design.md
-      - Install and run: install-and-run.md
-  - Miden CLI: 
+  - Design:
+      - Overview: design.md
+      - API docs: api-docs.md
+  - Miden client library: 'library.md'
+  - Miden CLI:
       - Configuration: 'cli-config.md'
       - Reference: 'cli-reference.md'
-  - Using the client library: 'library.md'
+  - Install and run: install-and-run.md
   - Examples: 'examples.md'
 
 


### PR DESCRIPTION
This PR closes https://github.com/0xPolygonMiden/miden-client/issues/282 and changes the client docs sections a bit. The goal is to explain the client design, the client as library and the client's CLI.

The new proposed structure is 

  - Overview:
      - Overview: index.md
      - Features: features.md
  - Design:
      - Overview: design.md
      - API docs: api-docs.md
  - Miden client library: 'library.md'
  - Miden CLI:
      - Configuration: 'cli-config.md'
      - Reference: 'cli-reference.md'
  - Install and run: install-and-run.md
  - Examples: 'examples.md'

Whereas `api-docs.md` links to https://docs.rs/miden-client/latest/miden_client/