### PR TITLE
fix doc 404 error

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
   - Miden CLI:
       - Configuration: 'cli-config.md'
       - Reference: 'cli-reference.md'
-  - Install and run: install-and-run.md'
+  - Install and run: 'install-and-run.md'
   - Examples: 'examples.md'
 
 


### PR DESCRIPTION
Try to fix the [Miden client -> Install and run](https://docs.polygon.technology/miden/miden-client/install-and-run.md') page 404 error.