### PR TITLE
docs: The spelling of "miden-clinet" is incorrect, it should be "miden-client". This could lead to a broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Miden client
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xPolygonMiden/miden-client/blob/main/LICENSE)
-[![test](https://github.com/0xPolygonMiden/miden-client/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-clinet/actions/workflows/test.yml)
+[![test](https://github.com/0xPolygonMiden/miden-client/actions/workflows/test.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-client/actions/workflows/test.yml)
 [![build](https://github.com/0xPolygonMiden/miden-client/actions/workflows/build.yml/badge.svg)](https://github.com/0xPolygonMiden/miden-client/actions/workflows/build.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.82+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)


### PR DESCRIPTION
The spelling of "miden-clinet" is incorrect, it should be "miden-client". This could lead to a broken link.