### PR TITLE
feat: make `Client` send and sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.7.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#487e8b934d61422cdc84e9bb42ea49befa08bd44"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=tomyrd-send-sync-traits#934ae4a6d1f1ffc082812b31e5d7a464c912089b"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.7.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#487e8b934d61422cdc84e9bb42ea49befa08bd44"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=tomyrd-send-sync-traits#934ae4a6d1f1ffc082812b31e5d7a464c912089b"
 dependencies = [
  "getrandom",
  "miden-assembly",
@@ -2083,7 +2083,11 @@ dependencies = [
  "miden-processor",
  "miden-verifier",
  "rand",
+ "rand_xoshiro",
+ "semver 1.0.24",
+ "serde",
  "thiserror 2.0.9",
+ "toml",
  "winter-rand-utils",
 ]
 
@@ -2149,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.7.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#487e8b934d61422cdc84e9bb42ea49befa08bd44"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=tomyrd-send-sync-traits#934ae4a6d1f1ffc082812b31e5d7a464c912089b"
 dependencies = [
  "async-trait",
  "miden-lib",
@@ -2166,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "miden-tx-prover"
 version = "0.7.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#487e8b934d61422cdc84e9bb42ea49befa08bd44"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=tomyrd-send-sync-traits#934ae4a6d1f1ffc082812b31e5d7a464c912089b"
 dependencies = [
  "async-trait",
  "axum",
@@ -2187,12 +2191,14 @@ dependencies = [
  "pingora-core",
  "pingora-limits",
  "pingora-proxy",
+ "prometheus",
  "prost",
  "prost-build",
  "protox",
  "reqwest",
  "serde",
  "serde_qs",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
  "toml",
@@ -3261,6 +3267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,6 +3597,9 @@ name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ repository = "https://github.com/0xPolygonMiden/miden-client"
 
 [workspace.dependencies]
 async-trait = "0.1"
-miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
-miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
-miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
-miden-tx-prover = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", features = ["async"] }
+miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "tomyrd-send-sync-traits", default-features = false }
+miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "tomyrd-send-sync-traits", default-features = false }
+miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "tomyrd-send-sync-traits", default-features = false, features = ["async"] }
+miden-tx-prover = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "tomyrd-send-sync-traits", features = ["async"] }
 rand = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { version = "2.0", default-features = false }

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -115,7 +115,7 @@ pub struct Client<R: FeltRng> {
     rng: R,
     /// An instance of [NodeRpcClient] which provides a way for the client to connect to the
     /// Miden node.
-    rpc_api: Box<dyn NodeRpcClient + Send>,
+    rpc_api: Box<dyn NodeRpcClient + Send + Sync>,
     /// An instance of a [LocalTransactionProver] which will be the default prover for the client.
     tx_prover: Arc<LocalTransactionProver>,
     tx_executor: TransactionExecutor,
@@ -147,7 +147,7 @@ impl<R: FeltRng> Client<R> {
     ///
     /// Returns an error if the client couldn't be instantiated.
     pub fn new(
-        rpc_api: Box<dyn NodeRpcClient + Send>,
+        rpc_api: Box<dyn NodeRpcClient + Send + Sync>,
         rng: R,
         store: Arc<dyn Store>,
         authenticator: Arc<dyn TransactionAuthenticator>,
@@ -182,7 +182,7 @@ impl<R: FeltRng> Client<R> {
     // --------------------------------------------------------------------------------------------
 
     #[cfg(any(test, feature = "testing"))]
-    pub fn test_rpc_api(&mut self) -> &mut Box<dyn NodeRpcClient + Send> {
+    pub fn test_rpc_api(&mut self) -> &mut Box<dyn NodeRpcClient + Send + Sync> {
         &mut self.rpc_api
     }
 

--- a/crates/rust-client/src/store/authenticator.rs
+++ b/crates/rust-client/src/store/authenticator.rs
@@ -11,18 +11,18 @@ use rand::Rng;
 use super::Store;
 
 /// Represents an authenticator based on a [Store].
-pub struct StoreAuthenticator<R> {
+pub struct StoreAuthenticator<R: Send + Sync> {
     store: Arc<dyn Store>,
     rng: Arc<RwLock<R>>,
 }
 
-impl<R: Rng> StoreAuthenticator<R> {
+impl<R: Rng + Send + Sync> StoreAuthenticator<R> {
     pub fn new_with_rng(store: Arc<dyn Store>, rng: R) -> Self {
         StoreAuthenticator { store, rng: Arc::new(RwLock::new(rng)) }
     }
 }
 
-impl<R: Rng> TransactionAuthenticator for StoreAuthenticator<R> {
+impl<R: Rng + Send + Sync> TransactionAuthenticator for StoreAuthenticator<R> {
     /// Gets a signature over a message, given a public key.
     ///
     /// The pub key should correspond to one of the keys tracked by the authenticator's store.

--- a/crates/rust-client/src/store/web_store/mod.rs
+++ b/crates/rust-client/src/store/web_store/mod.rs
@@ -219,3 +219,6 @@ impl Store for WebStore {
         self.get_unspent_input_note_nullifiers().await
     }
 }
+
+unsafe impl Send for WebStore {}
+unsafe impl Sync for WebStore {}

--- a/crates/rust-client/src/transactions/request/mod.rs
+++ b/crates/rust-client/src/transactions/request/mod.rs
@@ -340,21 +340,18 @@ mod tests {
 
     #[test]
     fn transaction_request_serialization() {
-        let sender_id = AccountId::new_dummy(
+        let sender_id = AccountId::dummy(
             [0u8; 15],
             AccountType::RegularAccountImmutableCode,
             AccountStorageMode::Private,
         );
-        let target_id = AccountId::new_dummy(
+        let target_id = AccountId::dummy(
             [1u8; 15],
             AccountType::RegularAccountImmutableCode,
             AccountStorageMode::Public,
         );
-        let faucet_id = AccountId::new_dummy(
-            [2u8; 15],
-            AccountType::FungibleFaucet,
-            AccountStorageMode::Private,
-        );
+        let faucet_id =
+            AccountId::dummy([2u8; 15], AccountType::FungibleFaucet, AccountStorageMode::Private);
         let mut rng = RpoRandomCoin::new(Default::default());
 
         let mut notes = vec![];

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -22,7 +22,7 @@ testing = ["miden-client/testing", "miden-tx-prover/testing"]
 miden-client = { version = "0.6", path = "../rust-client", default-features = false, features = ["idxdb", "web-tonic"] }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
-miden-tx-prover = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
+miden-tx-prover = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "tomyrd-send-sync-traits", default-features = false, features = ["async"] }
 rand = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { version = "0.6" }


### PR DESCRIPTION
related to #657 

This PR adds `Send` and `Sync` to the traits used in the client. [Some changes](https://github.com/0xPolygonMiden/miden-base/compare/tomyrd-send-sync-traits?expand=1) in miden-base were also needed. 

This makes it so that the client can be shared between tokio tasks like the issue requested but the issue is not entirely solved. Mostly because the store and rpc traits are `#[async_trait(?Send)]` meaning that the futures they create are not send. This means that the client can be shared, but any method called will generate futures that won't be send. This doesn't seem like an issue but tokio need that all data that is held across .await calls is Send.

If we remove the `?Send` from the async traits, the rust client works but not the web store and tonic client.