### PR TITLE
chore: Point to `0.7` versions of crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,8 @@ dependencies = [
 [[package]]
 name = "miden-lib"
 version = "0.7.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#829580636d2098978ece0a06d01477e2b3a3a131"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee8babd17ea380c6c5b948761ca63208b633b7130379ee2a57c6d3732d2f8bc"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1508,7 +1509,8 @@ dependencies = [
 [[package]]
 name = "miden-objects"
 version = "0.7.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#829580636d2098978ece0a06d01477e2b3a3a131"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7532561ba51c1edcdc510e4e4a097357d49a2b6ea899d9982176dc5608bfd32e"
 dependencies = [
  "getrandom",
  "miden-assembly",
@@ -1553,8 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "miden-proving-service-client"
-version = "0.1.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#829580636d2098978ece0a06d01477e2b3a3a131"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8bb57ec4864fe7b128a24fcf8872ba18c3229e6cea5aea6194c6b2e2d814a8"
 dependencies = [
  "async-trait",
  "miden-objects",
@@ -1586,7 +1589,8 @@ dependencies = [
 [[package]]
 name = "miden-tx"
 version = "0.7.0"
-source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#829580636d2098978ece0a06d01477e2b3a3a131"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4371509f1e4c25dfe26b7ffcffbb34aaa152c6eaad400f2624240a941baed2d0"
 dependencies = [
  "async-trait",
  "miden-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ repository = "https://github.com/0xPolygonMiden/miden-client"
 
 [workspace.dependencies]
 async-trait = "0.1"
-miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
-miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
-miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
-miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", features = ["tx-prover"] }
+miden-lib = { version = "0.7", default-features = false }
+miden-objects = { version = "0.7", default-features = false }
+miden-tx = { version = "0.7", default-features = false, features = ["async"] }
+miden-proving-service-client = { version = "0.7", default-features = false, features = ["tx-prover"] }
 rand = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { version = "2.0", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="next"
+NODE_BRANCH="main"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"
-PROVER_BRANCH="next"
+PROVER_BRANCH="main"
 PROVER_FEATURES_TESTING=--features "testing"
 PROVER_PORT=50051
 

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -57,7 +57,7 @@ uuid = { version = "1.10", features = ["serde", "v4"] }
 web-sys = { version = "0.3", features = ["console"]}
 
 [build-dependencies]
-miden-rpc-proto = { git = "https://github.com/0xPolygonMiden/miden-node", branch = "next" }
+miden-rpc-proto = { version = "0.7" }
 miden-lib = { workspace = true }
 miette = { version = "7.2", features = ["fancy"] }
 prost = { version = "0.13", default-features = false, features = ["derive"] }

--- a/crates/web-client/Cargo.toml
+++ b/crates/web-client/Cargo.toml
@@ -22,7 +22,7 @@ testing = ["miden-client/testing"]
 miden-client = { version = "0.6", path = "../rust-client", default-features = false, features = ["idxdb", "web-tonic"] }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
-miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false, features = ["tx-prover"] }
+miden-proving-service-client = { workspace = true }
 miden-tx = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
This PR does not prepare for the 0.7 release but points to the newer versions of the crates