### PR TITLE
fix(temporary): use tomyrd-next-dependecies-without-dep-updates branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FEATURES_CLIENT=--features "testing, concurrent"
 FEATURES_CLI=--features "testing, concurrent"
 NODE_FEATURES_TESTING=--features "testing"
 WARNINGS=RUSTDOCFLAGS="-D warnings"
-NODE_BRANCH="main"
+NODE_BRANCH="tomyrd-next-dependecies-without-dep-updates"
 
 # --- Linting -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
As @bobbinth mentioned [here](https://github.com/0xPolygonMiden/miden-node/issues/487#issuecomment-2334692982), the client's CI isn't currently working due to the node not working. This is a temporary fix until a further definite fix.