### PR TITLE
Added Sync Loop to Web Client Integration Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,8 @@
 
 ### Features
 
-* Added Sync Loop to Integration Tests for Small Speedup (#590).
 * Added FPI (Foreign Procedure Invocation) support for `TransactionRequest` (#560).
 * [BREAKING] Added transaction prover component to `Client` (#550).
-* Added Transaction Integration Tests for Web Client (#569).
-* Moved note update logic outside of the `Store` (#559)
-* Added delegated proving for web client + improved note models (#566).
-* Allow to set expiration delta for `TransactionRequest` (#553).
 * Added WASM consumable notes API + improved note models (#561).
 * Added remote prover support to the web client with CI tests (#562).
 * Added delegated proving for web client + improved note models (#566).
@@ -21,6 +16,7 @@
 * Added support for multiple input note inserts at once (#538).
 * Added support for custom transactions in web client (#519).
 * Added support for remote proving in the CLI (#552).
+* Added Sync Loop to Integration Tests for Small Speedup (#590).
 * Added Transaction Integration Tests for Web Client (#569).
 * Added WASM Input note tests + updated input note models (#554)
 * Added Account Integration Tests for Web Client (#532).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Features
 
+* Added Sync Loop to Integration Tests for Small Speedup (#590).
 * Added FPI (Foreign Procedure Invocation) support for `TransactionRequest` (#560).
 * [BREAKING] Added transaction prover component to `Client` (#550).
+* Added Transaction Integration Tests for Web Client (#569).
+* Moved note update logic outside of the `Store` (#559)
+* Added delegated proving for web client + improved note models (#566).
+* Allow to set expiration delta for `TransactionRequest` (#553).
 * Added WASM consumable notes API + improved note models (#561).
 * Added remote prover support to the web client with CI tests (#562).
 * Added delegated proving for web client + improved note models (#566).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.0 (TBD)
+
+### Fixes
+* Added Sync Loop to Integration Tests for Small Speedup (#590).
+
 ## 0.6.0 (2024-11-08)
 
 ### Features
@@ -16,7 +21,6 @@
 * Added support for multiple input note inserts at once (#538).
 * Added support for custom transactions in web client (#519).
 * Added support for remote proving in the CLI (#552).
-* Added Sync Loop to Integration Tests for Small Speedup (#590).
 * Added Transaction Integration Tests for Web Client (#569).
 * Added WASM Input note tests + updated input note models (#554)
 * Added Account Integration Tests for Web Client (#532).

--- a/crates/web-client/test/global.test.d.ts
+++ b/crates/web-client/test/global.test.d.ts
@@ -71,6 +71,11 @@ declare global {
     TransactionScriptInputPair: typeof TransactionScriptInputPair;
     TransactionScriptInputPairArray: typeof TransactionScriptInputPairArray;
     create_client: () => Promise<void>;
+
+     // Add the helpers namespace
+     helpers: {
+      waitForTransaction: (transactionId: string, maxWaitTime?: number, delayInterval?: number) => Promise<void>;
+    };
   }
 }
 

--- a/crates/web-client/test/global.test.d.ts
+++ b/crates/web-client/test/global.test.d.ts
@@ -72,9 +72,13 @@ declare global {
     TransactionScriptInputPairArray: typeof TransactionScriptInputPairArray;
     create_client: () => Promise<void>;
 
-     // Add the helpers namespace
-     helpers: {
-      waitForTransaction: (transactionId: string, maxWaitTime?: number, delayInterval?: number) => Promise<void>;
+    // Add the helpers namespace
+    helpers: {
+      waitForTransaction: (
+        transactionId: string,
+        maxWaitTime?: number,
+        delayInterval?: number
+      ) => Promise<void>;
     };
   }
 }

--- a/crates/web-client/test/mocha.global.setup.mjs
+++ b/crates/web-client/test/mocha.global.setup.mjs
@@ -39,109 +39,117 @@ before(async () => {
   }
 
   // Creates the client in the test context and attach to window object
-  await testingPage.evaluate(async (port) => {
-    const {
-      Account,
-      AccountHeader,
-      AccountId,
-      AccountStorageMode,
-      AdviceMap,
-      AuthSecretKey,
-      ConsumableNoteRecord,
-      Felt,
-      FeltArray,
-      FungibleAsset,
-      Note,
-      NoteAssets,
-      NoteConsumability,
-      NoteExecutionHint,
-      NoteExecutionMode,
-      NoteFilter,
-      NoteFilterTypes,
-      NoteIdAndArgs,
-      NoteIdAndArgsArray,
-      NoteInputs,
-      NoteMetadata,
-      NoteRecipient,
-      NoteTag,
-      NoteType,
-      OutputNote,
-      OutputNotesArray,
-      Rpo256,
-      TestUtils,
-      TransactionFilter,
-      TransactionRequest,
-      TransactionScriptInputPair,
-      TransactionScriptInputPairArray,
-      WebClient,
-    } = await import("./index.js");
-    let rpc_url = `http://localhost:${port}`;
-    const client = new WebClient();
-    await client.create_client(rpc_url);
-
-    window.client = client;
-    window.Account = Account;
-    window.AccountHeader = AccountHeader;
-    window.AccountId = AccountId;
-    window.AccountStorageMode = AccountStorageMode;
-    window.AdviceMap = AdviceMap;
-    window.AuthSecretKey = AuthSecretKey;
-    window.ConsumableNoteRecord = ConsumableNoteRecord;
-    window.Felt = Felt;
-    window.FeltArray = FeltArray;
-    window.FungibleAsset = FungibleAsset;
-    window.Note = Note;
-    window.NoteAssets = NoteAssets;
-    window.NoteConsumability = NoteConsumability;
-    window.NoteExecutionHint = NoteExecutionHint;
-    window.NoteExecutionMode = NoteExecutionMode;
-    window.NoteFilter = NoteFilter;
-    window.NoteFilterTypes = NoteFilterTypes;
-    window.NoteIdAndArgs = NoteIdAndArgs;
-    window.NoteIdAndArgsArray = NoteIdAndArgsArray;
-    window.NoteInputs = NoteInputs;
-    window.NoteMetadata = NoteMetadata;
-    window.NoteRecipient = NoteRecipient;
-    window.NoteTag = NoteTag;
-    window.NoteType = NoteType;
-    window.OutputNote = OutputNote;
-    window.OutputNotesArray = OutputNotesArray;
-    window.Rpo256 = Rpo256;
-    window.TestUtils = TestUtils;
-    window.TransactionFilter = TransactionFilter;
-    window.TransactionRequest = TransactionRequest;
-    window.TransactionScriptInputPair = TransactionScriptInputPair;
-    window.TransactionScriptInputPairArray = TransactionScriptInputPairArray;
-
-    // Create a namespace for helper functions
-    window.helpers = window.helpers || {};
-
-    window.helpers.waitForTransaction = async (
-      transactionId,
-      maxWaitTime = 20000,
-      delayInterval = 1000
-    ) => {
-      const client = window.client;
-      let timeWaited = 0;
-      while (true) {
-        if (timeWaited >= maxWaitTime) {
-          throw new Error("Timeout waiting for transaction");
-        }
-        await client.sync_state();
-        const uncomittedTransactions = await client.get_transactions(
-          window.TransactionFilter.uncomitted()
-        );
-        let uncomittedTransactionIds = uncomittedTransactions.map(
-          (transaction) => transaction.id().to_hex()
-        );
-        if (!uncomittedTransactionIds.includes(transactionId)) {
-          break;
-        }
-        await new Promise((r) => setTimeout(r, delayInterval));
-        timeWaited += delayInterval;
+  await testingPage.evaluate(
+    async (rpc_port, remote_prover_port) => {
+      const {
+        Account,
+        AccountHeader,
+        AccountId,
+        AccountStorageMode,
+        AdviceMap,
+        AuthSecretKey,
+        ConsumableNoteRecord,
+        Felt,
+        FeltArray,
+        FungibleAsset,
+        Note,
+        NoteAssets,
+        NoteConsumability,
+        NoteExecutionHint,
+        NoteExecutionMode,
+        NoteFilter,
+        NoteFilterTypes,
+        NoteIdAndArgs,
+        NoteIdAndArgsArray,
+        NoteInputs,
+        NoteMetadata,
+        NoteRecipient,
+        NoteTag,
+        NoteType,
+        OutputNote,
+        OutputNotesArray,
+        Rpo256,
+        TestUtils,
+        TransactionFilter,
+        TransactionRequest,
+        TransactionScriptInputPair,
+        TransactionScriptInputPairArray,
+        WebClient,
+      } = await import("./index.js");
+      let rpc_url = `http://localhost:${rpc_port}`;
+      let prover_url = null;
+      if (remote_prover_port) {
+        prover_url = `http://localhost:${remote_prover_port}`;
       }
-    };
-  }, LOCAL_MIDEN_NODE_PORT);
+      const client = new WebClient();
+      await client.create_client(rpc_url, prover_url);
+
+      window.client = client;
+      window.Account = Account;
+      window.AccountHeader = AccountHeader;
+      window.AccountId = AccountId;
+      window.AccountStorageMode = AccountStorageMode;
+      window.AdviceMap = AdviceMap;
+      window.AuthSecretKey = AuthSecretKey;
+      window.ConsumableNoteRecord = ConsumableNoteRecord;
+      window.Felt = Felt;
+      window.FeltArray = FeltArray;
+      window.FungibleAsset = FungibleAsset;
+      window.Note = Note;
+      window.NoteAssets = NoteAssets;
+      window.NoteConsumability = NoteConsumability;
+      window.NoteExecutionHint = NoteExecutionHint;
+      window.NoteExecutionMode = NoteExecutionMode;
+      window.NoteFilter = NoteFilter;
+      window.NoteFilterTypes = NoteFilterTypes;
+      window.NoteIdAndArgs = NoteIdAndArgs;
+      window.NoteIdAndArgsArray = NoteIdAndArgsArray;
+      window.NoteInputs = NoteInputs;
+      window.NoteMetadata = NoteMetadata;
+      window.NoteRecipient = NoteRecipient;
+      window.NoteTag = NoteTag;
+      window.NoteType = NoteType;
+      window.OutputNote = OutputNote;
+      window.OutputNotesArray = OutputNotesArray;
+      window.Rpo256 = Rpo256;
+      window.TestUtils = TestUtils;
+      window.TransactionFilter = TransactionFilter;
+      window.TransactionRequest = TransactionRequest;
+      window.TransactionScriptInputPair = TransactionScriptInputPair;
+      window.TransactionScriptInputPairArray = TransactionScriptInputPairArray;
+
+      // Create a namespace for helper functions
+      window.helpers = window.helpers || {};
+
+      window.helpers.waitForTransaction = async (
+        transactionId,
+        maxWaitTime = 20000,
+        delayInterval = 1000
+      ) => {
+        const client = window.client;
+        let timeWaited = 0;
+        while (true) {
+          if (timeWaited >= maxWaitTime) {
+            throw new Error("Timeout waiting for transaction");
+          }
+          await client.sync_state();
+          const uncomittedTransactions = await client.get_transactions(
+            window.TransactionFilter.uncomitted()
+          );
+          let uncomittedTransactionIds = uncomittedTransactions.map(
+            (transaction) => transaction.id().to_hex()
+          );
+          if (!uncomittedTransactionIds.includes(transactionId)) {
+            break;
+          }
+          await new Promise((r) => setTimeout(r, delayInterval));
+          timeWaited += delayInterval;
+        }
+      };
+    },
+    LOCAL_MIDEN_NODE_PORT,
+    env.REMOTE_PROVER ? REMOTE_TX_PROVER_PORT : null
+  );
 });
 
 beforeEach(async () => {

--- a/crates/web-client/test/mocha.global.setup.mjs
+++ b/crates/web-client/test/mocha.global.setup.mjs
@@ -6,6 +6,8 @@ import { spawn } from "child_process";
 import { register } from "ts-node";
 import { env } from "process";
 
+import { waitForTransaction } from "./webClientTestUtils";
+
 chai.use(chaiAsPromised);
 
 register({
@@ -39,88 +41,85 @@ before(async () => {
   }
 
   // Creates the client in the test context and attach to window object
-  await testingPage.evaluate(
-    async (rpc_port, remote_prover_port) => {
-      const {
-        Account,
-        AccountHeader,
-        AccountId,
-        AccountStorageMode,
-        AdviceMap,
-        AuthSecretKey,
-        ConsumableNoteRecord,
-        Felt,
-        FeltArray,
-        FungibleAsset,
-        Note,
-        NoteAssets,
-        NoteConsumability,
-        NoteExecutionHint,
-        NoteExecutionMode,
-        NoteFilter,
-        NoteFilterTypes,
-        NoteIdAndArgs,
-        NoteIdAndArgsArray,
-        NoteInputs,
-        NoteMetadata,
-        NoteRecipient,
-        NoteTag,
-        NoteType,
-        OutputNote,
-        OutputNotesArray,
-        Rpo256,
-        TestUtils,
-        TransactionFilter,
-        TransactionRequest,
-        TransactionScriptInputPair,
-        TransactionScriptInputPairArray,
-        WebClient,
-      } = await import("./index.js");
-      let rpc_url = `http://localhost:${rpc_port}`;
-      let prover_url = null;
-      if (remote_prover_port) {
-        prover_url = `http://localhost:${remote_prover_port}`;
-      }
-      const client = new WebClient();
-      await client.create_client(rpc_url, prover_url);
+  await testingPage.evaluate(async (port, waitForTransactionStr) => {
+    const {
+      Account,
+      AccountHeader,
+      AccountId,
+      AccountStorageMode,
+      AdviceMap,
+      AuthSecretKey,
+      ConsumableNoteRecord,
+      Felt,
+      FeltArray,
+      FungibleAsset,
+      Note,
+      NoteAssets,
+      NoteConsumability,
+      NoteExecutionHint,
+      NoteExecutionMode,
+      NoteFilter,
+      NoteFilterTypes,
+      NoteIdAndArgs,
+      NoteIdAndArgsArray,
+      NoteInputs,
+      NoteMetadata,
+      NoteRecipient,
+      NoteTag,
+      NoteType,
+      OutputNote,
+      OutputNotesArray,
+      Rpo256,
+      TestUtils,
+      TransactionFilter,
+      TransactionRequest,
+      TransactionScriptInputPair,
+      TransactionScriptInputPairArray,
+      WebClient,
+    } = await import("./index.js");
+    let rpc_url = `http://localhost:${port}`;
+    const client = new WebClient();
+    await client.create_client(rpc_url);
 
-      window.client = client;
-      window.Account = Account;
-      window.AccountHeader = AccountHeader;
-      window.AccountId = AccountId;
-      window.AccountStorageMode = AccountStorageMode;
-      window.AdviceMap = AdviceMap;
-      window.AuthSecretKey = AuthSecretKey;
-      window.ConsumableNoteRecord = ConsumableNoteRecord;
-      window.Felt = Felt;
-      window.FeltArray = FeltArray;
-      window.FungibleAsset = FungibleAsset;
-      window.Note = Note;
-      window.NoteAssets = NoteAssets;
-      window.NoteConsumability = NoteConsumability;
-      window.NoteExecutionHint = NoteExecutionHint;
-      window.NoteExecutionMode = NoteExecutionMode;
-      window.NoteFilter = NoteFilter;
-      window.NoteFilterTypes = NoteFilterTypes;
-      window.NoteIdAndArgs = NoteIdAndArgs;
-      window.NoteIdAndArgsArray = NoteIdAndArgsArray;
-      window.NoteInputs = NoteInputs;
-      window.NoteMetadata = NoteMetadata;
-      window.NoteRecipient = NoteRecipient;
-      window.NoteTag = NoteTag;
-      window.NoteType = NoteType;
-      window.OutputNote = OutputNote;
-      window.OutputNotesArray = OutputNotesArray;
-      window.Rpo256 = Rpo256;
-      window.TestUtils = TestUtils;
-      window.TransactionFilter = TransactionFilter;
-      window.TransactionRequest = TransactionRequest;
-      window.TransactionScriptInputPair = TransactionScriptInputPair;
-      window.TransactionScriptInputPairArray = TransactionScriptInputPairArray;
-    },
-    LOCAL_MIDEN_NODE_PORT,
-    env.REMOTE_PROVER ? REMOTE_TX_PROVER_PORT : null
-  );
+    window.client = client;
+    window.Account = Account;
+    window.AccountHeader = AccountHeader;
+    window.AccountId = AccountId;
+    window.AccountStorageMode = AccountStorageMode;
+    window.AdviceMap = AdviceMap;
+    window.AuthSecretKey = AuthSecretKey;
+    window.ConsumableNoteRecord = ConsumableNoteRecord;
+    window.Felt = Felt;
+    window.FeltArray = FeltArray;
+    window.FungibleAsset = FungibleAsset;
+    window.Note = Note;
+    window.NoteAssets = NoteAssets;
+    window.NoteConsumability = NoteConsumability;
+    window.NoteExecutionHint = NoteExecutionHint;
+    window.NoteExecutionMode = NoteExecutionMode;
+    window.NoteFilter = NoteFilter;
+    window.NoteFilterTypes = NoteFilterTypes;
+    window.NoteIdAndArgs = NoteIdAndArgs;
+    window.NoteIdAndArgsArray = NoteIdAndArgsArray;
+    window.NoteInputs = NoteInputs;
+    window.NoteMetadata = NoteMetadata;
+    window.NoteRecipient = NoteRecipient;
+    window.NoteTag = NoteTag;
+    window.NoteType = NoteType;
+    window.OutputNote = OutputNote;
+    window.OutputNotesArray = OutputNotesArray;
+    window.Rpo256 = Rpo256;
+    window.TestUtils = TestUtils;
+    window.TransactionFilter = TransactionFilter;
+    window.TransactionRequest = TransactionRequest;
+    window.TransactionScriptInputPair = TransactionScriptInputPair;
+    window.TransactionScriptInputPairArray = TransactionScriptInputPairArray;
+
+    // Create a namespace for helper functions
+    window.helpers = window.helpers || {};
+    
+    window.helpers.waitForTransaction = new Function(`return ${waitForTransactionStr}`)();
+  }, LOCAL_MIDEN_NODE_PORT, waitForTransaction.toString());
 });
 
 beforeEach(async () => {

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -9,7 +9,7 @@ import {
 // NEW_MINT_TRANSACTION TESTS
 // =======================================================================================================
 
-describe.only("new_mint_transactions tests", () => {
+describe("new_mint_transactions tests", () => {
   it("new_mint_transaction completes successfully", async () => {
     const { faucetId, accountId } = await setupWalletAndFaucet();
     const result = await mintTransaction(accountId, faucetId);
@@ -74,11 +74,18 @@ export const sendTransaction = async (): Promise<SendTransactionResult> => {
     );
     let created_notes = mint_transaction_result.created_notes().notes();
     let created_note_ids = created_notes.map((note) => note.id().to_string());
-    await window.helpers.waitForTransaction(mint_transaction_result.executed_transaction().id().to_hex());
+    await window.helpers.waitForTransaction(
+      mint_transaction_result.executed_transaction().id().to_hex()
+    );
 
     await client.fetch_and_cache_account_auth_by_pub_key(senderAccount.id());
-    const senderConsumeTransactionResult = await client.new_consume_transaction(senderAccount.id(), created_note_ids);
-    await window.helpers.waitForTransaction(senderConsumeTransactionResult.executed_transaction().id().to_hex());
+    const senderConsumeTransactionResult = await client.new_consume_transaction(
+      senderAccount.id(),
+      created_note_ids
+    );
+    await window.helpers.waitForTransaction(
+      senderConsumeTransactionResult.executed_transaction().id().to_hex()
+    );
 
     await client.fetch_and_cache_account_auth_by_pub_key(senderAccount.id());
     let send_transaction_result = await client.new_send_transaction(
@@ -92,14 +99,18 @@ export const sendTransaction = async (): Promise<SendTransactionResult> => {
     let send_created_note_ids = send_created_notes.map((note) =>
       note.id().to_string()
     );
-    await window.helpers.waitForTransaction(send_transaction_result.executed_transaction().id().to_hex());
+    await window.helpers.waitForTransaction(
+      send_transaction_result.executed_transaction().id().to_hex()
+    );
 
     await client.fetch_and_cache_account_auth_by_pub_key(targetAccount.id());
     const targetConsumeTransactionResult = await client.new_consume_transaction(
       targetAccount.id(),
       send_created_note_ids
     );
-    await window.helpers.waitForTransaction(targetConsumeTransactionResult.executed_transaction().id().to_hex());
+    await window.helpers.waitForTransaction(
+      targetConsumeTransactionResult.executed_transaction().id().to_hex()
+    );
 
     const changedSenderAccount = await client.get_account(senderAccount.id());
     const changedTargetAccount = await client.get_account(targetAccount.id());
@@ -322,7 +333,9 @@ export const customTransaction = async (
       transaction_request
     );
     await client.submit_transaction(transaction_result);
-    await window.helpers.waitForTransaction(transaction_result.executed_transaction().id().to_hex());
+    await window.helpers.waitForTransaction(
+      transaction_result.executed_transaction().id().to_hex()
+    );
 
     // Just like in the miden test, you can modify this script to get the execution to fail
     // by modifying the assert
@@ -378,7 +391,9 @@ export const customTransaction = async (
       transaction_request_2
     );
     await client.submit_transaction(transaction_result_2);
-    await window.helpers.waitForTransaction(transaction_result_2.executed_transaction().id().to_hex());
+    await window.helpers.waitForTransaction(
+      transaction_result_2.executed_transaction().id().to_hex()
+    );
   }, asserted_value);
 };
 

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -9,9 +9,8 @@ import {
 // NEW_MINT_TRANSACTION TESTS
 // =======================================================================================================
 
-describe("new_mint_transactions tests", () => {
+describe.only("new_mint_transactions tests", () => {
   it("new_mint_transaction completes successfully", async () => {
-    console.log("starting new_mint_transaction test");
     const { faucetId, accountId } = await setupWalletAndFaucet();
     const result = await mintTransaction(accountId, faucetId);
 
@@ -75,13 +74,11 @@ export const sendTransaction = async (): Promise<SendTransactionResult> => {
     );
     let created_notes = mint_transaction_result.created_notes().notes();
     let created_note_ids = created_notes.map((note) => note.id().to_string());
-    await new Promise((r) => setTimeout(r, 20000)); // TODO: Replace this with loop of sync -> check uncommitted transactions -> sleep
-    await client.sync_state();
+    await window.helpers.waitForTransaction(mint_transaction_result.executed_transaction().id().to_hex());
 
     await client.fetch_and_cache_account_auth_by_pub_key(senderAccount.id());
-    await client.new_consume_transaction(senderAccount.id(), created_note_ids);
-    await new Promise((r) => setTimeout(r, 20000)); // TODO: Replace this with loop of sync -> check uncommitted transactions -> sleep
-    await client.sync_state();
+    const senderConsumeTransactionResult = await client.new_consume_transaction(senderAccount.id(), created_note_ids);
+    await window.helpers.waitForTransaction(senderConsumeTransactionResult.executed_transaction().id().to_hex());
 
     await client.fetch_and_cache_account_auth_by_pub_key(senderAccount.id());
     let send_transaction_result = await client.new_send_transaction(
@@ -95,16 +92,14 @@ export const sendTransaction = async (): Promise<SendTransactionResult> => {
     let send_created_note_ids = send_created_notes.map((note) =>
       note.id().to_string()
     );
-    await new Promise((r) => setTimeout(r, 20000)); // TODO: Replace this with loop of sync -> check uncommitted transactions -> sleep
-    await client.sync_state();
+    await window.helpers.waitForTransaction(send_transaction_result.executed_transaction().id().to_hex());
 
     await client.fetch_and_cache_account_auth_by_pub_key(targetAccount.id());
-    await client.new_consume_transaction(
+    const targetConsumeTransactionResult = await client.new_consume_transaction(
       targetAccount.id(),
       send_created_note_ids
     );
-    await new Promise((r) => setTimeout(r, 20000)); // TODO: Replace this with loop of sync -> check uncommitted transactions -> sleep
-    await client.sync_state();
+    await window.helpers.waitForTransaction(targetConsumeTransactionResult.executed_transaction().id().to_hex());
 
     const changedSenderAccount = await client.get_account(senderAccount.id());
     const changedTargetAccount = await client.get_account(targetAccount.id());
@@ -327,8 +322,7 @@ export const customTransaction = async (
       transaction_request
     );
     await client.submit_transaction(transaction_result);
-    await new Promise((r) => setTimeout(r, 20000));
-    await client.sync_state();
+    await window.helpers.waitForTransaction(transaction_result.executed_transaction().id().to_hex());
 
     // Just like in the miden test, you can modify this script to get the execution to fail
     // by modifying the assert
@@ -384,8 +378,7 @@ export const customTransaction = async (
       transaction_request_2
     );
     await client.submit_transaction(transaction_result_2);
-    await new Promise((r) => setTimeout(r, 10000));
-    await client.sync_state();
+    await window.helpers.waitForTransaction(transaction_result_2.executed_transaction().id().to_hex());
   }, asserted_value);
 };
 

--- a/crates/web-client/test/notes.test.ts
+++ b/crates/web-client/test/notes.test.ts
@@ -133,7 +133,7 @@ describe("get_consumable_notes", () => {
       expect(c.accountId).to.equal(accountId2);
     });
   });
-  
+
   it("p2idr consume after block", async () => {
     const { accountId: senderAccountId, faucetId } =
       await setupWalletAndFaucet();

--- a/crates/web-client/test/notes.test.ts
+++ b/crates/web-client/test/notes.test.ts
@@ -108,6 +108,7 @@ describe("get_consumable_notes", () => {
       expect(record.consumability[0].consumableAfterBlock).to.be.undefined;
     });
   });
+
   it("no filter by account", async () => {
     const { createdNoteId: noteId1, accountId: accountId1 } =
       await setupMintedNote();
@@ -132,6 +133,7 @@ describe("get_consumable_notes", () => {
       expect(c.accountId).to.equal(accountId2);
     });
   });
+  
   it("p2idr consume after block", async () => {
     const { accountId: senderAccountId, faucetId } =
       await setupWalletAndFaucet();

--- a/crates/web-client/test/webClientTestUtils.ts
+++ b/crates/web-client/test/webClientTestUtils.ts
@@ -32,7 +32,9 @@ export const mintTransaction = async (
       );
 
       if (_sync) {
-        await window.helpers.waitForTransaction(new_mint_transaction_result.executed_transaction().id().to_hex());
+        await window.helpers.waitForTransaction(
+          new_mint_transaction_result.executed_transaction().id().to_hex()
+        );
       }
 
       return {
@@ -89,11 +91,18 @@ export const sendTransaction = async (
       );
       let created_notes = mint_transaction_result.created_notes().notes();
       let created_note_ids = created_notes.map((note) => note.id().to_string());
-      await window.helpers.waitForTransaction(mint_transaction_result.executed_transaction().id().to_hex());
-      
+      await window.helpers.waitForTransaction(
+        mint_transaction_result.executed_transaction().id().to_hex()
+      );
+
       await client.fetch_and_cache_account_auth_by_pub_key(senderAccountId);
-      const consume_transaction_result = await client.new_consume_transaction(senderAccountId, created_note_ids);
-      await window.helpers.waitForTransaction(consume_transaction_result.executed_transaction().id().to_hex());
+      const consume_transaction_result = await client.new_consume_transaction(
+        senderAccountId,
+        created_note_ids
+      );
+      await window.helpers.waitForTransaction(
+        consume_transaction_result.executed_transaction().id().to_hex()
+      );
 
       await client.fetch_and_cache_account_auth_by_pub_key(senderAccountId);
       let send_transaction_result = await client.new_send_transaction(
@@ -108,8 +117,10 @@ export const sendTransaction = async (
       let send_created_note_ids = send_created_notes.map((note) =>
         note.id().to_string()
       );
-      
-      await window.helpers.waitForTransaction(send_transaction_result.executed_transaction().id().to_hex());
+
+      await window.helpers.waitForTransaction(
+        send_transaction_result.executed_transaction().id().to_hex()
+      );
 
       return send_created_note_ids;
     },
@@ -145,7 +156,9 @@ export const consumeTransaction = async (
         targetAccountId,
         [_noteId]
       );
-      await window.helpers.waitForTransaction(consumeTransactionResult.executed_transaction().id().to_hex());
+      await window.helpers.waitForTransaction(
+        consumeTransactionResult.executed_transaction().id().to_hex()
+      );
 
       const changedTargetAccount = await client.get_account(targetAccountId);
 
@@ -214,33 +227,6 @@ export const syncState = async () => {
     };
   });
 };
-
-export const waitForTransaction = async(
-  transactionId: string,
-  maxWaitTime: number = 20000,
-  delayInterval: number = 1000
-) => {
-  const client = window.client;
-  let timeWaited = 0;
-  while(true) {
-    console.info(`Waiting for transaction ${transactionId}`);
-    if (timeWaited >= maxWaitTime) {
-      throw new Error("Timeout waiting for transaction");
-    }
-    await client.sync_state();
-    const uncomittedTransactions = await client.get_transactions(
-      window.TransactionFilter.uncomitted()
-    );
-    let uncomittedTransactionIds = uncomittedTransactions.map((transaction) =>
-      transaction.id().to_hex()
-    );
-    if(!uncomittedTransactionIds.includes(transactionId)) {
-      break;
-    }
-    await new Promise((r) => setTimeout(r, delayInterval));
-    timeWaited += delayInterval;
-  }
-}
 
 // Misc test utils
 


### PR DESCRIPTION
# Summary
This PR adds a slight optimization to the web client integration tests by checking to see whether transactions have been committed via a sync loop as opposed to using a fixed 20-second timeout across all tests. This should result in a slight speedup on the overall timing of the tests. 

Snapshot of run on this PR after change:
![image](https://github.com/user-attachments/assets/aa4d47a1-a4e8-4a0b-959e-a466a236b6a0)

Snapshot of random PR before change: 
![image](https://github.com/user-attachments/assets/e45128d5-32d2-40e2-9a02-99406c996ecb)

so seems to have a good improvement. Will continue to look for areas of optimization to continue shaving down the web client integration test times