### PR TITLE
feat: Adding remote proving + improving note models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (TBD)
 
+* Added delegated proving for web client + improved note models (#566).
 * Allow to set expiration delta for `TransactionRequest` (#553).
 * Added WASM consumable notes API + improved note models (#561).
 * [BREAKING] Refactored `OutputNoteRecord` to use states and transitions for updates (#551).

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -22,6 +22,7 @@ getrandom = { version = "0.2", features = ["js"] }
 miden-client = { path = "../rust-client", version = "0.5", default-features = false, features = ["idxdb", "web-tonic", "testing"] }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
+miden-tx-prover = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", features = ["async", "testing"], default-features = false }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",

--- a/crates/web-client/src/models/input_note_record.rs
+++ b/crates/web-client/src/models/input_note_record.rs
@@ -1,7 +1,10 @@
 use miden_client::store::InputNoteRecord as NativeInputNoteRecord;
 use wasm_bindgen::prelude::*;
 
-use super::{input_note_state::InputNoteState, note_details::NoteDetails, note_id::NoteId};
+use super::{
+    input_note_state::InputNoteState, note_details::NoteDetails, note_id::NoteId,
+    note_metadata::NoteMetadata,
+};
 
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -19,6 +22,13 @@ impl InputNoteRecord {
 
     pub fn details(&self) -> NoteDetails {
         self.0.details().into()
+    }
+
+    pub fn metadata(&self) -> Option<NoteMetadata> {
+        match self.0.metadata() {
+            Some(metadata) => Some(metadata.into()),
+            None => None,
+        }
     }
 }
 

--- a/crates/web-client/src/models/input_note_record.rs
+++ b/crates/web-client/src/models/input_note_record.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use super::{
     input_note_state::InputNoteState, note_details::NoteDetails, note_id::NoteId,
-    note_metadata::NoteMetadata,
+    note_inclusion_proof::NoteInclusionProof, note_metadata::NoteMetadata,
 };
 
 #[derive(Clone)]
@@ -25,10 +25,31 @@ impl InputNoteRecord {
     }
 
     pub fn metadata(&self) -> Option<NoteMetadata> {
-        match self.0.metadata() {
-            Some(metadata) => Some(metadata.into()),
-            None => None,
-        }
+        self.0.metadata().map(|metadata| metadata.into())
+    }
+
+    pub fn inclusion_proof(&self) -> Option<NoteInclusionProof> {
+        self.0.inclusion_proof().map(|proof| proof.into())
+    }
+
+    pub fn consumer_transaction_id(&self) -> Option<String> {
+        self.0.consumer_transaction_id().map(|id| id.to_string())
+    }
+
+    pub fn nullifier(&self) -> String {
+        self.0.nullifier().to_hex()
+    }
+
+    pub fn is_authenticated(&self) -> bool {
+        self.0.is_authenticated()
+    }
+
+    pub fn is_consumed(&self) -> bool {
+        self.0.is_consumed()
+    }
+
+    pub fn is_processing(&self) -> bool {
+        self.0.is_processing()
     }
 }
 


### PR DESCRIPTION
Bringing in the ability to create a web client with a remote proving url 

Tested this manually via spinning up a local proving node and pointing to it in some integration tests. 

On the backlog is to create a fully fledged integration test for this. The reason why its not included in this PR is that it would require us to set up a Makefile command to spin up a remote prover within the github actions context and then setup our test infra to toggle between the clients. 

This will be a fast-follow on our backlog, but to enable delegated proving for the Devcon wallet, putting up the PR in its current state. 