### PR TITLE
feat: add per transaction prover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 * Added Sync Loop to Integration Tests for Small Speedup (#590).
 
+### Changes
+* Added per transaction prover support to the client (#599).
+
 ## 0.6.0 (2024-11-08)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added Sync Loop to Integration Tests for Small Speedup (#590).
 
 ### Changes
-* Added per transaction prover support to the client (#599).
+* [BREAKING] Added per transaction prover support to the client (#599).
 
 ## 0.6.0 (2024-11-08)
 

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -293,7 +293,7 @@ async fn execute_transaction(
         Some(proving_url) => {
             let remote_prover = Arc::new(RemoteTransactionProver::new(&proving_url.to_string()));
             client
-                .submit_transaction_with_prover(remote_prover, transaction_execution_result)
+                .submit_transaction_with_prover(transaction_execution_result, remote_prover)
                 .await?;
         },
         None => client.submit_transaction(transaction_execution_result).await?,

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -10,10 +10,8 @@ use miden_client::{
         sqlite_store::SqliteStore, NoteFilter as ClientNoteFilter, OutputNoteRecord, Store,
         StoreAuthenticator,
     },
-    transactions::{LocalTransactionProver, TransactionProver},
     Client, ClientError, Felt, IdPrefixFetchError,
 };
-use miden_tx_prover::RemoteTransactionProver;
 use rand::Rng;
 mod commands;
 use commands::{
@@ -110,17 +108,11 @@ impl Cli {
         let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
         let authenticator = StoreAuthenticator::new_with_rng(store.clone() as Arc<dyn Store>, rng);
 
-        let tx_prover: Arc<dyn TransactionProver> = match &cli_config.remote_prover_endpoint {
-            Some(proving_url) => Arc::new(RemoteTransactionProver::new(&proving_url.to_string())),
-            None => Arc::new(LocalTransactionProver::new(Default::default())),
-        };
-
         let client = Client::new(
             Box::new(TonicRpcClient::new(&cli_config.rpc)),
             rng,
             store as Arc<dyn Store>,
             Arc::new(authenticator),
-            tx_prover as Arc<dyn TransactionProver>,
             in_debug_mode,
         );
 

--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -3,7 +3,6 @@ use std::{
     fs::File,
     io::Read,
     path::Path,
-    sync::Arc,
 };
 
 use assert_cmd::Command;
@@ -17,7 +16,6 @@ use miden_client::{
         NoteFilter, StoreAuthenticator,
     },
     testing::ACCOUNT_ID_OFF_CHAIN_SENDER,
-    transactions::{LocalTransactionProver, ProvingOptions},
     Client, Felt,
 };
 use rand::Rng;
@@ -556,7 +554,6 @@ async fn create_test_client_with_store_path(store_path: &Path) -> TestClient {
     let coin_seed: [u64; 4] = rng.gen();
 
     let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
-    let tx_prover = Arc::new(LocalTransactionProver::new(ProvingOptions::default()));
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
@@ -564,7 +561,6 @@ async fn create_test_client_with_store_path(store_path: &Path) -> TestClient {
         rng,
         store,
         std::sync::Arc::new(authenticator),
-        tx_prover,
         true,
     )
 }

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -115,7 +115,7 @@ pub struct Client<R: FeltRng> {
     /// An instance of [NodeRpcClient] which provides a way for the client to connect to the
     /// Miden node.
     rpc_api: Box<dyn NodeRpcClient + Send>,
-    /// An instance of [TransactionProver] which delegates proving.
+    /// An instance of a [LocalTransactionProver] which will be the default prover for the client.
     tx_prover: Arc<LocalTransactionProver>,
     tx_executor: TransactionExecutor,
 }

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -88,7 +88,9 @@ pub mod testing {
 use alloc::sync::Arc;
 
 use miden_objects::crypto::rand::FeltRng;
-use miden_tx::{auth::TransactionAuthenticator, DataStore, TransactionExecutor, TransactionProver};
+use miden_tx::{
+    auth::TransactionAuthenticator, DataStore, LocalTransactionProver, TransactionExecutor,
+};
 use rpc::NodeRpcClient;
 use store::{data_store::ClientDataStore, Store};
 use tracing::info;
@@ -114,7 +116,7 @@ pub struct Client<R: FeltRng> {
     /// Miden node.
     rpc_api: Box<dyn NodeRpcClient + Send>,
     /// An instance of [TransactionProver] which delegates proving.
-    tx_prover: Arc<dyn TransactionProver>,
+    tx_prover: Arc<LocalTransactionProver>,
     tx_executor: TransactionExecutor,
 }
 
@@ -135,7 +137,6 @@ impl<R: FeltRng> Client<R> {
     ///   store as the one for `store`, but it doesn't have to be the **same instance**.
     /// - `authenticator`: Defines the transaction authenticator that will be used by the
     ///   transaction executor whenever a signature is requested from within the VM.
-    /// - `tx_prover`: Defines how transaction proving is performed.
     /// - `in_debug_mode`: Instantiates the transaction executor (and in turn, its compiler) in
     ///   debug mode, which will enable debug logs for scripts compiled with this mode for easier
     ///   MASM debugging.
@@ -148,7 +149,6 @@ impl<R: FeltRng> Client<R> {
         rng: R,
         store: Arc<dyn Store>,
         authenticator: Arc<dyn TransactionAuthenticator>,
-        tx_prover: Arc<dyn TransactionProver>,
         in_debug_mode: bool,
     ) -> Self {
         if in_debug_mode {
@@ -159,6 +159,7 @@ impl<R: FeltRng> Client<R> {
         let authenticator = Some(authenticator);
         let tx_executor =
             TransactionExecutor::new(data_store, authenticator).with_debug_mode(in_debug_mode);
+        let tx_prover = Arc::new(LocalTransactionProver::default());
 
         Self {
             store,

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -25,7 +25,7 @@ use miden_objects::{
     transaction::{InputNote, ProvenTransaction},
     BlockHeader, Digest, Felt, Word,
 };
-use miden_tx::{testing::mock_chain::MockChain, LocalTransactionProver};
+use miden_tx::testing::mock_chain::MockChain;
 use rand::Rng;
 use tonic::Response;
 use uuid::Uuid;
@@ -340,9 +340,7 @@ pub async fn create_test_client() -> (MockClient, MockRpcApi) {
     let rpc_api = MockRpcApi::new();
     let boxed_rpc_api = Box::new(rpc_api.clone());
 
-    let prover = Arc::new(LocalTransactionProver::default());
-
-    let client = MockClient::new(boxed_rpc_api, rng, store, Arc::new(authenticator), prover, true);
+    let client = MockClient::new(boxed_rpc_api, rng, store, Arc::new(authenticator), true);
     (client, rpc_api)
 }
 

--- a/crates/rust-client/src/transactions/mod.rs
+++ b/crates/rust-client/src/transactions/mod.rs
@@ -4,6 +4,7 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     string::{String, ToString},
+    sync::Arc,
     vec::Vec,
 };
 use core::fmt::{self};
@@ -21,7 +22,9 @@ use miden_objects::{
     vm::AdviceInputs,
     AssetError, Digest, Felt, Word, ZERO,
 };
-pub use miden_tx::{LocalTransactionProver, ProvingOptions, TransactionProver};
+pub use miden_tx::{
+    LocalTransactionProver, ProvingOptions, TransactionProver, TransactionProverError,
+};
 use script_builder::{AccountCapabilities, AccountInterface};
 use tracing::info;
 
@@ -404,19 +407,31 @@ impl<R: FeltRng> Client<R> {
         &mut self,
         tx_result: TransactionResult,
     ) -> Result<(), ClientError> {
-        let proven_transaction = self.prove_transaction(&tx_result).await?;
+        let proven_transaction = self.prove_transaction(None, &tx_result).await?;
+        self.submit_proven_transaction(proven_transaction).await?;
+        self.apply_transaction(tx_result).await
+    }
+
+    pub async fn submit_transaction_with_prover(
+        &mut self,
+        tx_prover: Arc<dyn TransactionProver>,
+        tx_result: TransactionResult,
+    ) -> Result<(), ClientError> {
+        let proven_transaction = self.prove_transaction(Some(tx_prover), &tx_result).await?;
         self.submit_proven_transaction(proven_transaction).await?;
         self.apply_transaction(tx_result).await
     }
 
     async fn prove_transaction(
         &mut self,
+        tx_prover: Option<Arc<dyn TransactionProver>>,
         tx_result: &TransactionResult,
     ) -> Result<ProvenTransaction, ClientError> {
         info!("Proving transaction...");
+        let tx_prover = tx_prover.unwrap_or(self.tx_prover.clone());
 
         let proven_transaction =
-            self.tx_prover.prove(tx_result.executed_transaction().clone().into()).await?;
+            tx_prover.prove(tx_result.executed_transaction().clone().into()).await?;
 
         info!("Transaction proven.");
 
@@ -741,7 +756,7 @@ impl<R: FeltRng> Client<R> {
         &mut self,
         tx_result: &TransactionResult,
     ) -> Result<ProvenTransaction, ClientError> {
-        self.prove_transaction(tx_result).await
+        self.prove_transaction(None, tx_result).await
     }
 
     pub async fn testing_submit_proven_transaction(

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -5,7 +5,6 @@ use console_error_panic_hook::set_once;
 use miden_client::{
     rpc::WebTonicRpcClient,
     store::{web_store::WebStore, StoreAuthenticator},
-    transactions::{LocalTransactionProver, TransactionProver},
     Client,
 };
 use miden_objects::{crypto::rand::RpoRandomCoin, Felt};
@@ -27,6 +26,7 @@ pub mod transactions;
 #[wasm_bindgen]
 pub struct WebClient {
     store: Option<Arc<WebStore>>,
+    remote_prover: Option<Arc<RemoteTransactionProver>>,
     inner: Option<Client<RpoRandomCoin>>,
 }
 
@@ -41,7 +41,11 @@ impl WebClient {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         set_once();
-        WebClient { inner: None, store: None }
+        WebClient {
+            inner: None,
+            remote_prover: None,
+            store: None,
+        }
     }
 
     pub(crate) fn get_mut_inner(&mut self) -> Option<&mut Client<RpoRandomCoin>> {
@@ -66,19 +70,10 @@ impl WebClient {
             &node_url.unwrap_or_else(|| "http://18.203.155.106:57291".to_string()),
         ));
 
-        let tx_prover: Arc<dyn TransactionProver> = match proving_url {
-            Some(proving_url) => Arc::new(RemoteTransactionProver::new(&proving_url.to_string())),
-            None => Arc::new(LocalTransactionProver::new(Default::default())),
-        };
-
-        self.inner = Some(Client::new(
-            web_rpc_client,
-            rng,
-            web_store.clone(),
-            authenticator,
-            tx_prover,
-            false,
-        ));
+        self.remote_prover = proving_url
+            .map(|proving_url| Arc::new(RemoteTransactionProver::new(&proving_url.to_string())));
+        self.inner =
+            Some(Client::new(web_rpc_client, rng, web_store.clone(), authenticator, false));
         self.store = Some(web_store);
 
         Ok(JsValue::from_str("Client created successfully"))

--- a/crates/web-client/src/new_transactions.rs
+++ b/crates/web-client/src/new_transactions.rs
@@ -50,8 +50,8 @@ impl WebClient {
                 Some(ref remote_prover) => {
                     client
                         .submit_transaction_with_prover(
-                            remote_prover.clone(),
                             native_transaction_result,
+                            remote_prover.clone(),
                         )
                         .await
                         .map_err(|err| {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dev-dependencies]
+async-trait = { version = "0.1" }
 figment = { version = "0.10", features = ["toml", "env"] }
 miden-client = { path = "../crates/rust-client", features = [
     "concurrent",
@@ -25,6 +26,7 @@ rand = { workspace = true }
 rand_chacha = { version = "0.3", default-features = false}
 tokio = { workspace = true }
 uuid = { version = "1.10", features = ["serde", "v4"] }
+winter-maybe-async = { version = "0.10" }
 
 [[test]]
 name = "integration"

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -15,9 +15,7 @@ use miden_client::{
         NoteFilter, StoreAuthenticator, TransactionFilter,
     },
     sync::SyncSummary,
-    transactions::{
-        DataStoreError, LocalTransactionProver, TransactionExecutorError, TransactionRequest,
-    },
+    transactions::{DataStoreError, TransactionExecutorError, TransactionRequest},
     Client, ClientError,
 };
 use miden_objects::{
@@ -61,14 +59,12 @@ pub async fn create_test_client() -> TestClient {
 
     let rng = RpoRandomCoin::new(coin_seed.map(Felt::new));
 
-    let tx_prover = Arc::new(LocalTransactionProver::default());
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
         Box::new(TonicRpcClient::new(&rpc_config)),
         rng,
         store,
         Arc::new(authenticator),
-        tx_prover,
         true,
     )
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1338,8 +1338,8 @@ async fn test_custom_transaction_prover() {
 
     let result = client
         .submit_transaction_with_prover(
-            Arc::new(AlwaysFailingProver::new()),
             transaction_execution_result,
+            Arc::new(AlwaysFailingProver::new()),
         )
         .await;
 


### PR DESCRIPTION
closes #592 

This PR is an alternative approach to #598 which is mentioned in the original issue. I think this approach looks better when compared to #598 as it doesn't change the interface of the `submit_transaction` function (which is used a lot). 