### PR TITLE
chore: point `miden-base` dependencies to `next` branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ authors = ["miden contributors"]
 repository = "https://github.com/0xPolygonMiden/miden-client"
 
 [workspace.dependencies]
-miden-lib = { default-features = false, git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm"}
-miden-objects = { default-features = false, features = ["serde"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm" }
-miden-tx = { default-features = false , git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm" }
+miden-lib = { default-features = false, git = "https://github.com/0xPolygonMiden/miden-base", branch = "next"}
+miden-objects = { default-features = false, features = ["serde"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-tx = { default-features = false , git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 rand = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ node: ## Setup node directory
 	if [ -d miden-node ]; then cd miden-node ; else git clone https://github.com/0xPolygonMiden/miden-node.git && cd miden-node; fi
 	cd miden-node && git checkout $(NODE_BRANCH) && git pull origin $(NODE_BRANCH)
 	cd miden-node && rm -rf miden-store.sqlite3*
-	cd miden-node && cargo run --bin miden-node $(NODE_FEATURES_TESTING) -- make-genesis --inputs-path ../tests/config/genesis.toml --force
+	cd miden-node && cargo update && cargo run --bin miden-node $(NODE_FEATURES_TESTING) -- make-genesis --inputs-path ../tests/config/genesis.toml --force
 
 .PHONY: start-node
 start-node: ## Run node. This requires the node repo to be present at `miden-node`

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -53,8 +53,8 @@ winter-maybe-async = "0.10"
 
 [dev-dependencies]
 miden-client = { path = ".", features = ["testing", "concurrent", "sqlite", "tonic", "tokio"]}
-miden-lib = { default-features = false, features = ["testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm" }
-miden-objects = {default-features = false, features = ["serde", "testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm" }
+miden-lib = { default-features = false, features = ["testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-objects = {default-features = false, features = ["serde", "testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 uuid = { version = "1.9", features = ["serde", "v4"] }
 
 [build-dependencies]

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -32,5 +32,5 @@ wasm-bindgen-futures = { version = "0.4" }
 
 [dev-dependencies]
 miden-client = { path = "../rust-client", default-features = false, features = ["idxdb", "web-tonic"] }
-miden-lib = { default-features = false, features = ["testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm" }
-miden-objects = {default-features = false, features = ["serde", "testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm" }
+miden-lib = { default-features = false, features = ["testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
+miden-objects = {default-features = false, features = ["serde", "testing"], git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 [dev-dependencies]
 figment = { version = "0.10", features = ["toml", "env"] }
 miden-client = { path = "../crates/rust-client", features = ["concurrent", "testing", "std", "sqlite", "tonic"] }
-miden-objects = { default-features = false, features = ["serde"] , git = "https://github.com/0xPolygonMiden/miden-base", branch = "igamigo-fix-wasm" }
+miden-objects = { default-features = false, features = ["serde"] , git = "https://github.com/0xPolygonMiden/miden-base", branch = "next" }
 rand = { workspace = true }
 tokio = { workspace = true }
 uuid = { version = "1.9", features = ["serde", "v4"] }


### PR DESCRIPTION
closes #496 