### PR TITLE
Added Serial Num Parameter to Note Recipient Constructor in the Web Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Web Store InsertChainMmrNodes Duplicate Ids Causes Error (#627).
 * Fixed client bugs where some note metadata was not being updated (#625).
 * Added Sync Loop to Integration Tests for Small Speedup (#590).
+* Added Serial Num Parameter to Note Recipient Constructor in the Web Client (#671).
 
 ### Changes
 

--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -36,6 +36,7 @@ const {
   TransactionRequestBuilder,
   TransactionScriptInputPair,
   TransactionScriptInputPairArray,
+  Word,
   WebClient,
 } = await wasm({
   importHook: () => {
@@ -79,5 +80,6 @@ export {
   TransactionRequestBuilder,
   TransactionScriptInputPair,
   TransactionScriptInputPairArray,
+  Word,
   WebClient,
 };

--- a/crates/web-client/js/types/index.d.ts
+++ b/crates/web-client/js/types/index.d.ts
@@ -37,5 +37,6 @@ export {
   TransactionRequestBuilder,
   TransactionScriptInputPair,
   TransactionScriptInputPairArray,
+  Word,
   WebClient,
 } from "./crates/miden_client_web";

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.0.19",
+  "version": "0.6.1-next.3",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",

--- a/crates/web-client/src/models/note_recipient.rs
+++ b/crates/web-client/src/models/note_recipient.rs
@@ -1,13 +1,13 @@
 use miden_objects::{
-    crypto::rand::{FeltRng, RpoRandomCoin},
     notes::{
         NoteInputs as NativeNoteInputs, NoteRecipient as NativeNoteRecipient,
         NoteScript as NativeNoteScript,
     },
+    Word as NativeWord,
 };
 use wasm_bindgen::prelude::*;
 
-use super::{note_inputs::NoteInputs, note_script::NoteScript, rpo_digest::RpoDigest};
+use super::{note_inputs::NoteInputs, note_script::NoteScript, rpo_digest::RpoDigest, word::Word};
 
 #[derive(Clone)]
 #[wasm_bindgen]
@@ -16,13 +16,12 @@ pub struct NoteRecipient(NativeNoteRecipient);
 #[wasm_bindgen]
 impl NoteRecipient {
     #[wasm_bindgen(constructor)]
-    pub fn new(note_script: &NoteScript, inputs: &NoteInputs) -> NoteRecipient {
-        let mut random_coin = RpoRandomCoin::new(Default::default());
-        let serial_num = random_coin.draw_word();
+    pub fn new(serial_num: &Word, note_script: &NoteScript, inputs: &NoteInputs) -> NoteRecipient {
+        let native_serial_num: NativeWord = serial_num.into();
         let native_note_script: NativeNoteScript = note_script.into();
         let native_note_inputs: NativeNoteInputs = inputs.into();
         let native_note_recipient =
-            NativeNoteRecipient::new(serial_num, native_note_script, native_note_inputs);
+            NativeNoteRecipient::new(native_serial_num, native_note_script, native_note_inputs);
 
         NoteRecipient(native_note_recipient)
     }

--- a/crates/web-client/test/global.test.d.ts
+++ b/crates/web-client/test/global.test.d.ts
@@ -33,6 +33,7 @@ import {
   TransactionRequestBuilder,
   TransactionScriptInputPair,
   TransactionScriptInputPairArray,
+  Word,
   WebClient,
 } from "../dist/index";
 
@@ -72,6 +73,7 @@ declare global {
     TransactionRequestBuilder: typeof TransactionRequestBuilder;
     TransactionScriptInputPair: typeof TransactionScriptInputPair;
     TransactionScriptInputPairArray: typeof TransactionScriptInputPairArray;
+    Word: typeof Word;
     create_client: () => Promise<void>;
 
     // Add the helpers namespace

--- a/crates/web-client/test/mocha.global.setup.mjs
+++ b/crates/web-client/test/mocha.global.setup.mjs
@@ -86,6 +86,7 @@ before(async () => {
         TransactionRequestBuilder,
         TransactionScriptInputPair,
         TransactionScriptInputPairArray,
+        Word,
         WebClient,
       } = await import("./index.js");
       let rpc_url = `http://localhost:${rpc_port}`;
@@ -130,6 +131,7 @@ before(async () => {
       window.TransactionRequestBuilder = TransactionRequestBuilder;
       window.TransactionScriptInputPair = TransactionScriptInputPair;
       window.TransactionScriptInputPairArray = TransactionScriptInputPairArray;
+      window.Word = Word;
 
       // Create a namespace for helper functions
       window.helpers = window.helpers || {};

--- a/crates/web-client/test/notes.test.ts
+++ b/crates/web-client/test/notes.test.ts
@@ -3,11 +3,9 @@ import { testingPage } from "./mocha.global.setup.mjs";
 import {
   badHexId,
   consumeTransaction,
-  fetchAndCacheAccountAuth,
   mintTransaction,
   sendTransaction,
   setupWalletAndFaucet,
-  syncState,
 } from "./webClientTestUtils";
 
 const getInputNote = async (noteId: string) => {
@@ -39,11 +37,15 @@ const setupMintedNote = async () => {
   return { createdNoteId, accountId, faucetId };
 };
 
-const setupConsumedNote = async () => {
+export const setupConsumedNote = async () => {
   const { createdNoteId, accountId, faucetId } = await setupMintedNote();
   await consumeTransaction(accountId, faucetId, createdNoteId);
 
-  return { consumedNoteId: createdNoteId };
+  return {
+    consumedNoteId: createdNoteId,
+    accountId: accountId,
+    faucetId: faucetId,
+  };
 };
 
 const getConsumableNotes = async (accountId?: string) => {

--- a/crates/web-client/test/webClientTestUtils.ts
+++ b/crates/web-client/test/webClientTestUtils.ts
@@ -19,7 +19,6 @@ export const mintTransaction = async (
     async (_targetAccountId, _faucetAccountId, _sync) => {
       const client = window.client;
 
-      await new Promise((r) => setTimeout(r, 20000));
       const targetAccountId = window.AccountId.from_hex(_targetAccountId);
       const faucetAccountId = window.AccountId.from_hex(_faucetAccountId);
 


### PR DESCRIPTION
# Summary 
Per the [issue filed here](https://github.com/0xPolygonMiden/miden-client/issues/664), it was possible to hit a `DuplicateOutputNote` Error from the Web Client by creating a custom transaction with multiple output notes that were identical. The reason for this is creating a `NoteRecipient` currently uses the [same default seed ](https://github.com/0xPolygonMiden/miden-client/blob/86cba1512f834a9269fe4f2af7569d96a1d12e75/crates/web-client/src/models/note_recipient.rs#L20) every time so if everything else in the notes were the same, there would be nothing to differentiate the two.

The fix just exposes an additional `serial_num: &Word` parameter to the `Note Recipient` constructor of the Web Client API so that the user can pass in a seed and differentiate notes with otherwise identical information. 