### PR TITLE
feat: store note tags in separate table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+* Added dedicated separate table for tracked tags (#535).
 * [BREAKING] Added support for committed and discarded transactions (#531).
 * [BREAKING] Refactored Client struct to use trait objects for inner struct fields (#539).
 * Fixed panic on export command without type (#537).

--- a/crates/rust-client/src/accounts.rs
+++ b/crates/rust-client/src/accounts.rs
@@ -54,7 +54,8 @@ impl<R: FeltRng> Client<R> {
     // ACCOUNT CREATION
     // --------------------------------------------------------------------------------------------
 
-    /// Creates a new [Account] based on an [AccountTemplate] and saves it in the client's store.
+    /// Creates a new [Account] based on an [AccountTemplate] and saves it in the client's store. A
+    /// new tag derived from the account will start being tracked by the client.
     #[maybe_async]
     pub fn new_account(
         &mut self,

--- a/crates/rust-client/src/accounts.rs
+++ b/crates/rust-client/src/accounts.rs
@@ -15,12 +15,16 @@ use miden_objects::{
     accounts::AuthSecretKey,
     assets::TokenSymbol,
     crypto::{dsa::rpo_falcon512::SecretKey, rand::FeltRng},
+    notes::{NoteExecutionMode, NoteTag},
     Felt, Word,
 };
 use winter_maybe_async::{maybe_async, maybe_await};
 
 use super::Client;
-use crate::ClientError;
+use crate::{
+    sync::{NoteTagRecord, NoteTagSource},
+    ClientError,
+};
 
 /// Defines templates for creating different types of Miden accounts.
 pub enum AccountTemplate {
@@ -72,6 +76,12 @@ impl<R: FeltRng> Client<R> {
                 storage_mode
             )),
         }?;
+
+        let id = account_and_seed.0.id();
+        maybe_await!(self.store.add_note_tag(NoteTagRecord {
+            tag: NoteTag::from_account_id(id, NoteExecutionMode::Local)?,
+            source: NoteTagSource::Account(id),
+        }))?;
 
         Ok(account_and_seed)
     }

--- a/crates/rust-client/src/accounts.rs
+++ b/crates/rust-client/src/accounts.rs
@@ -21,10 +21,7 @@ use miden_objects::{
 use winter_maybe_async::{maybe_async, maybe_await};
 
 use super::Client;
-use crate::{
-    sync::{NoteTagRecord, NoteTagSource},
-    ClientError,
-};
+use crate::{sync::NoteTagRecord, ClientError};
 
 /// Defines templates for creating different types of Miden accounts.
 pub enum AccountTemplate {
@@ -79,10 +76,10 @@ impl<R: FeltRng> Client<R> {
         }?;
 
         let id = account_and_seed.0.id();
-        maybe_await!(self.store.add_note_tag(NoteTagRecord {
-            tag: NoteTag::from_account_id(id, NoteExecutionMode::Local)?,
-            source: NoteTagSource::Account(id),
-        }))?;
+        maybe_await!(self.store.add_note_tag(NoteTagRecord::with_account_source(
+            NoteTag::from_account_id(id, NoteExecutionMode::Local)?,
+            id
+        )))?;
 
         Ok(account_and_seed)
     }

--- a/crates/rust-client/src/notes/import.rs
+++ b/crates/rust-client/src/notes/import.rs
@@ -18,7 +18,7 @@ impl<R: FeltRng> Client<R> {
 
     /// Imports a new input note into the client's store. The information stored depends on the
     /// type of note file provided. If the note existed previously, it will be updated with the
-    /// new information.
+    /// new information. The tag specified by the `NoteFile` will start being tracked.
     ///
     /// - If the note file is a [NoteFile::NoteId], the note is fetched from the node and stored in
     ///   the client's store. If the note is private or does not exist, an error is returned.

--- a/crates/rust-client/src/notes/import.rs
+++ b/crates/rust-client/src/notes/import.rs
@@ -97,6 +97,11 @@ impl<R: FeltRng> Client<R> {
                 if previous_note
                     .inclusion_proof_received(inclusion_proof, *note_details.metadata())?
                 {
+                    maybe_await!(self.store.remove_note_tag(NoteTagRecord {
+                        tag: note_details.metadata().tag(),
+                        source: NoteTagSource::Note(note_details.id()),
+                    }))?;
+
                     Ok(Some(previous_note))
                 } else {
                     Ok(None)
@@ -169,6 +174,11 @@ impl<R: FeltRng> Client<R> {
             }
 
             if note_changed {
+                maybe_await!(self.store.remove_note_tag(NoteTagRecord {
+                    tag: metadata.tag(),
+                    source: NoteTagSource::Note(note_record.id()),
+                }))?;
+
                 Ok(Some(note_record))
             } else {
                 Ok(None)
@@ -213,6 +223,11 @@ impl<R: FeltRng> Client<R> {
                     note_record.inclusion_proof_received(inclusion_proof, metadata)?;
 
                 if note_record.block_header_received(block_header)? | note_changed {
+                    maybe_await!(self.store.remove_note_tag(NoteTagRecord {
+                        tag: metadata.tag(),
+                        source: NoteTagSource::Note(note_record.id()),
+                    }))?;
+
                     Ok(Some(note_record))
                 } else {
                     Ok(None)

--- a/crates/rust-client/src/notes/import.rs
+++ b/crates/rust-client/src/notes/import.rs
@@ -7,7 +7,8 @@ use miden_objects::{
 use winter_maybe_async::maybe_await;
 
 use crate::{
-    store::{ExpectedNoteState, InputNoteRecord},
+    store::{ExpectedNoteState, InputNoteRecord, NoteState},
+    sync::{NoteTagRecord, NoteTagSource},
     Client, ClientError,
 };
 
@@ -47,6 +48,12 @@ impl<R: FeltRng> Client<R> {
         };
 
         if let Some(note) = note {
+            if let NoteState::Expected(ExpectedNoteState { tag: Some(tag), .. }) = note.state() {
+                maybe_await!(self.store.add_note_tag(NoteTagRecord {
+                    tag: *tag,
+                    source: NoteTagSource::Note(note.id()),
+                }))?;
+            }
             maybe_await!(self.store.upsert_input_note(note))?;
         }
 

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -2,13 +2,16 @@
 //! and retrieving data, such as account states, transaction history, and block headers.
 #[cfg(feature = "async")]
 use alloc::boxed::Box;
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::fmt::Debug;
 
 use miden_objects::{
     accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
-    notes::{NoteId, Nullifier},
+    notes::{NoteId, NoteTag, Nullifier},
     BlockHeader, Digest, Word,
 };
 use winter_maybe_async::*;
@@ -273,9 +276,15 @@ pub trait Store {
     // SYNC
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the note tags that the client is interested in.
+    /// Returns the note tag records that the client is interested in.
     #[maybe_async]
     fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, StoreError>;
+
+    /// Returns the unique note tags (without source) that the client is interested in.
+    #[maybe_async]
+    fn get_unique_note_tags(&self) -> Result<BTreeSet<NoteTag>, StoreError> {
+        Ok(maybe_await!(self.get_note_tags())?.into_iter().map(|r| r.tag).collect())
+    }
 
     /// Adds a note tag to the list of tags that the client is interested in.
     ///

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -289,7 +289,7 @@ pub trait Store {
     /// If the tag was not present in the store returns false since no tag was actually removed.
     /// Otherwise returns true.
     #[maybe_async]
-    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError>;
+    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<usize, StoreError>;
 
     /// Returns the block number of the last state sync block.
     #[maybe_async]

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -8,13 +8,13 @@ use core::fmt::Debug;
 use miden_objects::{
     accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
-    notes::{NoteId, NoteTag, Nullifier},
+    notes::{NoteId, Nullifier},
     BlockHeader, Digest, Word,
 };
 use winter_maybe_async::*;
 
 use crate::{
-    sync::StateSyncUpdate,
+    sync::{NoteTagRecord, StateSyncUpdate},
     transactions::{TransactionRecord, TransactionResult},
 };
 
@@ -275,21 +275,21 @@ pub trait Store {
 
     /// Returns the note tags that the client is interested in.
     #[maybe_async]
-    fn get_note_tags(&self) -> Result<Vec<NoteTag>, StoreError>;
+    fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, StoreError>;
 
     /// Adds a note tag to the list of tags that the client is interested in.
     ///
     /// If the tag was already being tracked, returns false since no new tags were actually added.
     /// Otherwise true.
     #[maybe_async]
-    fn add_note_tag(&self, tag: NoteTag) -> Result<bool, StoreError>;
+    fn add_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError>;
 
     /// Removes a note tag from the list of tags that the client is interested in.
     ///
     /// If the tag was not present in the store returns false since no tag was actually removed.
     /// Otherwise returns true.
     #[maybe_async]
-    fn remove_note_tag(&self, tag: NoteTag) -> Result<bool, StoreError>;
+    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError>;
 
     /// Returns the block number of the last state sync block.
     #[maybe_async]

--- a/crates/rust-client/src/store/sqlite_store/mod.rs
+++ b/crates/rust-client/src/store/sqlite_store/mod.rs
@@ -84,7 +84,7 @@ impl Store for SqliteStore {
     }
 
     #[maybe_async]
-    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError> {
+    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<usize, StoreError> {
         self.remove_note_tag(tag)
     }
 

--- a/crates/rust-client/src/store/sqlite_store/mod.rs
+++ b/crates/rust-client/src/store/sqlite_store/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use miden_objects::{
     accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
-    notes::{NoteTag, Nullifier},
+    notes::Nullifier,
     BlockHeader, Digest, Word,
 };
 use rusqlite::{vtab::array, Connection};
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::{
     store::StoreError,
-    sync::StateSyncUpdate,
+    sync::{NoteTagRecord, StateSyncUpdate},
     transactions::{TransactionRecord, TransactionResult},
 };
 
@@ -74,17 +74,17 @@ use alloc::boxed::Box;
 #[maybe_async_trait]
 impl Store for SqliteStore {
     #[maybe_async]
-    fn get_note_tags(&self) -> Result<Vec<NoteTag>, StoreError> {
+    fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, StoreError> {
         self.get_note_tags()
     }
 
     #[maybe_async]
-    fn add_note_tag(&self, tag: NoteTag) -> Result<bool, StoreError> {
+    fn add_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError> {
         self.add_note_tag(tag)
     }
 
     #[maybe_async]
-    fn remove_note_tag(&self, tag: NoteTag) -> Result<bool, StoreError> {
+    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError> {
         self.remove_note_tag(tag)
     }
 

--- a/crates/rust-client/src/store/sqlite_store/mod.rs
+++ b/crates/rust-client/src/store/sqlite_store/mod.rs
@@ -1,11 +1,14 @@
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
 use core::cell::{RefCell, RefMut};
 use std::path::Path;
 
 use miden_objects::{
     accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
-    notes::Nullifier,
+    notes::{NoteTag, Nullifier},
     BlockHeader, Digest, Word,
 };
 use rusqlite::{vtab::array, Connection};
@@ -76,6 +79,11 @@ impl Store for SqliteStore {
     #[maybe_async]
     fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, StoreError> {
         self.get_note_tags()
+    }
+
+    #[maybe_async]
+    fn get_unique_note_tags(&self) -> Result<BTreeSet<NoteTag>, StoreError> {
+        self.get_unique_note_tags()
     }
 
     #[maybe_async]

--- a/crates/rust-client/src/store/sqlite_store/store.sql
+++ b/crates/rust-client/src/store/sqlite_store/store.sql
@@ -130,13 +130,18 @@ CREATE TABLE notes_scripts (
 -- Create state sync table
 CREATE TABLE state_sync (
     block_num UNSIGNED BIG INT NOT NULL,    -- the block number of the most recent state sync
-    tags BLOB NULL,                     -- the serialized list of tags, a NULL means an empty list
     PRIMARY KEY (block_num)
 );
 
+-- Create tags table
+CREATE TABLE tags (
+    tag BLOB NOT NULL,                  -- the serialized tag
+    source BLOB NOT NULL               -- the serialized tag source
+);
+
 -- insert initial row into state_sync table
-INSERT OR IGNORE INTO state_sync (block_num, tags)
-SELECT 0, NULL
+INSERT OR IGNORE INTO state_sync (block_num)
+SELECT 0
 WHERE (
     SELECT COUNT(*) FROM state_sync
 ) = 0;

--- a/crates/rust-client/src/store/sqlite_store/transactions.rs
+++ b/crates/rust-client/src/store/sqlite_store/transactions.rs
@@ -22,7 +22,7 @@ use super::{
 use crate::{
     rpc::TransactionUpdate,
     store::{ExpectedNoteState, NoteFilter, NoteState, StoreError, TransactionFilter},
-    sync::{NoteTagRecord, NoteTagSource},
+    sync::NoteTagRecord,
     transactions::{TransactionRecord, TransactionResult, TransactionStatus},
 };
 
@@ -122,13 +122,7 @@ impl SqliteStore {
         for note in created_input_notes {
             upsert_input_note_tx(&tx, &note)?;
             if let NoteState::Expected(ExpectedNoteState { tag: Some(tag), .. }) = note.state() {
-                add_note_tag_tx(
-                    &tx,
-                    NoteTagRecord {
-                        tag: *tag,
-                        source: NoteTagSource::Note(note.id()),
-                    },
-                )?;
+                add_note_tag_tx(&tx, NoteTagRecord::with_note_source(*tag, note.id()))?;
             }
         }
 

--- a/crates/rust-client/src/store/web_store/js/accounts.js
+++ b/crates/rust-client/src/store/web_store/js/accounts.js
@@ -1,9 +1,9 @@
-import { 
-    accountCodes, 
-    accountStorages, 
-    accountVaults, 
-    accountAuths, 
-    accounts 
+import {
+    accountCodes,
+    accountStorages,
+    accountVaults,
+    accountAuths,
+    accounts
 } from './schema.js';
 
 // GET FUNCTIONS
@@ -24,7 +24,7 @@ export async function getAccountIds() {
 }
 
 export async function getAllAccountHeaders() {
-    try {        
+    try {
         // Use a Map to track the latest record for each id based on nonce
         const latestRecordsMap = new Map();
 
@@ -73,12 +73,12 @@ export async function getAccountHeader(
           .where('id')
           .equals(accountId)
           .toArray();
-    
+
         if (allMatchingRecords.length === 0) {
           console.log('No records found for given ID.');
           throw new Error("No records found for given ID.")
         }
-    
+
         // Convert nonce to BigInt and sort
         // Note: This assumes all nonces are valid BigInt strings.
         const sortedRecords = allMatchingRecords.sort((a, b) => {
@@ -86,7 +86,7 @@ export async function getAccountHeader(
           const bigIntB = BigInt(b.nonce);
           return bigIntA > bigIntB ? -1 : bigIntA < bigIntB ? 1 : 0;
         });
-    
+
         // The first record is the most recent one due to the sorting
         const mostRecentRecord = sortedRecords[0];
 
@@ -174,7 +174,7 @@ export async function getAccountCode(
         const codeArrayBuffer = await codeRecord.code.arrayBuffer();
         const codeArray = new Uint8Array(codeArrayBuffer);
         const codeBase64 = uint8ArrayToBase64(codeArray);
-        
+
         return {
             root: codeRecord.root,
             code: codeBase64,
@@ -347,8 +347,8 @@ export async function fetchAndCacheAccountAuthByPubKey(
 // INSERT FUNCTIONS
 
 export async function insertAccountCode(
-    codeRoot, 
-    code, 
+    codeRoot,
+    code,
 ) {
     try {
         // Create a Blob from the ArrayBuffer
@@ -369,7 +369,7 @@ export async function insertAccountCode(
 }
 
 export async function insertAccountStorage(
-    storageRoot, 
+    storageRoot,
     storageSlots
 ) {
     try {
@@ -390,7 +390,7 @@ export async function insertAccountStorage(
 }
 
 export async function insertAccountAssetVault(
-    vaultRoot, 
+    vaultRoot,
     assets
 ) {
     try {
@@ -425,7 +425,7 @@ export async function insertAccountRecord(
         if (account_seed) {
             accountSeedBlob = new Blob([new Uint8Array(account_seed)]);
         }
-        
+
 
         // Prepare the data object to insert
         const data = {
@@ -448,7 +448,7 @@ export async function insertAccountRecord(
 }
 
 export async function insertAccountAuth(
-    accountId, 
+    accountId,
     authInfo,
     pubKey
 ) {

--- a/crates/rust-client/src/store/web_store/js/schema.js
+++ b/crates/rust-client/src/store/web_store/js/schema.js
@@ -46,7 +46,7 @@ db.version(1).stores({
   [Table.StateSync]: indexes('id'),
   [Table.BlockHeaders]: indexes('blockNum', 'hasClientNotes'),
   [Table.ChainMmrNodes]: indexes('id'),
-  [Table.Tags]: indexes('tag', 'source'),
+  [Table.Tags]: indexes('tag', 'source_note_id', 'source_account_id'),
 });
 
 function indexes(...items) {

--- a/crates/rust-client/src/store/web_store/js/schema.js
+++ b/crates/rust-client/src/store/web_store/js/schema.js
@@ -28,6 +28,7 @@ const Table = {
   StateSync: 'stateSync',
   BlockHeaders: 'blockHeaders',
   ChainMmrNodes: 'chainMmrNodes',
+  Tags: 'tags',
 };
 
 const db = new Dexie(DATABASE_NAME);
@@ -45,6 +46,7 @@ db.version(1).stores({
   [Table.StateSync]: indexes('id'),
   [Table.BlockHeaders]: indexes('blockNum', 'hasClientNotes'),
   [Table.ChainMmrNodes]: indexes('id'),
+  [Table.Tags]: indexes('tag', 'source'),
 });
 
 function indexes(...items) {
@@ -53,7 +55,7 @@ function indexes(...items) {
 
 db.on('populate', () => {
   // Populate the stateSync table with default values
-  db.stateSync.put({ id: 1, blockNum: "0", tags: null });
+  db.stateSync.put({ id: 1, blockNum: "0" });
 });
 
 const accountCodes = db.table(Table.AccountCode);
@@ -69,14 +71,15 @@ const notesScripts = db.table(Table.NotesScripts);
 const stateSync = db.table(Table.StateSync);
 const blockHeaders = db.table(Table.BlockHeaders);
 const chainMmrNodes = db.table(Table.ChainMmrNodes);
+const tags = db.table(Table.Tags);
 
-export { 
+export {
     db,
-    accountCodes, 
-    accountStorages, 
-    accountVaults, 
-    accountAuths, 
-    accounts, 
+    accountCodes,
+    accountStorages,
+    accountVaults,
+    accountAuths,
+    accounts,
     transactions,
     transactionScripts,
     inputNotes,
@@ -85,4 +88,5 @@ export {
     stateSync,
     blockHeaders,
     chainMmrNodes,
+    tags,
 };

--- a/crates/rust-client/src/store/web_store/js/sync.js
+++ b/crates/rust-client/src/store/web_store/js/sync.js
@@ -62,7 +62,7 @@ export async function removeNoteTag(
         let tagHashArray = new Uint8Array(tag);
         let tagHashBase64 = uint8ArrayToBase64(tagHashArray);
 
-        await tags.delete({ tag: tagHashBase64, source_note_id, source_account_id });
+        return await tags.where({ tag: tagHashBase64, source_note_id, source_account_id }).delete();
     } catch {
         console.error("Failed to remove note tag: ", err);
         throw err;

--- a/crates/rust-client/src/store/web_store/js/sync.js
+++ b/crates/rust-client/src/store/web_store/js/sync.js
@@ -13,7 +13,13 @@ export async function getNoteTags() {
     try {
         let records = await tags.toArray();
 
-        return records;
+        let processedRecords = records.map((record) => {
+            record.source_note_id = record.source_note_id == "" ? null : record.source_note_id;
+            record.source_account_id = record.source_account_id == "" ? null : record.source_account_id;
+            return record;
+        });
+
+        return processedRecords;
     } catch (error) {
         console.error('Error fetching tag record:', error.toString());
         return null;
@@ -45,8 +51,11 @@ export async function addNoteTag(
     try {
         let tagArray = new Uint8Array(tag);
         let tagBase64 = uint8ArrayToBase64(tagArray);
-
-        await tags.add({ tag: tagBase64, source_note_id, source_account_id  });
+        await tags.add({
+            tag: tagBase64,
+            source_note_id: source_note_id ? source_note_id : "",
+            source_account_id: source_account_id ? source_account_id : ""
+        });
     } catch {
         console.error("Failed to add note tag: ", err);
         throw err;
@@ -59,12 +68,16 @@ export async function removeNoteTag(
     source_account_id
 ) {
     try {
-        let tagHashArray = new Uint8Array(tag);
-        let tagHashBase64 = uint8ArrayToBase64(tagHashArray);
+        let tagArray = new Uint8Array(tag);
+        let tagBase64 = uint8ArrayToBase64(tagArray);
 
-        return await tags.where({ tag: tagHashBase64, source_note_id, source_account_id }).delete();
+        return await tags.where({
+            tag: tagBase64,
+            source_note_id: source_note_id ? source_note_id : "",
+            source_account_id: source_account_id ? source_account_id : ""
+        }).delete();
     } catch {
-        console.error("Failed to remove note tag: ", err);
+        console.log("Failed to remove note tag: ", err.toString());
         throw err;
     }
 }

--- a/crates/rust-client/src/store/web_store/js/sync.js
+++ b/crates/rust-client/src/store/web_store/js/sync.js
@@ -39,16 +39,14 @@ export async function getSyncHeight() {
 
 export async function addNoteTag(
     tag,
-    source
+    source_note_id,
+    source_account_id
 ) {
     try {
         let tagArray = new Uint8Array(tag);
         let tagBase64 = uint8ArrayToBase64(tagArray);
 
-        let sourceArray = new Uint8Array(source);
-        let sourceBase64 = uint8ArrayToBase64(sourceArray);
-
-        await tags.add({ tag: tagBase64, source: sourceBase64 });
+        await tags.add({ tag: tagBase64, source_note_id, source_account_id  });
     } catch {
         console.error("Failed to add note tag: ", err);
         throw err;
@@ -57,18 +55,16 @@ export async function addNoteTag(
 
 export async function removeNoteTag(
     tag,
-    source
+    source_note_id,
+    source_account_id
 ) {
     try {
         let tagHashArray = new Uint8Array(tag);
         let tagHashBase64 = uint8ArrayToBase64(tagHashArray);
 
-        let sourceHashArray = new Uint8Array(source);
-        let sourceHashBase64 = uint8ArrayToBase64(sourceHashArray);
-
-        await tags.delete({ tag: tagHashBase64, source: sourceHashBase64 });
+        await tags.delete({ tag: tagHashBase64, source_note_id, source_account_id });
     } catch {
-        console.error("Failed to add note tag: ", err);
+        console.error("Failed to remove note tag: ", err);
         throw err;
     }
 }
@@ -264,6 +260,9 @@ async function updateCommittedNotes(
                 inclusionProof: inclusionProofBlob,
                 metadata: metadataBlob
             });
+
+            // Remove note tags
+            await tags.delete({ source_note_id: noteId });
         }
     } catch (error) {
         console.error("Error updating committed notes:", error);

--- a/crates/rust-client/src/store/web_store/mod.rs
+++ b/crates/rust-client/src/store/web_store/mod.rs
@@ -5,7 +5,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use miden_objects::{
     accounts::{Account, AccountHeader, AccountId, AuthSecretKey},
     crypto::merkle::{InOrderIndex, MmrPeaks},
-    notes::{NoteTag, Nullifier},
+    notes::Nullifier,
     BlockHeader, Digest, Word,
 };
 use wasm_bindgen::prelude::*;
@@ -17,7 +17,7 @@ use super::{
     TransactionFilter,
 };
 use crate::{
-    sync::StateSyncUpdate,
+    sync::{NoteTagRecord, StateSyncUpdate},
     transactions::{TransactionRecord, TransactionResult},
 };
 
@@ -47,17 +47,17 @@ impl Store for WebStore {
     // SYNC
     // --------------------------------------------------------------------------------------------
     #[maybe_async]
-    fn get_note_tags(&self) -> Result<Vec<NoteTag>, StoreError> {
+    fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, StoreError> {
         self.get_note_tags().await
     }
 
     #[maybe_async]
-    fn add_note_tag(&self, tag: NoteTag) -> Result<bool, StoreError> {
+    fn add_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError> {
         self.add_note_tag(tag).await
     }
 
     #[maybe_async]
-    fn remove_note_tag(&self, tag: NoteTag) -> Result<bool, StoreError> {
+    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError> {
         self.remove_note_tag(tag).await
     }
 

--- a/crates/rust-client/src/store/web_store/mod.rs
+++ b/crates/rust-client/src/store/web_store/mod.rs
@@ -57,7 +57,7 @@ impl Store for WebStore {
     }
 
     #[maybe_async]
-    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<bool, StoreError> {
+    fn remove_note_tag(&self, tag: NoteTagRecord) -> Result<usize, StoreError> {
         self.remove_note_tag(tag).await
     }
 

--- a/crates/rust-client/src/store/web_store/sync/js_bindings.rs
+++ b/crates/rust-client/src/store/web_store/sync/js_bindings.rs
@@ -22,7 +22,7 @@ extern "C" {
     // ================================================================================================
 
     #[wasm_bindgen(js_name = addNoteTag)]
-    pub fn idxdb_add_note_tag(tags: Vec<u8>) -> js_sys::Promise;
+    pub fn idxdb_add_note_tag(tag: Vec<u8>, source: Vec<u8>) -> js_sys::Promise;
 
     #[wasm_bindgen(js_name = applyStateSync)]
     pub fn idxdb_apply_state_sync(
@@ -42,4 +42,9 @@ extern "C" {
         transactions_to_commit: Vec<String>,
         transactions_to_commit_block_nums: Vec<String>,
     ) -> js_sys::Promise;
+
+    // DELETES
+    // ================================================================================================
+    #[wasm_bindgen(js_name = removeNoteTag)]
+    pub fn idxdb_remove_note_tag(tag: Vec<u8>, source: Vec<u8>) -> js_sys::Promise;
 }

--- a/crates/rust-client/src/store/web_store/sync/js_bindings.rs
+++ b/crates/rust-client/src/store/web_store/sync/js_bindings.rs
@@ -22,7 +22,11 @@ extern "C" {
     // ================================================================================================
 
     #[wasm_bindgen(js_name = addNoteTag)]
-    pub fn idxdb_add_note_tag(tag: Vec<u8>, source: Vec<u8>) -> js_sys::Promise;
+    pub fn idxdb_add_note_tag(
+        tag: Vec<u8>,
+        source_note_id: Option<String>,
+        source_account_id: Option<String>,
+    ) -> js_sys::Promise;
 
     #[wasm_bindgen(js_name = applyStateSync)]
     pub fn idxdb_apply_state_sync(
@@ -46,5 +50,9 @@ extern "C" {
     // DELETES
     // ================================================================================================
     #[wasm_bindgen(js_name = removeNoteTag)]
-    pub fn idxdb_remove_note_tag(tag: Vec<u8>, source: Vec<u8>) -> js_sys::Promise;
+    pub fn idxdb_remove_note_tag(
+        tag: Vec<u8>,
+        source_note_id: Option<String>,
+        source_account_id: Option<String>,
+    ) -> js_sys::Promise;
 }

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -93,19 +93,9 @@ impl WebStore {
         };
 
         let promise = idxdb_remove_note_tag(tag.tag.to_bytes(), source_note_id, source_account_id);
-        let removed_tags = JsFuture::from(promise)
-            .await
-            .map_err(|js_error| {
-                StoreError::DatabaseError(format!("Failed to remove tags: {:?}", js_error))
-            })?
-            .as_string()
-            .ok_or(StoreError::ParsingError(
-                "Failed to parse number of removed tags".to_string(),
-            ))?;
+        let removed_tags = from_value(JsFuture::from(promise).await.unwrap()).unwrap();
 
-        removed_tags.parse::<usize>().map_err(|_| {
-            StoreError::ParsingError("Failed to parse number of removed tags".to_string())
-        })
+        Ok(removed_tags)
     }
 
     pub(super) async fn apply_state_sync(

--- a/crates/rust-client/src/store/web_store/sync/models.rs
+++ b/crates/rust-client/src/store/web_store/sync/models.rs
@@ -9,21 +9,19 @@ pub struct SyncHeightIdxdbObject {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct NoteTagsIdxdbObject {
-    #[serde(deserialize_with = "base64_to_vec_u8_optional", default)]
-    pub tags: Option<Vec<u8>>,
+pub struct NoteTagIdxdbObject {
+    #[serde(deserialize_with = "base64_to_vec_u8_required", default)]
+    pub tag: Vec<u8>,
+    #[serde(deserialize_with = "base64_to_vec_u8_required", default)]
+    pub source: Vec<u8>,
 }
 
-fn base64_to_vec_u8_optional<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+fn base64_to_vec_u8_required<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let base64_str: Option<String> = Option::deserialize(deserializer)?;
-    match base64_str {
-        Some(str) => general_purpose::STANDARD
-            .decode(&str)
-            .map(Some)
-            .map_err(|e| Error::custom(format!("Base64 decode error: {}", e))),
-        None => Ok(None),
-    }
+    let base64_str: String = Deserialize::deserialize(deserializer)?;
+    general_purpose::STANDARD
+        .decode(&base64_str)
+        .map_err(|e| Error::custom(format!("Base64 decode error: {}", e)))
 }

--- a/crates/rust-client/src/store/web_store/sync/models.rs
+++ b/crates/rust-client/src/store/web_store/sync/models.rs
@@ -12,8 +12,8 @@ pub struct SyncHeightIdxdbObject {
 pub struct NoteTagIdxdbObject {
     #[serde(deserialize_with = "base64_to_vec_u8_required", default)]
     pub tag: Vec<u8>,
-    #[serde(deserialize_with = "base64_to_vec_u8_required", default)]
-    pub source: Vec<u8>,
+    pub source_note_id: Option<String>,
+    pub source_account_id: Option<String>,
 }
 
 fn base64_to_vec_u8_required<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>

--- a/crates/rust-client/src/store/web_store/transactions/mod.rs
+++ b/crates/rust-client/src/store/web_store/transactions/mod.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::{
     store::{ExpectedNoteState, NoteFilter, NoteState, StoreError, TransactionFilter},
-    sync::{NoteTagRecord, NoteTagSource},
+    sync::NoteTagRecord,
     transactions::{TransactionRecord, TransactionResult, TransactionStatus},
 };
 
@@ -127,11 +127,7 @@ impl WebStore {
         // Updates for notes
         for note in created_input_notes {
             if let NoteState::Expected(ExpectedNoteState { tag: Some(tag), .. }) = note.state() {
-                self.add_note_tag(NoteTagRecord {
-                    tag: *tag,
-                    source: NoteTagSource::Note(note.id()),
-                })
-                .await?;
+                self.add_note_tag(NoteTagRecord::with_note_source(*tag, note.id())).await?;
             }
             upsert_input_note_tx(note).await?;
         }

--- a/crates/rust-client/src/store/web_store/transactions/mod.rs
+++ b/crates/rust-client/src/store/web_store/transactions/mod.rs
@@ -14,7 +14,8 @@ use super::{
     WebStore,
 };
 use crate::{
-    store::{NoteFilter, StoreError, TransactionFilter},
+    store::{ExpectedNoteState, NoteFilter, NoteState, StoreError, TransactionFilter},
+    sync::{NoteTagRecord, NoteTagSource},
     transactions::{TransactionRecord, TransactionResult, TransactionStatus},
 };
 
@@ -125,6 +126,13 @@ impl WebStore {
 
         // Updates for notes
         for note in created_input_notes {
+            if let NoteState::Expected(ExpectedNoteState { tag: Some(tag), .. }) = note.state() {
+                self.add_note_tag(NoteTagRecord {
+                    tag: *tag,
+                    source: NoteTagSource::Note(note.id()),
+                })
+                .await?;
+            }
             upsert_input_note_tx(note).await?;
         }
 

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -232,7 +232,8 @@ impl<R: FeltRng> Client<R> {
             .map(|(acc_header, _)| acc_header)
             .collect();
 
-        let note_tags: Vec<NoteTag> = maybe_await!(self.get_tracked_note_tags())?;
+        let note_tags: Vec<NoteTag> =
+            maybe_await!(self.get_unique_note_tags())?.into_iter().collect();
 
         // To receive information about added nullifiers, we reduce them to the higher 16 bits
         // Note that besides filtering by nullifier prefixes, the node also filters by block number

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -30,6 +30,7 @@ mod block_headers;
 use block_headers::apply_mmr_changes;
 
 mod tags;
+pub use tags::{NoteTagRecord, NoteTagSource};
 
 /// Contains stats about the sync operation.
 pub struct SyncSummary {

--- a/crates/rust-client/src/sync/tags.rs
+++ b/crates/rust-client/src/sync/tags.rs
@@ -1,8 +1,13 @@
 use alloc::{collections::BTreeSet, vec::Vec};
 
 use miden_objects::{
+    accounts::AccountId,
     crypto::rand::FeltRng,
-    notes::{NoteExecutionMode, NoteTag},
+    notes::{NoteExecutionMode, NoteId, NoteTag},
+};
+use miden_tx::{
+    auth::TransactionAuthenticator,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 use tracing::warn;
 use winter_maybe_async::{maybe_async, maybe_await};
@@ -19,14 +24,18 @@ impl<R: FeltRng> Client<R> {
     /// the client and do not need to be added here. That is, notes for managed accounts will be
     /// retrieved automatically by the client when syncing.
     #[maybe_async]
-    pub fn get_note_tags(&self) -> Result<Vec<NoteTag>, ClientError> {
+    pub fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, ClientError> {
         maybe_await!(self.store.get_note_tags()).map_err(|err| err.into())
     }
 
     /// Adds a note tag for the client to track.
     #[maybe_async]
     pub fn add_note_tag(&mut self, tag: NoteTag) -> Result<(), ClientError> {
-        match maybe_await!(self.store.add_note_tag(tag)).map_err(|err| err.into()) {
+        match maybe_await!(self
+            .store
+            .add_note_tag(NoteTagRecord { tag, source: NoteTagSource::User }))
+        .map_err(|err| err.into())
+        {
             Ok(true) => Ok(()),
             Ok(false) => {
                 warn!("Tag {} is already being tracked", tag);
@@ -39,19 +48,20 @@ impl<R: FeltRng> Client<R> {
     /// Removes a note tag for the client to track.
     #[maybe_async]
     pub fn remove_note_tag(&mut self, tag: NoteTag) -> Result<(), ClientError> {
-        match maybe_await!(self.store.remove_note_tag(tag))? {
-            true => Ok(()),
-            false => {
-                warn!("Tag {} wasn't being tracked", tag);
-                Ok(())
-            },
+        if !maybe_await!(self
+            .store
+            .remove_note_tag(NoteTagRecord { tag, source: NoteTagSource::User }))?
+        {
+            warn!("Tag {} wasn't being tracked", tag);
         }
+
+        Ok(())
     }
 
     /// Returns the list of note tags tracked by the client.
     #[maybe_async]
     pub(crate) fn get_tracked_note_tags(&self) -> Result<Vec<NoteTag>, ClientError> {
-        let stored_tags = maybe_await!(self.get_note_tags())?;
+        let stored_tags = maybe_await!(self.get_note_tags())?.into_iter().map(|r| r.tag).collect();
 
         let account_tags = maybe_await!(self.get_account_headers())?
             .into_iter()
@@ -71,5 +81,51 @@ impl<R: FeltRng> Client<R> {
             .collect::<BTreeSet<NoteTag>>()
             .into_iter()
             .collect())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct NoteTagRecord {
+    pub tag: NoteTag,
+    pub source: NoteTagSource,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum NoteTagSource {
+    Account(AccountId),
+    Note(NoteId),
+    User,
+}
+
+impl Serializable for NoteTagSource {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            NoteTagSource::Account(account_id) => {
+                target.write_u8(0);
+                account_id.write_into(target);
+            },
+            NoteTagSource::Note(note_id) => {
+                target.write_u8(1);
+                note_id.write_into(target);
+            },
+            NoteTagSource::User => target.write_u8(2),
+        }
+    }
+}
+
+impl Deserializable for NoteTagSource {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        match source.read_u8()? {
+            0 => Ok(NoteTagSource::Account(AccountId::read_from(source)?)),
+            1 => Ok(NoteTagSource::Note(NoteId::read_from(source)?)),
+            2 => Ok(NoteTagSource::User),
+            val => Err(DeserializationError::InvalidValue(format!("Invalid tag source: {}", val))),
+        }
+    }
+}
+
+impl PartialEq<NoteTag> for NoteTagRecord {
+    fn eq(&self, other: &NoteTag) -> bool {
+        self.tag == *other
     }
 }

--- a/crates/rust-client/src/sync/tags.rs
+++ b/crates/rust-client/src/sync/tags.rs
@@ -67,12 +67,15 @@ impl<R: FeltRng> Client<R> {
     }
 }
 
+/// Represents a note tag of which the Store can keep track and retrieve.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct NoteTagRecord {
     pub tag: NoteTag,
     pub source: NoteTagSource,
 }
 
+/// Represents the source of the tag. This is used to differentiate between tags that are added by
+/// the user and tags that are added automatically by the client to track notes .
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum NoteTagSource {
     Account(AccountId),

--- a/crates/rust-client/src/sync/tags.rs
+++ b/crates/rust-client/src/sync/tags.rs
@@ -25,6 +25,12 @@ impl<R: FeltRng> Client<R> {
         maybe_await!(self.store.get_note_tags()).map_err(|err| err.into())
     }
 
+    /// Returns the unique note tags (without source) that the client is interested in.
+    #[maybe_async]
+    pub fn get_unique_note_tags(&self) -> Result<BTreeSet<NoteTag>, ClientError> {
+        maybe_await!(self.store.get_unique_note_tags()).map_err(|err| err.into())
+    }
+
     /// Adds a note tag for the client to track.
     #[maybe_async]
     pub fn add_note_tag(&mut self, tag: NoteTag) -> Result<(), ClientError> {
@@ -54,17 +60,6 @@ impl<R: FeltRng> Client<R> {
         }
 
         Ok(())
-    }
-
-    /// Returns the list of note tags tracked by the client.
-    #[maybe_async]
-    pub(crate) fn get_tracked_note_tags(&self) -> Result<Vec<NoteTag>, ClientError> {
-        Ok(maybe_await!(self.get_note_tags())?
-            .into_iter()
-            .map(|r| r.tag)
-            .collect::<BTreeSet<NoteTag>>()
-            .into_iter()
-            .collect())
     }
 }
 

--- a/crates/rust-client/src/sync/tags.rs
+++ b/crates/rust-client/src/sync/tags.rs
@@ -45,9 +45,10 @@ impl<R: FeltRng> Client<R> {
     /// Removes a note tag for the client to track.
     #[maybe_async]
     pub fn remove_note_tag(&mut self, tag: NoteTag) -> Result<(), ClientError> {
-        if !maybe_await!(self
+        if maybe_await!(self
             .store
             .remove_note_tag(NoteTagRecord { tag, source: NoteTagSource::User }))?
+            == 0
         {
             warn!("Tag {} wasn't being tracked", tag);
         }
@@ -78,9 +79,28 @@ pub struct NoteTagRecord {
 /// the user and tags that are added automatically by the client to track notes .
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum NoteTagSource {
+    /// Tag for notes directed to a tracked account.
     Account(AccountId),
+    /// Tag for tracked expected notes.
     Note(NoteId),
+    /// Tag manually added by the user.
     User,
+}
+
+impl NoteTagRecord {
+    pub fn with_note_source(tag: NoteTag, note_id: NoteId) -> Self {
+        Self {
+            tag,
+            source: NoteTagSource::Note(note_id),
+        }
+    }
+
+    pub fn with_account_source(tag: NoteTag, account_id: AccountId) -> Self {
+        Self {
+            tag,
+            source: NoteTagSource::Account(account_id),
+        }
+    }
 }
 
 impl Serializable for NoteTagSource {

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -336,7 +336,7 @@ async fn test_tags() {
     let (mut client, _rpc_api) = create_test_client();
 
     // Assert that the store gets created with the tag 0 (used for notes consumable by any account)
-    assert_eq!(client.get_note_tags().unwrap(), vec![]);
+    assert!(client.get_note_tags().unwrap().is_empty());
 
     // add a tag
     let tag_1: NoteTag = 1.into();

--- a/crates/web-client/src/tags.rs
+++ b/crates/web-client/src/tags.rs
@@ -31,7 +31,13 @@ impl WebClient {
 
     pub async fn list_tags(&mut self) -> Result<JsValue, JsValue> {
         if let Some(client) = self.get_mut_inner() {
-            let tags: Vec<NoteTag> = client.get_note_tags().await.unwrap();
+            let tags: Vec<NoteTag> = client
+                .get_note_tags()
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|tag_record| tag_record.tag)
+                .collect();
 
             // call toString() on each tag
             let result = tags.iter().map(|tag| tag.to_string()).collect::<Vec<String>>();

--- a/crates/web-client/test/mocha.global.setup.mjs
+++ b/crates/web-client/test/mocha.global.setup.mjs
@@ -40,13 +40,13 @@ before(async () => {
   // Creates the client in the test context and attach to window object
   await testingPage.exposeFunction("create_client", async () => {
     await testingPage.evaluate(async (port) => {
-      const { 
+      const {
         Account,
-        AccountHeader, 
-        AccountStorageMode, 
-        AuthSecretKey, 
+        AccountHeader,
+        AccountStorageMode,
+        AuthSecretKey,
         TestUtils,
-        WebClient 
+        WebClient
       } = await import("./index.js");
       let rpc_url = `http://localhost:${port}`;
       const client = new WebClient();

--- a/crates/web-client/test/tags.test.ts
+++ b/crates/web-client/test/tags.test.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import { testingPage } from "./mocha.global.setup.mjs";
+
+// ADD_TAG TESTS
+// =======================================================================================================
+
+interface AddTagSuccessResult {
+    tag: string;
+    tags: string[];
+}
+
+export const addTag = async (tag: string): Promise<AddTagSuccessResult> => {
+    return await testingPage.evaluate(async (tag) => {
+        if (!window.client) {
+            await window.create_client();
+        }
+
+        const client = window.client;
+        await client.add_tag(tag);
+        const tags = await client.list_tags();
+
+        return {
+            tag: tag,
+            tags: tags
+        };
+    }, tag);
+};
+
+describe("add_tag tests", () => {
+    it("adds a tag to the system", async () => {
+        const tag = "123";
+        const result = await addTag(tag);
+
+        expect(result.tags).to.include(tag);
+    });
+});
+
+// REMOVE_TAG TESTS
+// =======================================================================================================
+
+interface RemoveTagSuccessResult {
+    tag: string;
+    tags: string[];
+}
+
+export const removeTag = async (tag: string): Promise<RemoveTagSuccessResult> => {
+    return await testingPage.evaluate(async (tag) => {
+        if (!window.client) {
+            await window.create_client();
+        }
+
+        const client = window.client;
+        await client.add_tag(tag);
+        await client.remove_tag(tag);
+
+        const tags = await client.list_tags();
+
+        return {
+            tag: tag,
+            tags: tags
+        };
+    }, tag);
+};
+
+describe("remove_tag tests", () => {
+    it("removes a tag from the system", async () => {
+        const tag = "321";
+        const result = await removeTag(tag);
+
+        expect(result.tags).to.not.include(tag);
+    });
+});

--- a/crates/web-client/yarn.lock
+++ b/crates/web-client/yarn.lock
@@ -145,9 +145,9 @@
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/chai-as-promised@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-8.0.0.tgz#52d399a5fe4a0ec5a2d18638711814b2fa2da821"
-  integrity sha512-YbYaXFqJwSABp9OXQTVrPPmstZgNjkRieWVd/xAl5Yc/e5+F44bXLeQggpvm0sjsS1bg+2Y5cwU+rquwwD2dXA==
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-8.0.1.tgz"
+  integrity sha512-dAlDhLjJlABwAVYObo9TPWYTRg9NaQM5CXeaeJYcYAkvzUf0JRLIiog88ao2Wqy/20WUnhbbUZcgvngEbJ3YXQ==
   dependencies:
     "@types/chai" "*"
 
@@ -427,12 +427,12 @@ camelcase@^6.0.0:
 
 chai-as-promised@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-8.0.0.tgz#7eda823f2a6fe9fd3a76bc76878886e955232e6f"
+  resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.0.tgz"
   integrity sha512-sMsGXTrS3FunP/wbqh/KxM8Kj/aLPXQGkNtvE5wPfSToq8wkkvBpTZo1LIiEVmC4BwkKpag+l5h/20lBMk6nUg==
   dependencies:
     check-error "^2.0.0"
 
-chai@^5.1.1:
+chai@^5.1.1, "chai@>= 2.1.2 < 6":
   version "5.1.1"
   resolved "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz"
   integrity sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==
@@ -1177,13 +1177,11 @@ jackspeak@^3.1.2:
     "@pkgjs/parseargs" "^0.11.0"
 
 jackspeak@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz"
-  integrity sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz"
+  integrity sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
-  optionalDependencies:
-    "@pkgjs/parseargs" "^0.11.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -1254,9 +1252,9 @@ lru-cache@^10.2.0:
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz"
-  integrity sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==
+  version "11.0.1"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz"
+  integrity sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==
 
 lru-cache@^7.14.1:
   version "7.18.3"
@@ -1320,15 +1318,15 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
-
-minipass@^5.0.0:
+minipass@^5.0.0, "minipass@^5.0.0 || ^6.0.2 || ^7.0.0":
   version "5.0.0"
   resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 minizlib@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
closes #484 

This PR looks to refactor the way we deal with note tags in the client. Previously, the note tag list sent to the node was built from zero each time, joining tags derived from accounts+notes and tags added by the user. This refactor creates a new table in the store that stores all of the tracked tags, including those derived from accounts and notes.

A new struct is introduced to represent the stored tags:
```rust
/// Represents a note tag of which the Store can keep track and retrieve.
pub struct NoteTagRecord {
    pub tag: NoteTag,
    pub source: NoteTagSource,
}

/// Represents the source of the tag. This is used to differentiate between tags that are added by
/// the user and tags that are added automatically by the client to track notes .
pub enum NoteTagSource {
    Account(AccountId),
    Note(NoteId),
    User,
}
```

The `source` field let's us keep track of where the tag comes from, the same tag may be added by different sources. The tags table is always updated with client changes like:
- New notes/accounts which add new tags to the table
- Committed notes which remove the tag from the table (we no longer need to track them)
- Tags manually added/removed by the user