### PR TITLE
fix: remove `NoteFilter::List` error from web store

### DIFF
--- a/crates/rust-client/src/store/web_store/notes/mod.rs
+++ b/crates/rust-client/src/store/web_store/notes/mod.rs
@@ -41,15 +41,6 @@ impl WebStore {
                 NoteFilter::Unique(note_id) if notes.is_empty() => {
                     return Err(StoreError::NoteNotFound(*note_id));
                 },
-                NoteFilter::List(note_ids) if note_ids.len() != notes.len() => {
-                    let missing_note_id = note_ids
-                        .iter()
-                        .find(|&&note_id| {
-                            !notes.iter().any(|note_record| note_record.id() == note_id)
-                        })
-                        .expect("should find one note id that wasn't retrieved by the db");
-                    return Err(StoreError::NoteNotFound(*missing_note_id));
-                },
                 _ => {},
             },
             Err(e) => return Err(e),
@@ -75,15 +66,6 @@ impl WebStore {
             Ok(ref notes) => match filter {
                 NoteFilter::Unique(note_id) if notes.is_empty() => {
                     return Err(StoreError::NoteNotFound(note_id));
-                },
-                NoteFilter::List(note_ids) if note_ids.len() != notes.len() => {
-                    let missing_note_id = note_ids
-                        .iter()
-                        .find(|&&note_id| {
-                            !notes.iter().any(|note_record| note_record.id() == note_id)
-                        })
-                        .expect("should find one note id that wasn't retrieved by the db");
-                    return Err(StoreError::NoteNotFound(*missing_note_id));
                 },
                 _ => {},
             },


### PR DESCRIPTION
In #559 we changed the way `NoteFilter::List` behaved when it didn't find every listed note. Originally it returned an error but in that PR we changed it so that it just returned an incomplete list. The sqlite store was updated but we didn't remove the error from the idxdb store.

The test was flaky because it was failing here: 
https://github.com/0xPolygonMiden/miden-client/blob/db8454a08b8e8723b8e7b6cf7a77b7c78c036f0c/crates/rust-client/src/sync/mod.rs#L290-L294 

Where the notes returned by the node may or may not exist in the store. Depending on the state of the node at a given moment, it may return notes that are not relevant to the client.