### PR TITLE
fix: genesis account name

### DIFF
--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -151,7 +151,7 @@ fn test_mint_with_untracked_account() {
 // ================================================================================================
 
 // Only one faucet is being created on the genesis block
-const GENESIS_ACCOUNTS_FILENAMES: [&str; 1] = ["account0.mac"];
+const GENESIS_ACCOUNTS_FILENAMES: [&str; 1] = ["faucet.mac"];
 
 // This tests that it's possible to import the genesis accounts and interact with them. To do so it:
 //


### PR DESCRIPTION
After https://github.com/0xPolygonMiden/miden-node/pull/517 got merged, the genesis account name changed from `account0.mac` to `faucet.mac`