### PR TITLE
feat: improve build time for testing

### DIFF
--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf dist && rollup -c rollup.config.js && cpr js/types dist && node clean.js",
     "test": "node --loader ts-node/esm --loader esm ./node_modules/mocha/bin/mocha --file ./test/mocha.global.setup.mjs",
     "test:logs": "DEBUG_MODE=true node --loader ts-node/esm --loader esm ./node_modules/mocha/bin/mocha --file ./test/mocha.global.setup.mjs",
-    "test:clean": "npm install && npm run build && node --loader ts-node/esm --loader esm ./node_modules/mocha/bin/mocha --file ./test/mocha.global.setup.mjs"
+    "test:clean": "npm install && MIDEN_WEB_TESTING=true npm run build && node --loader ts-node/esm --loader esm ./node_modules/mocha/bin/mocha --file ./test/mocha.global.setup.mjs"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/crates/web-client/rollup.config.js
+++ b/crates/web-client/rollup.config.js
@@ -2,13 +2,16 @@ import rust from "@wasm-tool/rollup-plugin-rust";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 
+// Flag that indicates if the build is meant for testing purposes.
 const testing = process.env.MIDEN_WEB_TESTING === 'true';
 
 /**
  * Rollup configuration file for building a Cargo project and creating a WebAssembly (WASM) module.
  * The configuration sets up two build processes:
  * 1. Compiling Rust code into WASM using the @wasm-tool/rollup-plugin-rust plugin, with specific
- *    cargo arguments to enable WebAssembly features and set maximum memory limits.
+ *    cargo arguments to enable WebAssembly features and set maximum memory limits. If the build is
+ *    meant for testing, the WASM optimization level is set to 0 to improve build times, this is
+ *    aimed at reducing the feedback loop during development.
  * 2. Resolving and bundling the generated WASM module along with the main JavaScript file
  *    (`index.js`) into the `dist` directory.
  *

--- a/crates/web-client/rollup.config.js
+++ b/crates/web-client/rollup.config.js
@@ -2,6 +2,8 @@ import rust from "@wasm-tool/rollup-plugin-rust";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 
+const testing = process.env.MIDEN_WEB_TESTING === 'true';
+
 /**
  * Rollup configuration file for building a Cargo project and creating a WebAssembly (WASM) module.
  * The configuration sets up two build processes:
@@ -36,6 +38,8 @@ export default [
                 experimental: {
                     typescriptDeclarationDir: "dist/crates",
                 },
+
+                wasmOptArgs: testing ? ["-O0"] : null,
             }),
             resolve(),
             commonjs(),


### PR DESCRIPTION
This PR adds a flag to remove wasm optimizations when running the `npm run build` command when testing. This marginally increases the individual test time but it greatly reduces the time to build the wasm files which is a net positive.