### PR TITLE
fix: Error handling for web client sync state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+* Added better error handling for WASM sync state 
 * Added WASM Input note tests + updated input note models (#554)
 * Added new variants for the `NoteFilter` struct (#538).
 * [BREAKING] Added note tags for future notes in `TransactionRequest` (#538).

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",

--- a/crates/web-client/src/sync.rs
+++ b/crates/web-client/src/sync.rs
@@ -6,7 +6,10 @@ use crate::{models::sync_summary::SyncSummary, WebClient};
 impl WebClient {
     pub async fn sync_state(&mut self) -> Result<SyncSummary, JsValue> {
         if let Some(client) = self.get_mut_inner() {
-            let sync_summary = client.sync_state().await.unwrap();
+            let sync_summary = client
+                .sync_state()
+                .await
+                .map_err(|err| JsValue::from_str(&format!("Failed to sync state: {}", err)))?;
 
             Ok(sync_summary.into())
         } else {


### PR DESCRIPTION
Small PR to add error handling for sync state so that js client doesnt silently fail 