### PR TITLE
fix: `AccountStub`->`AccountHeader`, `AccountStorageType`->`AccountStorageMode`, docs and miden-base using `next`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+* [BREAKING] Renamed `off-chain` and `on-chain` to `private` and `public` respectively for the account storage modes (#516).
 * [BREAKING] Added IDs to `SyncSummary` fields (#513).
 * [BREAKING] Re-exported `TransactionRequest` from submodule, renamed `AccountDetails::Offchain` to `AccountDetails::Private`, renamed `NoteDetails::OffChain` to `NoteDetails::Private` (#508).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = [
-  "bin/miden-cli",
-  "crates/rust-client",
-  "crates/web-client",
-  "tests"
-]
+members = ["bin/miden-cli", "crates/rust-client", "crates/web-client", "tests"]
 
 default-members = ["crates/rust-client", "bin/miden-cli"]
 
@@ -18,9 +13,9 @@ authors = ["miden contributors"]
 repository = "https://github.com/0xPolygonMiden/miden-client"
 
 [workspace.dependencies]
-miden-lib = { version = "0.5", default-features = false }
-miden-objects = { version = "0.5", default-features = false, features = ["serde"] }
-miden-tx = { version = "0.5", default-features = false }
+miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
+miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false, features = ["serde"]}
+miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
 rand = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FEATURES_CLIENT=--features "testing, concurrent"
 FEATURES_CLI=--features "testing, concurrent"
 NODE_FEATURES_TESTING=--features "testing"
 WARNINGS=RUSTDOCFLAGS="-D warnings"
-NODE_BRANCH="main"
+NODE_BRANCH="next"
 
 # --- Linting -------------------------------------------------------------------------------------
 

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -17,7 +17,7 @@ use crate::{
 /// Create a new faucet account
 pub struct NewFaucetCmd {
     #[clap(short, long, default_value_t = AccountStorageMode::Private)]
-    /// Storage type of the account
+    /// Storage mode of the account
     storage_mode: AccountStorageMode,
     #[clap(short, long)]
     /// Defines if the account assets are non-fungible (by default it is fungible)
@@ -74,7 +74,7 @@ impl NewFaucetCmd {
 /// Create a new wallet account
 pub struct NewWalletCmd {
     #[clap(short, long, default_value_t = AccountStorageMode::Private)]
-    /// Storage type of the account
+    /// Storage mode of the account
     pub storage_mode: AccountStorageMode,
     #[clap(short, long)]
     /// Defines if the account code is mutable (by default it is not mutable)

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -1,6 +1,6 @@
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use miden_client::{
-    accounts::{AccountStorageType, AccountTemplate},
+    accounts::{AccountStorageMode, AccountTemplate},
     assets::TokenSymbol,
     auth::TransactionAuthenticator,
     crypto::FeltRng,
@@ -16,7 +16,7 @@ use crate::{
 #[derive(Debug, Parser, Clone)]
 /// Create a new faucet account
 pub struct NewFaucetCmd {
-    #[clap(short, long, value_enum, default_value_t = AccountStorageMode::OffChain)]
+    #[clap(short, long, default_value_t = AccountStorageMode::Private)]
     /// Storage type of the account
     storage_type: AccountStorageMode,
     #[clap(short, long)]
@@ -56,7 +56,7 @@ impl NewFaucetCmd {
                 .map_err(|err| format!("error: token symbol is invalid: {}", err))?,
             decimals,
             max_supply: self.max_supply.expect("max supply must be provided"),
-            storage_type: self.storage_type.into(),
+            storage_type: self.storage_type,
         };
 
         let (new_account, _account_seed) = client.new_account(client_template)?;
@@ -73,7 +73,7 @@ impl NewFaucetCmd {
 #[derive(Debug, Parser, Clone)]
 /// Create a new wallet account
 pub struct NewWalletCmd {
-    #[clap(short, long, value_enum, default_value_t = AccountStorageMode::OffChain)]
+    #[clap(short, long, default_value_t = AccountStorageMode::Private)]
     /// Storage type of the account
     pub storage_type: AccountStorageMode,
     #[clap(short, long)]
@@ -88,7 +88,7 @@ impl NewWalletCmd {
     ) -> Result<(), String> {
         let client_template = AccountTemplate::BasicWallet {
             mutable_code: self.mutable,
-            storage_type: self.storage_type.into(),
+            storage_type: self.storage_type,
         };
 
         let (new_account, _account_seed) = client.new_account(client_template)?;
@@ -102,26 +102,5 @@ impl NewWalletCmd {
         maybe_set_default_account(&mut current_config, new_account.id())?;
 
         Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum AccountStorageMode {
-    OffChain,
-    OnChain,
-}
-
-impl From<AccountStorageMode> for AccountStorageType {
-    fn from(value: AccountStorageMode) -> Self {
-        match value {
-            AccountStorageMode::OffChain => AccountStorageType::OffChain,
-            AccountStorageMode::OnChain => AccountStorageType::OnChain,
-        }
-    }
-}
-
-impl From<&AccountStorageMode> for AccountStorageType {
-    fn from(value: &AccountStorageMode) -> Self {
-        AccountStorageType::from(*value)
     }
 }

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -18,7 +18,7 @@ use crate::{
 pub struct NewFaucetCmd {
     #[clap(short, long, default_value_t = AccountStorageMode::Private)]
     /// Storage type of the account
-    storage_type: AccountStorageMode,
+    storage_mode: AccountStorageMode,
     #[clap(short, long)]
     /// Defines if the account assets are non-fungible (by default it is fungible)
     non_fungible: bool,
@@ -56,7 +56,7 @@ impl NewFaucetCmd {
                 .map_err(|err| format!("error: token symbol is invalid: {}", err))?,
             decimals,
             max_supply: self.max_supply.expect("max supply must be provided"),
-            storage_type: self.storage_type,
+            storage_mode: self.storage_mode,
         };
 
         let (new_account, _account_seed) = client.new_account(client_template)?;
@@ -75,7 +75,7 @@ impl NewFaucetCmd {
 pub struct NewWalletCmd {
     #[clap(short, long, default_value_t = AccountStorageMode::Private)]
     /// Storage type of the account
-    pub storage_type: AccountStorageMode,
+    pub storage_mode: AccountStorageMode,
     #[clap(short, long)]
     /// Defines if the account code is mutable (by default it is not mutable)
     pub mutable: bool,
@@ -88,7 +88,7 @@ impl NewWalletCmd {
     ) -> Result<(), String> {
         let client_template = AccountTemplate::BasicWallet {
             mutable_code: self.mutable,
-            storage_type: self.storage_type,
+            storage_mode: self.storage_mode,
         };
 
         let (new_account, _account_seed) = client.new_account(client_template)?;

--- a/bin/miden-cli/src/info.rs
+++ b/bin/miden-cli/src/info.rs
@@ -27,7 +27,7 @@ fn print_client_stats<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuth
     println!("Block number: {}", client.get_sync_height().map_err(|e| e.to_string())?);
     println!(
         "Tracked accounts: {}",
-        client.get_account_stubs().map_err(|e| e.to_string())?.len()
+        client.get_account_headers().map_err(|e| e.to_string())?.len()
     );
     println!(
         "Expected notes: {}",

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -3,7 +3,7 @@ use std::{env, rc::Rc};
 use clap::Parser;
 use comfy_table::{presets, Attribute, Cell, ContentArrangement, Table};
 use miden_client::{
-    accounts::AccountStub,
+    accounts::AccountHeader,
     auth::{StoreAuthenticator, TransactionAuthenticator},
     crypto::{FeltRng, RpoRandomCoin},
     rpc::{NodeRpcClient, TonicRpcClient},
@@ -220,9 +220,9 @@ fn get_account_with_id_prefix<
 >(
     client: &Client<N, R, S, A>,
     account_id_prefix: &str,
-) -> Result<AccountStub, IdPrefixFetchError> {
+) -> Result<AccountHeader, IdPrefixFetchError> {
     let mut accounts = client
-        .get_account_stubs()
+        .get_account_headers()
         .map_err(|err| {
             tracing::error!("Error when fetching all accounts from the store: {err}");
             IdPrefixFetchError::NoMatch(
@@ -230,7 +230,7 @@ fn get_account_with_id_prefix<
             )
         })?
         .into_iter()
-        .filter(|(account_stub, _)| account_stub.id().to_hex().starts_with(account_id_prefix))
+        .filter(|(account_header, _)| account_header.id().to_hex().starts_with(account_id_prefix))
         .map(|(acc, _)| acc)
         .collect::<Vec<_>>();
 
@@ -240,7 +240,8 @@ fn get_account_with_id_prefix<
         ));
     }
     if accounts.len() > 1 {
-        let account_ids = accounts.iter().map(|account_stub| account_stub.id()).collect::<Vec<_>>();
+        let account_ids =
+            accounts.iter().map(|account_header| account_header.id()).collect::<Vec<_>>();
         tracing::error!(
             "Multiple accounts found for the prefix {}: {:?}",
             account_id_prefix,

--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -103,7 +103,7 @@ fn test_mint_with_untracked_account() {
         let mut client = create_test_client_with_store_path(&other_store_path);
         let account_template = AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         };
         let (account, _seed) = client.new_account(account_template).unwrap();
 

--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -8,7 +8,7 @@ use std::{
 
 use assert_cmd::Command;
 use miden_client::{
-    accounts::{Account, AccountId, AccountStorageType, AccountTemplate},
+    accounts::{Account, AccountId, AccountStorageMode, AccountTemplate},
     auth::StoreAuthenticator,
     config::RpcConfig,
     crypto::RpoRandomCoin,
@@ -103,7 +103,7 @@ fn test_mint_with_untracked_account() {
         let mut client = create_test_client_with_store_path(&other_store_path);
         let account_template = AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         };
         let (account, _seed) = client.new_account(account_template).unwrap();
 
@@ -120,7 +120,7 @@ fn test_mint_with_untracked_account() {
     create_faucet_cmd.args([
         "new-faucet",
         "-s",
-        "off-chain",
+        "private",
         "-t",
         "BTC",
         "-d",
@@ -132,7 +132,7 @@ fn test_mint_with_untracked_account() {
 
     let fungible_faucet_account_id = {
         let client = create_test_client_with_store_path(&store_path);
-        let accounts = client.get_account_stubs().unwrap();
+        let accounts = client.get_account_headers().unwrap();
 
         accounts.first().unwrap().0.id().to_hex()
     };
@@ -201,7 +201,7 @@ fn test_import_genesis_accounts_can_be_used_for_transactions() {
 
     let (first_basic_account_id, second_basic_account_id, fungible_faucet_account_id) = {
         let client = create_test_client_with_store_path(&store_path);
-        let accounts = client.get_account_stubs().unwrap();
+        let accounts = client.get_account_headers().unwrap();
 
         let account_ids = accounts.iter().map(|(acc, _seed)| acc.id()).collect::<Vec<_>>();
         let regular_accounts = account_ids.iter().filter(|id| !id.is_faucet()).collect::<Vec<_>>();
@@ -305,12 +305,12 @@ fn test_cli_export_import_note() {
 
     // Create wallet account
     let mut create_wallet_cmd = Command::cargo_bin("miden").unwrap();
-    create_wallet_cmd.args(["new-wallet", "-s", "off-chain"]);
+    create_wallet_cmd.args(["new-wallet", "-s", "private"]);
     create_wallet_cmd.current_dir(&temp_dir_2).assert().success();
 
     let first_basic_account_id = {
         let client = create_test_client_with_store_path(&store_path_2);
-        let accounts = client.get_account_stubs().unwrap();
+        let accounts = client.get_account_headers().unwrap();
 
         accounts.first().unwrap().0.id().to_hex()
     };
@@ -325,7 +325,7 @@ fn test_cli_export_import_note() {
     create_faucet_cmd.args([
         "new-faucet",
         "-s",
-        "off-chain",
+        "private",
         "-t",
         "BTC",
         "-d",
@@ -337,7 +337,7 @@ fn test_cli_export_import_note() {
 
     let fungible_faucet_account_id = {
         let client = create_test_client_with_store_path(&store_path_1);
-        let accounts = client.get_account_stubs().unwrap();
+        let accounts = client.get_account_headers().unwrap();
 
         accounts.first().unwrap().0.id().to_hex()
     };
@@ -412,12 +412,12 @@ fn test_cli_export_import_account() {
 
     // Create wallet account
     let mut create_wallet_cmd = Command::cargo_bin("miden").unwrap();
-    create_wallet_cmd.args(["new-wallet", "-s", "off-chain"]);
+    create_wallet_cmd.args(["new-wallet", "-s", "private"]);
     create_wallet_cmd.current_dir(&temp_dir_1).assert().success();
 
     let first_basic_account_id = {
         let client = create_test_client_with_store_path(&store_path_1);
-        let accounts = client.get_account_stubs().unwrap();
+        let accounts = client.get_account_headers().unwrap();
 
         accounts.first().unwrap().0.id().to_hex()
     };

--- a/crates/rust-client/build.rs
+++ b/crates/rust-client/build.rs
@@ -44,7 +44,7 @@ fn compile_tonic_client_proto(proto_dir: &Path) -> miette::Result<()> {
     let mut web_tonic_prost_config = prost_build::Config::new();
     web_tonic_prost_config.skip_debug(["AccountId", "Digest"]);
 
-    // Generate the stub of the user facing server from its proto file
+    // Generate the header of the user facing server from its proto file
     tonic_build::configure()
         .build_transport(false)
         .build_server(false)

--- a/crates/rust-client/src/accounts.rs
+++ b/crates/rust-client/src/accounts.rs
@@ -31,7 +31,7 @@ pub enum AccountTemplate {
         mutable_code: bool,
         /// Specifies the type of storage used by the account. This is defined by the
         /// `AccountStorageMode` enum.
-        storage_type: AccountStorageMode,
+        storage_mode: AccountStorageMode,
     },
 
     /// The `FungibleFaucet` variant represents an account designed to issue fungible tokens.
@@ -43,7 +43,7 @@ pub enum AccountTemplate {
         /// The maximum supply of tokens that the faucet can issue.
         max_supply: u64,
         /// Specifies the type of storage used by the account.
-        storage_type: AccountStorageMode,
+        storage_mode: AccountStorageMode,
     },
 }
 
@@ -58,14 +58,14 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         template: AccountTemplate,
     ) -> Result<(Account, Word), ClientError> {
         let account_and_seed = match template {
-            AccountTemplate::BasicWallet { mutable_code, storage_type: storage_mode } => {
+            AccountTemplate::BasicWallet { mutable_code, storage_mode } => {
                 maybe_await!(self.new_basic_wallet(mutable_code, storage_mode))
             },
             AccountTemplate::FungibleFaucet {
                 token_symbol,
                 decimals,
                 max_supply,
-                storage_type: storage_mode,
+                storage_mode,
             } => maybe_await!(self.new_fungible_faucet(
                 token_symbol,
                 decimals,
@@ -114,7 +114,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     fn new_basic_wallet(
         &mut self,
         mutable_code: bool,
-        account_storage_type: AccountStorageMode,
+        account_storage_mode: AccountStorageMode,
     ) -> Result<(Account, Word), ClientError> {
         let key_pair = SecretKey::with_rng(&mut self.rng);
 
@@ -129,14 +129,14 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                 init_seed,
                 auth_scheme,
                 AccountType::RegularAccountImmutableCode,
-                account_storage_type,
+                account_storage_mode,
             )
         } else {
             miden_lib::accounts::wallets::create_basic_wallet(
                 init_seed,
                 auth_scheme,
                 AccountType::RegularAccountUpdatableCode,
-                account_storage_type,
+                account_storage_mode,
             )
         }?;
 
@@ -154,7 +154,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         token_symbol: TokenSymbol,
         decimals: u8,
         max_supply: u64,
-        account_storage_type: AccountStorageMode,
+        account_storage_mode: AccountStorageMode,
     ) -> Result<(Account, Word), ClientError> {
         let key_pair = SecretKey::with_rng(&mut self.rng);
 
@@ -170,7 +170,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
             decimals,
             Felt::try_from(max_supply.to_le_bytes().as_slice())
                 .expect("u64 can be safely converted to a field element"),
-            account_storage_type,
+            account_storage_mode,
             auth_scheme,
         )?;
 

--- a/crates/rust-client/src/accounts.rs
+++ b/crates/rust-client/src/accounts.rs
@@ -8,8 +8,8 @@ use alloc::vec::Vec;
 
 use miden_lib::AuthScheme;
 pub use miden_objects::accounts::{
-    Account, AccountCode, AccountData, AccountId, AccountStorage, AccountStorageType, AccountStub,
-    AccountType, StorageSlotType,
+    Account, AccountCode, AccountData, AccountHeader, AccountId, AccountStorage,
+    AccountStorageMode, AccountType, StorageSlotType,
 };
 use miden_objects::{
     accounts::AuthSecretKey,
@@ -30,8 +30,8 @@ pub enum AccountTemplate {
         /// A boolean indicating whether the account's code can be modified after creation.
         mutable_code: bool,
         /// Specifies the type of storage used by the account. This is defined by the
-        /// `AccountStorageType` enum.
-        storage_type: AccountStorageType,
+        /// `AccountStorageMode` enum.
+        storage_type: AccountStorageMode,
     },
 
     /// The `FungibleFaucet` variant represents an account designed to issue fungible tokens.
@@ -43,7 +43,7 @@ pub enum AccountTemplate {
         /// The maximum supply of tokens that the faucet can issue.
         max_supply: u64,
         /// Specifies the type of storage used by the account.
-        storage_type: AccountStorageType,
+        storage_type: AccountStorageMode,
     },
 }
 
@@ -114,7 +114,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     fn new_basic_wallet(
         &mut self,
         mutable_code: bool,
-        account_storage_type: AccountStorageType,
+        account_storage_type: AccountStorageMode,
     ) -> Result<(Account, Word), ClientError> {
         let key_pair = SecretKey::with_rng(&mut self.rng);
 
@@ -154,7 +154,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         token_symbol: TokenSymbol,
         decimals: u8,
         max_supply: u64,
-        account_storage_type: AccountStorageType,
+        account_storage_type: AccountStorageMode,
     ) -> Result<(Account, Word), ClientError> {
         let key_pair = SecretKey::with_rng(&mut self.rng);
 
@@ -206,13 +206,13 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     // ACCOUNT DATA RETRIEVAL
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a list of [AccountStub] of all accounts stored in the database along with the seeds
-    /// used to create them.
+    /// Returns a list of [AccountHeader] of all accounts stored in the database along with the
+    /// seeds used to create them.
     ///
     /// Said accounts' state is the state after the last performed sync.
     #[maybe_async]
-    pub fn get_account_stubs(&self) -> Result<Vec<(AccountStub, Option<Word>)>, ClientError> {
-        maybe_await!(self.store.get_account_stubs()).map_err(|err| err.into())
+    pub fn get_account_headers(&self) -> Result<Vec<(AccountHeader, Option<Word>)>, ClientError> {
+        maybe_await!(self.store.get_account_headers()).map_err(|err| err.into())
     }
 
     /// Retrieves a full [Account] object. The seed will be returned if the account is new,
@@ -233,7 +233,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         maybe_await!(self.store.get_account(account_id)).map_err(|err| err.into())
     }
 
-    /// Retrieves an [AccountStub] object for the specified [AccountId] along with the seed
+    /// Retrieves an [AccountHeader] object for the specified [AccountId] along with the seed
     /// used to create it. The seed will be returned if the account is new, otherwise it
     /// will be `None`.
     ///
@@ -243,11 +243,11 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     ///
     /// Returns a `StoreError::AccountDataNotFound` if there is no account for the provided ID
     #[maybe_async]
-    pub fn get_account_stub_by_id(
+    pub fn get_account_header_by_id(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Option<Word>), ClientError> {
-        maybe_await!(self.store.get_account_stub(account_id)).map_err(|err| err.into())
+    ) -> Result<(AccountHeader, Option<Word>), ClientError> {
+        maybe_await!(self.store.get_account_header(account_id)).map_err(|err| err.into())
     }
 
     /// Returns an [AuthSecretKey] object utilized to authenticate an account.
@@ -340,7 +340,7 @@ pub mod tests {
             .into_iter()
             .map(|account_data| account_data.account)
             .collect();
-        let accounts = client.get_account_stubs().unwrap();
+        let accounts = client.get_account_headers().unwrap();
 
         assert_eq!(accounts.len(), 2);
         for (client_acc, expected_acc) in accounts.iter().zip(expected_accounts.iter()) {

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -9,7 +9,7 @@ use miden_lib::{transaction::TransactionKernel, AuthScheme};
 use miden_objects::{
     accounts::{
         account_id::testing::ACCOUNT_ID_OFF_CHAIN_SENDER, get_account_seed_single, Account,
-        AccountCode, AccountId, AccountStorage, AccountStorageType, AccountType, AuthSecretKey,
+        AccountCode, AccountId, AccountStorage, AccountStorageMode, AccountType, AuthSecretKey,
         SlotItem, StorageSlot,
     },
     assembly::Assembler,
@@ -441,7 +441,7 @@ pub async fn insert_mock_data(client: &mut MockClient) -> Vec<BlockHeader> {
     let account_seed = get_account_seed_single(
         init_seed,
         account.account_type(),
-        miden_objects::accounts::AccountStorageType::OffChain,
+        miden_objects::accounts::AccountStorageMode::Private,
         account.code().commitment(),
         account.storage().root(),
     )
@@ -515,7 +515,7 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
         init_seed,
         auth_scheme,
         AccountType::RegularAccountImmutableCode,
-        AccountStorageType::OffChain,
+        AccountStorageMode::Private,
     )
     .unwrap();
 
@@ -535,7 +535,7 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
         init_seed,
         auth_scheme,
         AccountType::RegularAccountImmutableCode,
-        AccountStorageType::OffChain,
+        AccountStorageMode::Private,
     )
     .unwrap();
 
@@ -558,7 +558,7 @@ pub async fn create_mock_transaction(client: &mut MockClient) {
         miden_objects::assets::TokenSymbol::new("MOCK").unwrap(),
         4u8,
         Felt::try_from(max_supply.as_slice()).unwrap(),
-        AccountStorageType::OffChain,
+        AccountStorageMode::Private,
         auth_scheme,
     )
     .unwrap();
@@ -594,7 +594,7 @@ pub fn mock_fungible_faucet_account(
         10u8,
         Felt::try_from(initial_balance.to_le_bytes().as_slice())
             .expect("u64 can be safely converted to a field element"),
-        AccountStorageType::OffChain,
+        AccountStorageMode::Private,
         auth_scheme,
     )
     .unwrap();

--- a/crates/rust-client/src/rpc/tonic_client/generated/note.rs
+++ b/crates/rust-client/src/rpc/tonic_client/generated/note.rs
@@ -24,7 +24,7 @@ pub struct Note {
     pub metadata: ::core::option::Option<NoteMetadata>,
     #[prost(message, optional, tag = "5")]
     pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
-    /// This field will be present when the note is on-chain.
+    /// This field will be present when the note is public.
     /// details contain the `Note` in a serialized format.
     #[prost(bytes = "vec", optional, tag = "6")]
     pub details: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,

--- a/crates/rust-client/src/rpc/tonic_client/generated/responses.rs
+++ b/crates/rust-client/src/rpc/tonic_client/generated/responses.rs
@@ -179,7 +179,7 @@ pub struct ListNotesResponse {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAccountDetailsResponse {
-    /// Account info (with details for on-chain accounts)
+    /// Account info (with details for public accounts)
     #[prost(message, optional, tag = "1")]
     pub details: ::core::option::Option<super::account::AccountInfo>,
 }

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -260,7 +260,7 @@ impl NodeRpcClient for TonicRpcClient {
         let hash = hash.try_into()?;
 
         let update_summary = AccountUpdateSummary::new(hash, account_summary.block_num);
-        if account_id.is_on_chain() {
+        if account_id.is_public() {
             let details_bytes = account_info.details.ok_or(RpcError::ExpectedFieldMissing(
                 "GetAccountDetails response's account should have `details`".to_string(),
             ))?;

--- a/crates/rust-client/src/rpc/web_tonic_client/generated/note.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/generated/note.rs
@@ -24,7 +24,7 @@ pub struct Note {
     pub metadata: ::core::option::Option<NoteMetadata>,
     #[prost(message, optional, tag = "5")]
     pub merkle_path: ::core::option::Option<super::merkle::MerklePath>,
-    /// This field will be present when the note is on-chain.
+    /// This field will be present when the note is public.
     /// details contain the `Note` in a serialized format.
     #[prost(bytes = "vec", optional, tag = "6")]
     pub details: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,

--- a/crates/rust-client/src/rpc/web_tonic_client/generated/responses.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/generated/responses.rs
@@ -179,7 +179,7 @@ pub struct ListNotesResponse {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAccountDetailsResponse {
-    /// Account info (with details for on-chain accounts)
+    /// Account info (with details for public accounts)
     #[prost(message, optional, tag = "1")]
     pub details: ::core::option::Option<super::account::AccountInfo>,
 }

--- a/crates/rust-client/src/rpc/web_tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/mod.rs
@@ -258,7 +258,7 @@ impl NodeRpcClient for WebTonicRpcClient {
         let hash = hash.try_into()?;
 
         let update_summary = AccountUpdateSummary::new(hash, account_summary.block_num);
-        if account_id.is_on_chain() {
+        if account_id.is_public() {
             let details_bytes = account_info.details.ok_or(RpcError::ExpectedFieldMissing(
                 "GetAccountDetails response's account should have `details`".to_string(),
             ))?;

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -5,7 +5,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use core::fmt::Debug;
 
 use miden_objects::{
-    accounts::{Account, AccountId, AccountStub, AuthSecretKey},
+    accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
     notes::{NoteId, NoteInclusionProof, NoteMetadata, NoteTag, Nullifier},
     BlockHeader, Digest, Word,
@@ -256,14 +256,14 @@ pub trait Store {
     #[maybe_async]
     fn get_account_ids(&self) -> Result<Vec<AccountId>, StoreError>;
 
-    /// Returns a list of [AccountStub] of all accounts stored in the database along with the seeds
-    /// used to create them.
+    /// Returns a list of [AccountHeader] of all accounts stored in the database along with the
+    /// seeds used to create them.
     ///
     /// Said accounts' state is the state after the last performed sync.
     #[maybe_async]
-    fn get_account_stubs(&self) -> Result<Vec<(AccountStub, Option<Word>)>, StoreError>;
+    fn get_account_headers(&self) -> Result<Vec<(AccountHeader, Option<Word>)>, StoreError>;
 
-    /// Retrieves an [AccountStub] object for the specified [AccountId] along with the seed
+    /// Retrieves an [AccountHeader] object for the specified [AccountId] along with the seed
     /// used to create it. The seed will be returned if the account is new, otherwise it
     /// will be `None`.
     ///
@@ -273,18 +273,18 @@ pub trait Store {
     ///
     /// Returns a `StoreError::AccountDataNotFound` if there is no account for the provided ID
     #[maybe_async]
-    fn get_account_stub(
+    fn get_account_header(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Option<Word>), StoreError>;
+    ) -> Result<(AccountHeader, Option<Word>), StoreError>;
 
-    /// Returns an [AccountStub] corresponding to the stored account state that matches the given
+    /// Returns an [AccountHeader] corresponding to the stored account state that matches the given
     /// hash. If no account state matches the provided hash, `None` is returned.
     #[maybe_async]
-    fn get_account_stub_by_hash(
+    fn get_account_header_by_hash(
         &self,
         account_hash: Digest,
-    ) -> Result<Option<AccountStub>, StoreError>;
+    ) -> Result<Option<AccountHeader>, StoreError>;
 
     /// Retrieves a full [Account] object. The seed will be returned if the account is new,
     /// otherwise it will be `None`.

--- a/crates/rust-client/src/store/sqlite_store/mod.rs
+++ b/crates/rust-client/src/store/sqlite_store/mod.rs
@@ -3,7 +3,7 @@ use core::cell::{RefCell, RefMut};
 use std::path::Path;
 
 use miden_objects::{
-    accounts::{Account, AccountId, AccountStub, AuthSecretKey},
+    accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
     notes::{NoteTag, Nullifier},
     BlockHeader, Digest, Word,
@@ -239,24 +239,24 @@ impl Store for SqliteStore {
     }
 
     #[maybe_async]
-    fn get_account_stubs(&self) -> Result<Vec<(AccountStub, Option<Word>)>, StoreError> {
-        self.get_account_stubs()
+    fn get_account_headers(&self) -> Result<Vec<(AccountHeader, Option<Word>)>, StoreError> {
+        self.get_account_headers()
     }
 
     #[maybe_async]
-    fn get_account_stub(
+    fn get_account_header(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Option<Word>), StoreError> {
-        self.get_account_stub(account_id)
+    ) -> Result<(AccountHeader, Option<Word>), StoreError> {
+        self.get_account_header(account_id)
     }
 
     #[maybe_async]
-    fn get_account_stub_by_hash(
+    fn get_account_header_by_hash(
         &self,
         account_hash: Digest,
-    ) -> Result<Option<AccountStub>, StoreError> {
-        self.get_account_stub_by_hash(account_hash)
+    ) -> Result<Option<AccountHeader>, StoreError> {
+        self.get_account_header_by_hash(account_hash)
     }
 
     #[maybe_async]

--- a/crates/rust-client/src/store/web_store/accounts/js_bindings.rs
+++ b/crates/rust-client/src/store/web_store/accounts/js_bindings.rs
@@ -11,14 +11,14 @@ extern "C" {
     #[wasm_bindgen(js_name = getAccountIds)]
     pub fn idxdb_get_account_ids() -> js_sys::Promise;
 
-    #[wasm_bindgen(js_name = getAllAccountStubs)]
-    pub fn idxdb_get_account_stubs() -> js_sys::Promise;
+    #[wasm_bindgen(js_name = getAllAccountHeaders)]
+    pub fn idxdb_get_account_headers() -> js_sys::Promise;
 
-    #[wasm_bindgen(js_name = getAccountStub)]
-    pub fn idxdb_get_account_stub(account_id: String) -> js_sys::Promise;
+    #[wasm_bindgen(js_name = getAccountHeader)]
+    pub fn idxdb_get_account_header(account_id: String) -> js_sys::Promise;
 
-    #[wasm_bindgen(js_name = getAccountStubByHash)]
-    pub fn idxdb_get_account_stub_by_hash(account_hash: String) -> js_sys::Promise;
+    #[wasm_bindgen(js_name = getAccountHeaderByHash)]
+    pub fn idxdb_get_account_header_by_hash(account_hash: String) -> js_sys::Promise;
 
     #[wasm_bindgen(js_name = getAccountCode)]
     pub fn idxdb_get_account_code(code_root: String) -> js_sys::Promise;

--- a/crates/rust-client/src/store/web_store/js/accounts.js
+++ b/crates/rust-client/src/store/web_store/js/accounts.js
@@ -23,7 +23,7 @@ export async function getAccountIds() {
     }
 }
 
-export async function getAllAccountStubs() {
+export async function getAllAccountHeaders() {
     try {        
         // Use a Map to track the latest record for each id based on nonce
         const latestRecordsMap = new Map();
@@ -59,12 +59,12 @@ export async function getAllAccountStubs() {
 
         return resultObject;
     } catch (error) {
-        console.error('Error fetching all latest account stubs:', error);
+        console.error('Error fetching all latest account headers:', error);
         throw error;
     }
 }
 
-export async function getAccountStub(
+export async function getAccountHeader(
     accountId
 ) {
     try {
@@ -97,7 +97,7 @@ export async function getAccountStub(
             let accountSeedArray = new Uint8Array(accountSeedArrayBuffer);
             accountSeedBase64 = uint8ArrayToBase64(accountSeedArray);
         }
-        const accountStub = {
+        const AccountHeader = {
             id: mostRecentRecord.id,
             nonce: mostRecentRecord.nonce,
             vault_root: mostRecentRecord.vaultRoot,
@@ -105,14 +105,14 @@ export async function getAccountStub(
             code_root: mostRecentRecord.codeRoot,
             account_seed: accountSeedBase64
         }
-        return accountStub;
+        return AccountHeader;
       } catch (error) {
         console.error('Error fetching most recent account record:', error);
         throw error; // Re-throw the error for further handling
       }
 }
 
-export async function getAccountStubByHash(
+export async function getAccountHeaderByHash(
     accountHash
 ) {
     try {
@@ -137,7 +137,7 @@ export async function getAccountStubByHash(
             let accountSeedArray = new Uint8Array(accountSeedArrayBuffer);
             accountSeedBase64 = uint8ArrayToBase64(accountSeedArray);
         }
-        const accountStub = {
+        const AccountHeader = {
             id: matchingRecord.id,
             nonce: matchingRecord.nonce,
             vault_root: matchingRecord.vaultRoot,
@@ -145,7 +145,7 @@ export async function getAccountStubByHash(
             code_root: matchingRecord.codeRoot,
             account_seed: accountSeedBase64
         }
-        return accountStub;
+        return AccountHeader;
       } catch (error) {
         console.error('Error fetching most recent account record:', error);
         throw error; // Re-throw the error for further handling

--- a/crates/rust-client/src/store/web_store/mod.rs
+++ b/crates/rust-client/src/store/web_store/mod.rs
@@ -1,7 +1,7 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 
 use miden_objects::{
-    accounts::{Account, AccountId, AccountStub, AuthSecretKey},
+    accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
     notes::{NoteTag, Nullifier},
     BlockHeader, Digest, Word,
@@ -188,24 +188,24 @@ impl Store for WebStore {
     }
 
     #[maybe_async]
-    fn get_account_stubs(&self) -> Result<Vec<(AccountStub, Option<Word>)>, StoreError> {
-        maybe_await!(self.get_account_stubs())
+    fn get_account_headers(&self) -> Result<Vec<(AccountHeader, Option<Word>)>, StoreError> {
+        maybe_await!(self.get_account_headers())
     }
 
     #[maybe_async]
-    fn get_account_stub(
+    fn get_account_header(
         &self,
         account_id: AccountId,
-    ) -> Result<(AccountStub, Option<Word>), StoreError> {
-        maybe_await!(self.get_account_stub(account_id))
+    ) -> Result<(AccountHeader, Option<Word>), StoreError> {
+        maybe_await!(self.get_account_header(account_id))
     }
 
     #[maybe_async]
-    fn get_account_stub_by_hash(
+    fn get_account_header_by_hash(
         &self,
         account_hash: Digest,
-    ) -> Result<Option<AccountStub>, StoreError> {
-        maybe_await!(self.get_account_stub_by_hash(account_hash))
+    ) -> Result<Option<AccountHeader>, StoreError> {
+        maybe_await!(self.get_account_header_by_hash(account_hash))
     }
 
     #[maybe_async]

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -9,7 +9,7 @@ use core::cmp::max;
 
 use crypto::merkle::{InOrderIndex, MmrPeaks};
 use miden_objects::{
-    accounts::{Account, AccountId, AccountStub},
+    accounts::{Account, AccountHeader, AccountId},
     crypto::{self, rand::FeltRng},
     notes::{Note, NoteId, NoteInclusionProof, NoteInputs, NoteRecipient, NoteTag, Nullifier},
     transaction::{InputNote, TransactionId},
@@ -272,9 +272,9 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     async fn sync_state_once(&mut self) -> Result<SyncStatus, ClientError> {
         let current_block_num = maybe_await!(self.store.get_sync_height())?;
 
-        let accounts: Vec<AccountStub> = maybe_await!(self.store.get_account_stubs())?
+        let accounts: Vec<AccountHeader> = maybe_await!(self.store.get_account_headers())?
             .into_iter()
-            .map(|(acc_stub, _)| acc_stub)
+            .map(|(acc_header, _)| acc_header)
             .collect();
 
         let note_tags: Vec<NoteTag> = maybe_await!(self.get_tracked_note_tags())?;
@@ -308,7 +308,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
             self.check_block_relevance(&new_note_details).await?;
 
         let (onchain_accounts, offchain_accounts): (Vec<_>, Vec<_>) =
-            accounts.into_iter().partition(|account_stub| account_stub.id().is_on_chain());
+            accounts.into_iter().partition(|account_header| account_header.id().is_public());
 
         let updated_onchain_accounts = self
             .get_updated_onchain_accounts(&response.account_hash_updates, &onchain_accounts)
@@ -552,7 +552,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     async fn get_updated_onchain_accounts(
         &mut self,
         account_updates: &[(AccountId, Digest)],
-        current_onchain_accounts: &[AccountStub],
+        current_onchain_accounts: &[AccountHeader],
     ) -> Result<Vec<Account>, ClientError> {
         let mut accounts_to_update: Vec<Account> = Vec::new();
         for (remote_account_id, remote_account_hash) in account_updates {
@@ -562,7 +562,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
                 .find(|acc| *remote_account_id == acc.id() && *remote_account_hash != acc.hash());
 
             if let Some(tracked_account) = current_account {
-                info!("On-chain account hash difference detected for account with ID: {}. Fetching node for updates...", tracked_account.id());
+                info!("Public account hash difference detected for account with ID: {}. Fetching node for updates...", tracked_account.id());
                 let account_details = self.rpc_api.get_account_update(tracked_account.id()).await?;
                 if let AccountDetails::Public(account, _) = account_details {
                     // We should only do the update if it's newer, otherwise we ignore it
@@ -585,7 +585,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     fn validate_local_account_hashes(
         &mut self,
         account_updates: &[(AccountId, Digest)],
-        current_offchain_accounts: &[AccountStub],
+        current_offchain_accounts: &[AccountHeader],
     ) -> Result<(), ClientError> {
         for (remote_account_id, remote_account_hash) in account_updates {
             // ensure that if we track that account, it has the same hash
@@ -597,7 +597,7 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
             // update we ignore it.
             if mismatched_accounts.is_some() {
                 let account_by_hash =
-                    maybe_await!(self.store.get_account_stub_by_hash(*remote_account_hash))?;
+                    maybe_await!(self.store.get_account_header_by_hash(*remote_account_hash))?;
 
                 if account_by_hash.is_none() {
                     return Err(StoreError::AccountHashMismatch(*remote_account_id).into());

--- a/crates/rust-client/src/sync/tags.rs
+++ b/crates/rust-client/src/sync/tags.rs
@@ -59,9 +59,9 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
     pub(crate) fn get_tracked_note_tags(&self) -> Result<Vec<NoteTag>, ClientError> {
         let stored_tags = maybe_await!(self.get_note_tags())?;
 
-        let account_tags = maybe_await!(self.get_account_stubs())?
+        let account_tags = maybe_await!(self.get_account_headers())?
             .into_iter()
-            .map(|(stub, _)| NoteTag::from_account_id(stub.id(), NoteExecutionMode::Local))
+            .map(|(header, _)| NoteTag::from_account_id(header.id(), NoteExecutionMode::Local))
             .collect::<Result<Vec<_>, _>>()?;
 
         let expected_notes = maybe_await!(self.store.get_input_notes(NoteFilter::Expected))?;

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -93,7 +93,7 @@ async fn insert_basic_account() {
 
     let account_template = AccountTemplate::BasicWallet {
         mutable_code: true,
-        storage_type: AccountStorageMode::Private,
+        storage_mode: AccountStorageMode::Private,
     };
 
     // Insert Account
@@ -127,7 +127,7 @@ async fn insert_faucet_account() {
         token_symbol: TokenSymbol::new("TEST").unwrap(),
         decimals: 10,
         max_supply: 9999999999,
-        storage_type: AccountStorageMode::Private,
+        storage_mode: AccountStorageMode::Private,
     };
 
     // Insert Account

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -5,8 +5,8 @@ use alloc::vec::Vec;
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{
     accounts::{
-        account_id::testing::ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN, AccountCode, AccountId,
-        AccountStorageType, AccountStub, AuthSecretKey,
+        account_id::testing::ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN, AccountCode, AccountHeader,
+        AccountId, AccountStorageMode, AuthSecretKey,
     },
     assets::{FungibleAsset, TokenSymbol},
     crypto::dsa::rpo_falcon512::SecretKey,
@@ -93,7 +93,7 @@ async fn insert_basic_account() {
 
     let account_template = AccountTemplate::BasicWallet {
         mutable_code: true,
-        storage_type: AccountStorageType::OffChain,
+        storage_type: AccountStorageMode::Private,
     };
 
     // Insert Account
@@ -107,7 +107,7 @@ async fn insert_basic_account() {
     assert!(fetched_account_data.is_ok());
 
     let (fetched_account, fetched_account_seed) = fetched_account_data.unwrap();
-    // Validate stub has matching data
+    // Validate header has matching data
     assert_eq!(account.id(), fetched_account.id());
     assert_eq!(account.nonce(), fetched_account.nonce());
     assert_eq!(account.vault(), fetched_account.vault());
@@ -127,7 +127,7 @@ async fn insert_faucet_account() {
         token_symbol: TokenSymbol::new("TEST").unwrap(),
         decimals: 10,
         max_supply: 9999999999,
-        storage_type: AccountStorageType::OffChain,
+        storage_type: AccountStorageMode::Private,
     };
 
     // Insert Account
@@ -141,7 +141,7 @@ async fn insert_faucet_account() {
     assert!(fetched_account_data.is_ok());
 
     let (fetched_account, fetched_account_seed) = fetched_account_data.unwrap();
-    // Validate stub has matching data
+    // Validate header has matching data
     assert_eq!(account.id(), fetched_account.id());
     assert_eq!(account.nonce(), fetched_account.nonce());
     assert_eq!(account.vault(), fetched_account.vault());
@@ -223,16 +223,16 @@ async fn test_get_account_by_id() {
         .unwrap();
 
     // Retrieving an existing account should succeed
-    let (acc_from_db, _account_seed) = match client.get_account_stub_by_id(account.id()) {
+    let (acc_from_db, _account_seed) = match client.get_account_header_by_id(account.id()) {
         Ok(account) => account,
         Err(err) => panic!("Error retrieving account: {}", err),
     };
-    assert_eq!(AccountStub::from(account), acc_from_db);
+    assert_eq!(AccountHeader::from(account), acc_from_db);
 
     // Retrieving a non existing account should fail
     let hex = format!("0x{}", "1".repeat(16));
     let invalid_id = AccountId::from_hex(&hex).unwrap();
-    assert!(client.get_account_stub_by_id(invalid_id).is_err());
+    assert!(client.get_account_header_by_id(invalid_id).is_err());
 }
 
 #[tokio::test]

--- a/crates/rust-client/src/transactions/mod.rs
+++ b/crates/rust-client/src/transactions/mod.rs
@@ -16,7 +16,9 @@ use miden_objects::{
     transaction::{InputNotes, TransactionArgs},
     AssetError, Digest, Felt, NoteError, Word,
 };
-use miden_tx::{auth::TransactionAuthenticator, ProvingOptions, TransactionProver};
+use miden_tx::{
+    auth::TransactionAuthenticator, LocalTransactionProver, ProvingOptions, TransactionProver,
+};
 use script_builder::{AccountCapabilities, AccountInterface, TransactionScriptBuilder};
 use tracing::info;
 use winter_maybe_async::{maybe_async, maybe_await};
@@ -47,7 +49,7 @@ pub use script_builder::TransactionScriptBuilderError;
 // --------------------------------------------------------------------------------------------
 
 /// Represents the result of executing a transaction by the client.
-///  
+///
 /// It contains an [ExecutedTransaction], and a list of `relevant_notes` that contains the
 /// `output_notes` that the client has to store as input notes, based on the NoteScreener
 /// output from filtering the transaction's output notes or some partial note we expect to receive
@@ -314,20 +316,21 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
         &mut self,
         tx_result: TransactionResult,
     ) -> Result<(), ClientError> {
-        let proven_transaction = self.prove_transaction(&tx_result)?;
+        let proven_transaction = maybe_await!(self.prove_transaction(&tx_result))?;
         self.submit_proven_transaction(proven_transaction).await?;
         maybe_await!(self.apply_transaction(tx_result))
     }
 
+    #[maybe_async]
     fn prove_transaction(
         &mut self,
         tx_result: &TransactionResult,
     ) -> Result<ProvenTransaction, ClientError> {
-        let transaction_prover = TransactionProver::new(ProvingOptions::default());
+        let transaction_prover = LocalTransactionProver::new(ProvingOptions::default());
 
         info!("Proving transaction...");
         let proven_transaction =
-            transaction_prover.prove_transaction(tx_result.executed_transaction().clone())?;
+            maybe_await!(transaction_prover.prove(tx_result.executed_transaction().clone()))?;
         info!("Transaction proven.");
 
         Ok(proven_transaction)
@@ -542,11 +545,12 @@ impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client
 
 #[cfg(feature = "testing")]
 impl<N: NodeRpcClient, R: FeltRng, S: Store, A: TransactionAuthenticator> Client<N, R, S, A> {
+    #[maybe_async]
     pub fn testing_prove_transaction(
         &mut self,
         tx_result: &TransactionResult,
     ) -> Result<ProvenTransaction, ClientError> {
-        self.prove_transaction(tx_result)
+        maybe_await!(self.prove_transaction(tx_result))
     }
 
     pub async fn testing_submit_proven_transaction(

--- a/crates/rust-client/src/transactions/request.rs
+++ b/crates/rust-client/src/transactions/request.rs
@@ -645,9 +645,9 @@ impl SwapTransactionData {
 
 // TODO: Remove this in favor of precompiled scripts
 pub mod known_script_roots {
-    pub const P2ID: &str = "0x39b8d330926f2617d631191af4566f953e39cd7b461ae4ede7cc4fde9b9c8de7";
-    pub const P2IDR: &str = "0x0355e580bd492cc03ec7f779b58041f5de68d7fe3a4843cd5623554acfbc862b";
-    pub const SWAP: &str = "0x76fbfd9b74214b9216ec1d50d0b864393e2e550a84b7737b28bbe4f2d5e85d77";
+    pub const P2ID: &str = "0x3ac682b6e75ef2e7636090a701bea5e163a568add45f4be5ddc597c0991d79f1";
+    pub const P2IDR: &str = "0x30a90e514e8c46ec103560009b4aa098203de1544a713370641b29ba638509c7";
+    pub const SWAP: &str = "0xfe58a620708d33ceb611b7bd5809886e30313b4d77b96fad89ab4f1c2a54fc16";
 }
 
 // TESTS

--- a/crates/web-client/README.md
+++ b/crates/web-client/README.md
@@ -306,21 +306,21 @@ import_account(account_bytes: any): Promise<string>;
 import_note(note_bytes: string, verify: boolean): Promise<any>;
 
 /**
- * @param {string} storage_type
+ * @param {string} storage_mode
  * @param {boolean} mutable
  * @returns {Promise<any>}
  */
-new_wallet(storage_type: string, mutable: boolean): Promise<any>;
+new_wallet(storage_mode: string, mutable: boolean): Promise<any>;
 
 /**
- * @param {string} storage_type
+ * @param {string} storage_mode
  * @param {boolean} non_fungible
  * @param {string} token_symbol
  * @param {string} decimals
  * @param {string} max_supply
  * @returns {Promise<any>}
  */
-new_faucet(storage_type: string, non_fungible: boolean, token_symbol: string, decimals: string, max_supply: string): Promise<any>;
+new_faucet(storage_mode: string, non_fungible: boolean, token_symbol: string, decimals: string, max_supply: string): Promise<any>;
 
 /**
  * @param {string} target_account_id

--- a/crates/web-client/README.md
+++ b/crates/web-client/README.md
@@ -247,7 +247,7 @@ const notes = await webClient.get_input_notes("All")
 
 ```typescript
 /**
- * @returns {Promise<SerializedAccountStub>}
+ * @returns {Promise<SerializedAccountHeader>}
  * 
  * Example of returned object:
  * {
@@ -258,7 +258,7 @@ const notes = await webClient.get_input_notes("All")
  *   code_root: string
  * }
  */
-get_accounts(): Promise<SerializedAccountStub>;
+get_accounts(): Promise<SerializedAccountHeader>;
 
 /**
  * @param {string} account_id

--- a/crates/web-client/js/types/index.d.ts
+++ b/crates/web-client/js/types/index.d.ts
@@ -1,6 +1,6 @@
 export {
   WebClient,
   NewTransactionResult,
-  SerializedAccountStub,
-  NewSwapTransactionResult,
+  SerializedAccountHeader,
+  NewSwapTransactionResult
 } from "./crates/miden_client_web";

--- a/crates/web-client/src/account.rs
+++ b/crates/web-client/src/account.rs
@@ -1,17 +1,17 @@
 use miden_objects::accounts::AccountId;
 use wasm_bindgen::prelude::*;
 
-use crate::{models::accounts::SerializedAccountStub, WebClient};
+use crate::{models::accounts::SerializedAccountHeader, WebClient};
 
 #[wasm_bindgen]
 impl WebClient {
     pub async fn get_accounts(&mut self) -> Result<JsValue, JsValue> {
         if let Some(client) = self.get_mut_inner() {
-            let account_tuples = client.get_account_stubs().await.unwrap();
-            let accounts: Vec<SerializedAccountStub> = account_tuples
+            let account_tuples = client.get_account_headers().await.unwrap();
+            let accounts: Vec<SerializedAccountHeader> = account_tuples
                 .into_iter()
                 .map(|(account, _)| {
-                    SerializedAccountStub::new(
+                    SerializedAccountHeader::new(
                         account.id().to_string(),
                         account.nonce().to_string(),
                         account.vault_root().to_string(),

--- a/crates/web-client/src/models/accounts.rs
+++ b/crates/web-client/src/models/accounts.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize)]
-pub struct SerializedAccountStub {
+pub struct SerializedAccountHeader {
     id: String,
     nonce: String,
     vault_root: String,
@@ -12,15 +12,15 @@ pub struct SerializedAccountStub {
 }
 
 #[wasm_bindgen]
-impl SerializedAccountStub {
+impl SerializedAccountHeader {
     pub fn new(
         id: String,
         nonce: String,
         vault_root: String,
         storage_root: String,
         code_root: String,
-    ) -> SerializedAccountStub {
-        SerializedAccountStub {
+    ) -> SerializedAccountHeader {
+        SerializedAccountHeader {
             id,
             nonce,
             vault_root,

--- a/crates/web-client/src/new_account.rs
+++ b/crates/web-client/src/new_account.rs
@@ -10,13 +10,13 @@ use crate::WebClient;
 impl WebClient {
     pub async fn new_wallet(
         &mut self,
-        storage_type: String,
+        storage_mode: String,
         mutable: bool,
     ) -> Result<JsValue, JsValue> {
         if let Some(client) = self.get_mut_inner() {
             let client_template = AccountTemplate::BasicWallet {
                 mutable_code: mutable,
-                storage_type: AccountStorageMode::try_from(storage_type.as_str())
+                storage_mode: AccountStorageMode::try_from(storage_mode.as_str())
                     .map_err(|_| JsValue::from_str("Invalid storage mode"))?,
             };
 
@@ -35,7 +35,7 @@ impl WebClient {
 
     pub async fn new_faucet(
         &mut self,
-        storage_type: String,
+        storage_mode: String,
         non_fungible: bool,
         token_symbol: String,
         decimals: String,
@@ -53,7 +53,7 @@ impl WebClient {
                 max_supply: max_supply
                     .parse::<u64>()
                     .map_err(|e| JsValue::from_str(&e.to_string()))?,
-                storage_type: AccountStorageMode::from_str(&storage_type)
+                storage_mode: AccountStorageMode::from_str(&storage_mode)
                     .map_err(|_| JsValue::from_str("Invalid storage mode"))?,
             };
 

--- a/crates/web-client/src/new_account.rs
+++ b/crates/web-client/src/new_account.rs
@@ -1,5 +1,7 @@
+use std::str::FromStr;
+
 use miden_client::accounts::AccountTemplate;
-use miden_objects::{accounts::AccountStorageType, assets::TokenSymbol};
+use miden_objects::{accounts::AccountStorageMode, assets::TokenSymbol};
 use wasm_bindgen::prelude::*;
 
 use crate::WebClient;
@@ -14,11 +16,8 @@ impl WebClient {
         if let Some(client) = self.get_mut_inner() {
             let client_template = AccountTemplate::BasicWallet {
                 mutable_code: mutable,
-                storage_type: match storage_type.as_str() {
-                    "OffChain" => AccountStorageType::OffChain,
-                    "OnChain" => AccountStorageType::OnChain,
-                    _ => return Err(JsValue::from_str("Invalid storage mode")),
-                },
+                storage_type: AccountStorageMode::try_from(storage_type.as_str())
+                    .map_err(|_| JsValue::from_str("Invalid storage mode"))?,
             };
 
             match client.new_account(client_template).await {
@@ -54,11 +53,8 @@ impl WebClient {
                 max_supply: max_supply
                     .parse::<u64>()
                     .map_err(|e| JsValue::from_str(&e.to_string()))?,
-                storage_type: match storage_type.as_str() {
-                    "OffChain" => AccountStorageType::OffChain,
-                    "OnChain" => AccountStorageType::OnChain,
-                    _ => return Err(JsValue::from_str("Invalid storage mode")),
-                },
+                storage_type: AccountStorageMode::from_str(&storage_type)
+                    .map_err(|_| JsValue::from_str("Invalid storage mode"))?,
             };
 
             match client.new_account(client_template).await {

--- a/crates/web-client/test/faucet.test.ts
+++ b/crates/web-client/test/faucet.test.ts
@@ -3,7 +3,7 @@ import { createNewFaucet, isValidAddress } from "./webClientTestUtils.js";
 describe("faucet tests", () => {
   it("create a new faucet", async () => {
     const result = await createNewFaucet(
-      "OffChain",
+      "Private",
       false,
       "DMX",
       "10",

--- a/crates/web-client/test/wallet.test.ts
+++ b/crates/web-client/test/wallet.test.ts
@@ -2,7 +2,7 @@ import { createNewWallet, isValidAddress } from "./webClientTestUtils.js";
 
 describe("wallet tests", () => {
   it("create a new wallet", async () => {
-    const result = await createNewWallet("OffChain", false);
+    const result = await createNewWallet("Private", false);
 
     isValidAddress(result);
   });

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,7 +81,7 @@ For the `--default` flag, if `<ID>` is "none" then the previous default account 
 Creates a new wallet account.
 
 This command has two optional flags:
-- `--storage-type <TYPE>`: Used to select the storage type of the account (off-chain if not specified). It may receive "off-chain" or "on-chain".
+- `--storage-type <TYPE>`: Used to select the storage type of the account (private if not specified). It may receive "private" or "public".
 - `--mutable`: Makes the account code mutable (it's immutable by default).
 
 After creating an account with the `new-wallet` command, it is automatically stored and tracked by the client. This means the client can execute transactions that modify the state of accounts and track related changes by synchronizing with the Miden node.
@@ -91,7 +91,7 @@ After creating an account with the `new-wallet` command, it is automatically sto
 Creates a new faucet account.
 
 This command has two optional flags:
-- `--storage-type <type>`: Used to select the storage type of the account (off-chain if not specified). It may receive "off-chain" or "on-chain".
+- `--storage-type <type>`: Used to select the storage type of the account (private if not specified). It may receive "private" or "public".
 - `--non-fungible`: Makes the faucet asset non-fungible (it's fungible by default).
 
 After creating an account with the `new-faucet` command, it is automatically stored and tracked by the client. This means the client can execute transactions that modify the state of accounts and track related changes by synchronizing with the Miden node.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,7 +81,7 @@ For the `--default` flag, if `<ID>` is "none" then the previous default account 
 Creates a new wallet account.
 
 This command has two optional flags:
-- `--storage-type <TYPE>`: Used to select the storage type of the account (private if not specified). It may receive "private" or "public".
+- `--storage-type <TYPE>`: Used to select the storage mode of the account (private if not specified). It may receive "private" or "public".
 - `--mutable`: Makes the account code mutable (it's immutable by default).
 
 After creating an account with the `new-wallet` command, it is automatically stored and tracked by the client. This means the client can execute transactions that modify the state of accounts and track related changes by synchronizing with the Miden node.
@@ -91,7 +91,7 @@ After creating an account with the `new-wallet` command, it is automatically sto
 Creates a new faucet account.
 
 This command has two optional flags:
-- `--storage-type <type>`: Used to select the storage type of the account (private if not specified). It may receive "private" or "public".
+- `--storage-type <type>`: Used to select the storage mode of the account (private if not specified). It may receive "private" or "public".
 - `--non-fungible`: Makes the faucet asset non-fungible (it's fungible by default).
 
 After creating an account with the `new-faucet` command, it is automatically stored and tracked by the client. This means the client can execute transactions that modify the state of accounts and track related changes by synchronizing with the Miden node.

--- a/docs/library.md
+++ b/docs/library.md
@@ -48,7 +48,7 @@ let client: Client<TonicRpcClient, SqliteDataStore> = {
 
 ## Create local account
 
-With the Miden client, you can create and track any number of on-chain and local accounts. For local accounts, the state is tracked locally, and the rollup only keeps commitments to the data, which in turn guarantees privacy.
+With the Miden client, you can create and track any number of public and local accounts. For local accounts, the state is tracked locally, and the rollup only keeps commitments to the data, which in turn guarantees privacy.
 
 The `AccountTemplate` enum defines the type of account. The following code creates a new local account:
 
@@ -62,12 +62,12 @@ let (new_account, account_seed) = client.new_account(account_template)?;
 ```
 Once an account is created, it is kept locally and its state is automatically tracked by the client.
 
-To create an on-chain account, you can specify `AccountStorageMode::OnChain` like so:
+To create an public account, you can specify `AccountStorageMode::Public` like so:
 
 ```Rust
 let account_template = AccountTemplate::BasicWallet {
     mutable_code: false,
-    storage_mode: AccountStorageMode::OnChain,
+    storage_mode: AccountStorageMode::Public,
 };
 
 let (new_account, account_seed) = client.new_account(client_template)?;

--- a/tests/config/genesis.toml
+++ b/tests/config/genesis.toml
@@ -6,14 +6,14 @@ type = "BasicWallet"
 init_seed = "0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 auth_scheme = "RpoFalcon512"
 auth_seed = "0xb123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-storage_mode = "off-chain"
+storage_mode = "private"
 
 [[accounts]]
 type = "BasicWallet"
 init_seed = "0xa123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdea"
 auth_scheme = "RpoFalcon512"
 auth_seed = "0xb123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdea"
-storage_mode = "off-chain"
+storage_mode = "private"
 
 [[accounts]]
 type = "BasicFungibleFaucet"
@@ -23,4 +23,4 @@ auth_seed = "0xd123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 token_symbol = "POL"
 decimals = 12
 max_supply = 1000000
-storage_mode = "off-chain"
+storage_mode = "private"

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -215,7 +215,7 @@ pub async fn setup(
             token_symbol: TokenSymbol::new("MATIC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000_000,
-            storage_type: accounts_storage_mode,
+            storage_mode: accounts_storage_mode,
         })
         .unwrap();
 
@@ -223,14 +223,14 @@ pub async fn setup(
     let (first_basic_account, _) = client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
     let (second_basic_account, _) = client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -22,7 +22,7 @@ use miden_client::{
 use miden_objects::{
     accounts::{
         account_id::testing::ACCOUNT_ID_REGULAR_ACCOUNT_UPDATABLE_CODE_OFF_CHAIN, Account,
-        AccountId, AccountStorageType,
+        AccountId, AccountStorageMode,
     },
     assets::{Asset, FungibleAsset, TokenSymbol},
     crypto::rand::RpoRandomCoin,
@@ -202,10 +202,10 @@ pub const TRANSFER_AMOUNT: u64 = 59;
 /// Sets up a basic client and returns (basic_account, basic_account, faucet_account)
 pub async fn setup(
     client: &mut TestClient,
-    accounts_storage_mode: AccountStorageType,
+    accounts_storage_mode: AccountStorageMode,
 ) -> (Account, Account, Account) {
     // Enusre clean state
-    assert!(client.get_account_stubs().unwrap().is_empty());
+    assert!(client.get_account_headers().unwrap().is_empty());
     assert!(client.get_transactions(TransactionFilter::All).unwrap().is_empty());
     assert!(client.get_input_notes(NoteFilter::All).unwrap().is_empty());
 
@@ -223,14 +223,14 @@ pub async fn setup(
     let (first_basic_account, _) = client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
     let (second_basic_account, _) = client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -6,7 +6,7 @@ use miden_client::{
     ZERO,
 };
 use miden_objects::{
-    accounts::{AccountId, AccountStorageType, AuthSecretKey},
+    accounts::{AccountId, AccountStorageMode, AuthSecretKey},
     assets::{FungibleAsset, TokenSymbol},
     crypto::{
         hash::rpo::Rpo256,
@@ -58,7 +58,7 @@ async fn test_transaction_request() {
 
     let account_template = AccountTemplate::BasicWallet {
         mutable_code: false,
-        storage_type: AccountStorageType::OffChain,
+        storage_type: AccountStorageMode::Private,
     };
 
     client.sync_state().await.unwrap();
@@ -69,7 +69,7 @@ async fn test_transaction_request() {
         token_symbol: TokenSymbol::new("TEST").unwrap(),
         decimals: 5u8,
         max_supply: 10_000u64,
-        storage_type: AccountStorageType::OffChain,
+        storage_type: AccountStorageMode::Private,
     };
     let (fungible_faucet, _seed) = client.new_account(account_template).unwrap();
 
@@ -169,7 +169,7 @@ async fn test_merkle_store() {
 
     let account_template = AccountTemplate::BasicWallet {
         mutable_code: false,
-        storage_type: AccountStorageType::OffChain,
+        storage_type: AccountStorageMode::Private,
     };
 
     client.sync_state().await.unwrap();
@@ -180,7 +180,7 @@ async fn test_merkle_store() {
         token_symbol: TokenSymbol::new("TEST").unwrap(),
         decimals: 5u8,
         max_supply: 10_000u64,
-        storage_type: AccountStorageType::OffChain,
+        storage_type: AccountStorageMode::Private,
     };
     let (fungible_faucet, _seed) = client.new_account(account_template).unwrap();
 

--- a/tests/integration/custom_transactions_tests.rs
+++ b/tests/integration/custom_transactions_tests.rs
@@ -58,7 +58,7 @@ async fn test_transaction_request() {
 
     let account_template = AccountTemplate::BasicWallet {
         mutable_code: false,
-        storage_type: AccountStorageMode::Private,
+        storage_mode: AccountStorageMode::Private,
     };
 
     client.sync_state().await.unwrap();
@@ -69,7 +69,7 @@ async fn test_transaction_request() {
         token_symbol: TokenSymbol::new("TEST").unwrap(),
         decimals: 5u8,
         max_supply: 10_000u64,
-        storage_type: AccountStorageMode::Private,
+        storage_mode: AccountStorageMode::Private,
     };
     let (fungible_faucet, _seed) = client.new_account(account_template).unwrap();
 
@@ -169,7 +169,7 @@ async fn test_merkle_store() {
 
     let account_template = AccountTemplate::BasicWallet {
         mutable_code: false,
-        storage_type: AccountStorageMode::Private,
+        storage_mode: AccountStorageMode::Private,
     };
 
     client.sync_state().await.unwrap();
@@ -180,7 +180,7 @@ async fn test_merkle_store() {
         token_symbol: TokenSymbol::new("TEST").unwrap(),
         decimals: 5u8,
         max_supply: 10_000u64,
-        storage_type: AccountStorageMode::Private,
+        storage_mode: AccountStorageMode::Private,
     };
     let (fungible_faucet, _seed) = client.new_account(account_template).unwrap();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -557,7 +557,7 @@ async fn test_import_expected_notes() {
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -642,7 +642,7 @@ async fn test_import_expected_note_uncommitted() {
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -684,7 +684,7 @@ async fn test_import_expected_notes_from_the_past_as_committed() {
     let (_client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -735,7 +735,7 @@ async fn test_get_account_update() {
     let (basic_wallet_2, _) = client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Public,
+            storage_mode: AccountStorageMode::Public,
         })
         .unwrap();
 
@@ -778,7 +778,7 @@ async fn test_sync_detail_values() {
     let (second_regular_account, _) = client2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -965,7 +965,7 @@ async fn test_import_ignored_notes() {
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -1031,7 +1031,7 @@ async fn test_update_ignored_tag() {
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -1097,7 +1097,7 @@ async fn test_consume_multiple_expected_notes() {
     let (target_basic_account_2, _) = unauth_client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
     unauth_client.sync_state().await.unwrap();
@@ -1185,7 +1185,7 @@ async fn test_import_consumed_note_with_proof() {
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -9,7 +9,7 @@ use miden_client::{
     ClientError,
 };
 use miden_objects::{
-    accounts::{AccountId, AccountStorageType},
+    accounts::{AccountId, AccountStorageMode},
     assets::{Asset, FungibleAsset},
     notes::{NoteFile, NoteTag, NoteType},
 };
@@ -26,11 +26,11 @@ async fn test_added_notes() {
     let mut client = create_test_client();
     wait_for_node(&mut client).await;
 
-    let (_, _, faucet_account_stub) = setup(&mut client, AccountStorageType::OffChain).await;
+    let (_, _, faucet_account_header) = setup(&mut client, AccountStorageMode::Private).await;
 
     // Mint some asset for an account not tracked by the client. It should not be stored as an
     // input note afterwards since it is not being tracked by the client
-    let fungible_asset = FungibleAsset::new(faucet_account_stub.id(), MINT_AMOUNT).unwrap();
+    let fungible_asset = FungibleAsset::new(faucet_account_header.id(), MINT_AMOUNT).unwrap();
     let tx_request = TransactionRequest::mint_fungible_asset(
         fungible_asset,
         AccountId::try_from(ACCOUNT_ID_REGULAR).unwrap(),
@@ -39,7 +39,7 @@ async fn test_added_notes() {
     )
     .unwrap();
     println!("Running Mint tx...");
-    execute_tx_and_sync(&mut client, faucet_account_stub.id(), tx_request).await;
+    execute_tx_and_sync(&mut client, faucet_account_header.id(), tx_request).await;
 
     // Check that no new notes were added
     println!("Fetching Committed Notes...");
@@ -52,12 +52,12 @@ async fn test_multiple_tx_on_same_block() {
     let mut client = create_test_client();
     wait_for_node(&mut client).await;
 
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, second_regular_account, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     // First Mint necesary token
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::Private).await;
@@ -138,12 +138,12 @@ async fn test_p2id_transfer() {
     let mut client = create_test_client();
     wait_for_node(&mut client).await;
 
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, second_regular_account, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     // First Mint necesary token
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::Private).await;
@@ -208,12 +208,12 @@ async fn test_p2id_transfer_failing_not_enough_balance() {
     let mut client = create_test_client();
     wait_for_node(&mut client).await;
 
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, second_regular_account, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     // First Mint necesary token
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::Private).await;
@@ -247,12 +247,12 @@ async fn test_p2idr_transfer_consumed_by_target() {
     let mut client = create_test_client();
     wait_for_node(&mut client).await;
 
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, second_regular_account, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     // First Mint necesary token
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::Private).await;
@@ -350,12 +350,12 @@ async fn test_p2idr_transfer_consumed_by_sender() {
     let mut client = create_test_client();
     wait_for_node(&mut client).await;
 
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, second_regular_account, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     // First Mint necesary token
     let note = mint_note(&mut client, from_account_id, faucet_account_id, NoteType::Private).await;
@@ -438,12 +438,12 @@ async fn test_p2idr_transfer_consumed_by_sender() {
 async fn test_get_consumable_notes() {
     let mut client = create_test_client();
 
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, second_regular_account, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     //No consumable notes initially
     assert!(client.get_consumable_notes(None).unwrap().is_empty());
@@ -502,11 +502,11 @@ async fn test_get_consumable_notes() {
 async fn test_get_output_notes() {
     let mut client = create_test_client();
 
-    let (first_regular_account, _, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, _, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
     let random_account_id = AccountId::from_hex("0x0123456789abcdef").unwrap();
 
     // No output notes initially
@@ -551,13 +551,13 @@ async fn test_get_output_notes() {
 async fn test_import_expected_notes() {
     let mut client_1 = create_test_client();
     let (first_basic_account, _second_basic_account, faucet_account) =
-        setup(&mut client_1, AccountStorageType::OffChain).await;
+        setup(&mut client_1, AccountStorageMode::Private).await;
 
     let mut client_2 = create_test_client();
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -636,13 +636,13 @@ async fn test_import_expected_notes() {
 async fn test_import_expected_note_uncommitted() {
     let mut client_1 = create_test_client();
     let (_, _second_basic_account, faucet_account) =
-        setup(&mut client_1, AccountStorageType::OffChain).await;
+        setup(&mut client_1, AccountStorageMode::Private).await;
 
     let mut client_2 = create_test_client();
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -678,13 +678,13 @@ async fn test_import_expected_note_uncommitted() {
 async fn test_import_expected_notes_from_the_past_as_committed() {
     let mut client_1 = create_test_client();
     let (first_basic_account, _second_basic_account, faucet_account) =
-        setup(&mut client_1, AccountStorageType::OffChain).await;
+        setup(&mut client_1, AccountStorageMode::Private).await;
 
     let mut client_2 = create_test_client();
     let (_client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -730,13 +730,12 @@ async fn test_get_account_update() {
     // Create a client with both public and private accounts.
     let mut client = create_test_client();
 
-    let (basic_wallet_1, _, faucet_account) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (basic_wallet_1, _, faucet_account) = setup(&mut client, AccountStorageMode::Private).await;
 
     let (basic_wallet_2, _) = client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OnChain,
+            storage_type: AccountStorageMode::Public,
         })
         .unwrap();
 
@@ -773,19 +772,19 @@ async fn test_sync_detail_values() {
     wait_for_node(&mut client1).await;
     wait_for_node(&mut client2).await;
 
-    let (first_regular_account, _, faucet_account_stub) =
-        setup(&mut client1, AccountStorageType::OffChain).await;
+    let (first_regular_account, _, faucet_account_header) =
+        setup(&mut client1, AccountStorageMode::Private).await;
 
     let (second_regular_account, _) = client2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     // First Mint necesary token
     let note = mint_note(&mut client1, from_account_id, faucet_account_id, NoteType::Private).await;
@@ -833,11 +832,11 @@ async fn test_sync_detail_values() {
 async fn test_multiple_transactions_can_be_committed_in_different_blocks_without_sync() {
     let mut client = create_test_client();
 
-    let (first_regular_account, _second_regular_account, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (first_regular_account, _second_regular_account, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
 
     let from_account_id = first_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     // Mint first note
     let (first_note_id, first_note_tx_id) = {
@@ -960,13 +959,13 @@ async fn test_multiple_transactions_can_be_committed_in_different_blocks_without
 async fn test_import_ignored_notes() {
     let mut client_1 = create_test_client();
     let (_first_basic_account, _second_basic_account, faucet_account) =
-        setup(&mut client_1, AccountStorageType::OffChain).await;
+        setup(&mut client_1, AccountStorageMode::Private).await;
 
     let mut client_2 = create_test_client();
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -1026,13 +1025,13 @@ async fn test_import_ignored_notes() {
 async fn test_update_ignored_tag() {
     let mut client_1 = create_test_client();
     let (_first_basic_account, _second_basic_account, faucet_account) =
-        setup(&mut client_1, AccountStorageType::OffChain).await;
+        setup(&mut client_1, AccountStorageMode::Private).await;
 
     let mut client_2 = create_test_client();
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -1093,17 +1092,17 @@ async fn test_consume_multiple_expected_notes() {
     wait_for_node(&mut client).await;
 
     // Setup accounts
-    let (target_basic_account_1, _, faucet_account_stub) =
-        setup(&mut client, AccountStorageType::OffChain).await;
+    let (target_basic_account_1, _, faucet_account_header) =
+        setup(&mut client, AccountStorageMode::Private).await;
     let (target_basic_account_2, _) = unauth_client
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
     unauth_client.sync_state().await.unwrap();
 
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
     let to_account_ids = [target_basic_account_1.id(), target_basic_account_2.id()];
 
     // Mint tokens to the accounts
@@ -1179,14 +1178,14 @@ async fn test_consume_multiple_expected_notes() {
 #[tokio::test]
 async fn test_import_consumed_note_with_proof() {
     let mut client_1 = create_test_client();
-    let (first_regular_account, _, faucet_account_stub) =
-        setup(&mut client_1, AccountStorageType::OffChain).await;
+    let (first_regular_account, _, faucet_account_header) =
+        setup(&mut client_1, AccountStorageMode::Private).await;
 
     let mut client_2 = create_test_client();
     let (client_2_account, _seed) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: true,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -1194,7 +1193,7 @@ async fn test_import_consumed_note_with_proof() {
 
     let from_account_id = first_regular_account.id();
     let to_account_id = client_2_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     let note =
         mint_note(&mut client_1, from_account_id, faucet_account_id, NoteType::Private).await;
@@ -1242,8 +1241,8 @@ async fn test_import_consumed_note_with_proof() {
 #[tokio::test]
 async fn test_import_consumed_note_with_id() {
     let mut client_1 = create_test_client();
-    let (first_regular_account, second_regular_account, faucet_account_stub) =
-        setup(&mut client_1, AccountStorageType::OffChain).await;
+    let (first_regular_account, second_regular_account, faucet_account_header) =
+        setup(&mut client_1, AccountStorageMode::Private).await;
 
     let mut client_2 = create_test_client();
 
@@ -1251,7 +1250,7 @@ async fn test_import_consumed_note_with_id() {
 
     let from_account_id = first_regular_account.id();
     let to_account_id = second_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
     let note =
         mint_note(&mut client_1, from_account_id, faucet_account_id, NoteType::Private).await;

--- a/tests/integration/onchain_tests.rs
+++ b/tests/integration/onchain_tests.rs
@@ -28,7 +28,7 @@ async fn test_onchain_notes_flow() {
             token_symbol: TokenSymbol::new("MATIC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000_000,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -36,7 +36,7 @@ async fn test_onchain_notes_flow() {
     let (basic_wallet_1, _) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -44,7 +44,7 @@ async fn test_onchain_notes_flow() {
     let (basic_wallet_2, _) = client_3
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
     client_1.sync_state().await.unwrap();
@@ -281,7 +281,7 @@ async fn test_onchain_notes_sync_with_tag() {
             token_symbol: TokenSymbol::new("MATIC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000_000,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 

--- a/tests/integration/onchain_tests.rs
+++ b/tests/integration/onchain_tests.rs
@@ -4,7 +4,7 @@ use miden_client::{
     transactions::{PaymentTransactionData, TransactionRequest},
 };
 use miden_objects::{
-    accounts::{AccountId, AccountStorageType},
+    accounts::{AccountId, AccountStorageMode},
     assets::{Asset, FungibleAsset, TokenSymbol},
     notes::{NoteFile, NoteTag, NoteType},
     transaction::InputNote,
@@ -28,7 +28,7 @@ async fn test_onchain_notes_flow() {
             token_symbol: TokenSymbol::new("MATIC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000_000,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -36,7 +36,7 @@ async fn test_onchain_notes_flow() {
     let (basic_wallet_1, _) = client_2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -44,7 +44,7 @@ async fn test_onchain_notes_flow() {
     let (basic_wallet_2, _) = client_3
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
     client_1.sync_state().await.unwrap();
@@ -116,22 +116,24 @@ async fn test_onchain_accounts() {
     let mut client_2 = create_test_client();
     wait_for_node(&mut client_2).await;
 
-    let (first_regular_account, _second_regular_account, faucet_account_stub) =
-        setup(&mut client_1, AccountStorageType::OnChain).await;
+    let (first_regular_account, _second_regular_account, faucet_account_header) =
+        setup(&mut client_1, AccountStorageMode::Public).await;
 
     let (
         second_client_first_regular_account,
         _other_second_regular_account,
-        _other_faucet_account_stub,
-    ) = setup(&mut client_2, AccountStorageType::OffChain).await;
+        _other_faucet_account_header,
+    ) = setup(&mut client_2, AccountStorageMode::Private).await;
 
     let target_account_id = first_regular_account.id();
     let second_client_target_account_id = second_client_first_regular_account.id();
-    let faucet_account_id = faucet_account_stub.id();
+    let faucet_account_id = faucet_account_header.id();
 
-    let (_, faucet_seed) = client_1.get_account_stub_by_id(faucet_account_id).unwrap();
+    let (_, faucet_seed) = client_1.get_account_header_by_id(faucet_account_id).unwrap();
     let auth_info = client_1.get_account_auth(faucet_account_id).unwrap();
-    client_2.insert_account(&faucet_account_stub, faucet_seed, &auth_info).unwrap();
+    client_2
+        .insert_account(&faucet_account_header, faucet_seed, &auth_info)
+        .unwrap();
 
     // First Mint necesary token
     println!("First client consuming note");
@@ -142,8 +144,10 @@ async fn test_onchain_accounts() {
     // between clients
     client_2.sync_state().await.unwrap();
 
-    let (client_1_faucet, _) = client_1.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
-    let (client_2_faucet, _) = client_2.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
+    let (client_1_faucet, _) =
+        client_1.get_account_header_by_id(faucet_account_header.id()).unwrap();
+    let (client_2_faucet, _) =
+        client_2.get_account_header_by_id(faucet_account_header.id()).unwrap();
 
     assert_eq!(client_1_faucet.hash(), client_2_faucet.hash());
 
@@ -174,8 +178,10 @@ async fn test_onchain_accounts() {
     )
     .await;
 
-    let (client_1_faucet, _) = client_1.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
-    let (client_2_faucet, _) = client_2.get_account_stub_by_id(faucet_account_stub.id()).unwrap();
+    let (client_1_faucet, _) =
+        client_1.get_account_header_by_id(faucet_account_header.id()).unwrap();
+    let (client_2_faucet, _) =
+        client_2.get_account_header_by_id(faucet_account_header.id()).unwrap();
 
     assert_eq!(client_1_faucet.hash(), client_2_faucet.hash());
 
@@ -275,7 +281,7 @@ async fn test_onchain_notes_sync_with_tag() {
             token_symbol: TokenSymbol::new("MATIC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000_000,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -5,7 +5,7 @@ use miden_client::{
     transactions::{SwapTransactionData, TransactionRequest},
 };
 use miden_objects::{
-    accounts::{AccountId, AccountStorageType},
+    accounts::{AccountId, AccountStorageMode},
     assets::{Asset, FungibleAsset, TokenSymbol},
     notes::{NoteDetails, NoteExecutionMode, NoteFile, NoteId, NoteTag, NoteType},
 };
@@ -34,7 +34,7 @@ async fn test_swap_fully_onchain() {
     let (account_a, _) = client1
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -42,7 +42,7 @@ async fn test_swap_fully_onchain() {
     let (account_b, _) = client2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -52,7 +52,7 @@ async fn test_swap_fully_onchain() {
             token_symbol: TokenSymbol::new("BTC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
     // Create client with faucets ETH faucet (note: it's not real ETH)
@@ -61,7 +61,7 @@ async fn test_swap_fully_onchain() {
             token_symbol: TokenSymbol::new("ETH").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -241,7 +241,7 @@ async fn test_swap_offchain() {
     let (account_a, _) = client1
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -249,7 +249,7 @@ async fn test_swap_offchain() {
     let (account_b, _) = client2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -259,7 +259,7 @@ async fn test_swap_offchain() {
             token_symbol: TokenSymbol::new("BTC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
     // Create client with faucets ETH faucet (note: it's not real ETH)
@@ -268,7 +268,7 @@ async fn test_swap_offchain() {
             token_symbol: TokenSymbol::new("ETH").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageType::OffChain,
+            storage_type: AccountStorageMode::Private,
         })
         .unwrap();
 

--- a/tests/integration/swap_transactions_tests.rs
+++ b/tests/integration/swap_transactions_tests.rs
@@ -34,7 +34,7 @@ async fn test_swap_fully_onchain() {
     let (account_a, _) = client1
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -42,7 +42,7 @@ async fn test_swap_fully_onchain() {
     let (account_b, _) = client2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -52,7 +52,7 @@ async fn test_swap_fully_onchain() {
             token_symbol: TokenSymbol::new("BTC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
     // Create client with faucets ETH faucet (note: it's not real ETH)
@@ -61,7 +61,7 @@ async fn test_swap_fully_onchain() {
             token_symbol: TokenSymbol::new("ETH").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -241,7 +241,7 @@ async fn test_swap_offchain() {
     let (account_a, _) = client1
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -249,7 +249,7 @@ async fn test_swap_offchain() {
     let (account_b, _) = client2
         .new_account(AccountTemplate::BasicWallet {
             mutable_code: false,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 
@@ -259,7 +259,7 @@ async fn test_swap_offchain() {
             token_symbol: TokenSymbol::new("BTC").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
     // Create client with faucets ETH faucet (note: it's not real ETH)
@@ -268,7 +268,7 @@ async fn test_swap_offchain() {
             token_symbol: TokenSymbol::new("ETH").unwrap(),
             decimals: 8,
             max_supply: 1_000_000,
-            storage_type: AccountStorageMode::Private,
+            storage_mode: AccountStorageMode::Private,
         })
         .unwrap();
 


### PR DESCRIPTION
This PR updates the miden-base dependency to the `next` branch.

It adds a breaking change, since the CLI now receives `private` and `public` for account store types instead of the old `off-chain` and `on-chain`.