### PR TITLE
refactor: remove steps from `StateSync` interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
@@ -474,9 +474,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -825,8 +825,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -837,9 +849,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -944,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -956,9 +968,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1426,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06bf3ad2a85f3f8f0da73b6357c77e482b1ceb36cacda8a2d85caae3bd1f702"
+checksum = "1945918276152bd9b8e8434643ad24d4968e075b68a5ed03927b53ac75490a79"
 dependencies = [
  "blake3",
  "cc",
@@ -1511,11 +1523,11 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4622f71888d4641577d145dd561165824b9b9293fd0be2306326f11bcf39e67d"
+checksum = "8fe3f10d0e3787176f0803be2ecb4646f3a17fe10af45a50736c8d079a3c94d8"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "miden-assembly",
  "miden-core",
  "miden-crypto",
@@ -1577,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "miden-rpc-proto"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2edb867ffc4cd908bb98b48f326016e36158129faba39aef574a0f33433b60"
+checksum = "e68f00e0e97ba6bc65896e5ca2bb0995d59b14fd8f0389916dc2ee792f353f50"
 
 [[package]]
 name = "miden-stdlib"
@@ -1674,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1901,18 +1913,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1921,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2148,7 +2160,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2195,7 +2207,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -2303,9 +2315,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -2354,9 +2366,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -2374,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2385,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -2565,12 +2577,13 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2992,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3032,7 +3045,7 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -3096,6 +3109,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3447,9 +3469,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
 ]
@@ -3554,6 +3576,15 @@ dependencies = [
  "winter-fri",
  "winter-math",
  "winter-utils",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/bin/miden-cli/src/commands/sync.rs
+++ b/bin/miden-cli/src/commands/sync.rs
@@ -12,8 +12,7 @@ impl SyncCmd {
         let new_details = client.sync_state().await?;
 
         println!("State synced to block {}", new_details.block_num);
-        println!("New public notes: {}", new_details.received_notes.len());
-        println!("Tracked notes updated: {}", new_details.committed_notes.len());
+        println!("Committed notes: {}", new_details.committed_notes.len());
         println!("Tracked notes consumed: {}", new_details.consumed_notes.len());
         println!("Tracked accounts updated: {}", new_details.updated_accounts.len());
         println!("Locked accounts: {}", new_details.locked_accounts.len());

--- a/crates/rust-client/src/account.rs
+++ b/crates/rust-client/src/account.rs
@@ -256,7 +256,7 @@ impl<R: FeltRng> Client<R> {
 // ACCOUNT UPDATES
 // ================================================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 /// Contains account changes to apply to the store.
 pub struct AccountUpdates {
     /// Updated public accounts.
@@ -285,6 +285,11 @@ impl AccountUpdates {
     /// Returns the mismatched private accounts.
     pub fn mismatched_private_accounts(&self) -> &[(AccountId, Digest)] {
         &self.mismatched_private_accounts
+    }
+
+    pub fn extend(&mut self, other: AccountUpdates) {
+        self.updated_public_accounts.extend(other.updated_public_accounts);
+        self.mismatched_private_accounts.extend(other.mismatched_private_accounts);
     }
 }
 

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -175,7 +175,7 @@ impl<R: FeltRng> Client<R> {
                 note_record.inclusion_proof_received(inclusion_proof, metadata)?;
 
             if block_height < current_block_num {
-                let mut current_partial_mmr = self.build_current_partial_mmr(true).await?;
+                let mut current_partial_mmr = self.build_current_partial_mmr().await?;
 
                 let block_header = self
                     .get_and_store_authenticated_block(block_height, &mut current_partial_mmr)
@@ -219,7 +219,7 @@ impl<R: FeltRng> Client<R> {
 
         match committed_note_data {
             Some((metadata, inclusion_proof)) => {
-                let mut current_partial_mmr = self.build_current_partial_mmr(true).await?;
+                let mut current_partial_mmr = self.build_current_partial_mmr().await?;
                 let block_header = self
                     .get_and_store_authenticated_block(
                         inclusion_proof.location().block_num(),

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -248,9 +248,9 @@ pub async fn get_input_note_with_id_prefix<R: FeltRng>(
 /// Contains note changes to apply to the store.
 #[derive(Clone, Debug, Default)]
 pub struct NoteUpdates {
-    /// A map of updated input note records corresponding to locally-tracked input notes.
+    /// A map of new and updated input note records to be upserted in the store.
     updated_input_notes: BTreeMap<NoteId, InputNoteRecord>,
-    /// A map of updated output note records corresponding to locally-tracked output notes.
+    /// A map of updated output note records to be upserted in the store.
     updated_output_notes: BTreeMap<NoteId, OutputNoteRecord>,
 }
 
@@ -272,14 +272,12 @@ impl NoteUpdates {
         }
     }
 
-    /// Returns all updated input note records. That is, any input notes that are locally tracked
-    /// and have been updated.
+    /// Returns all input note records that have been updated.
     pub fn updated_input_notes(&self) -> impl Iterator<Item = &InputNoteRecord> {
         self.updated_input_notes.values()
     }
 
-    /// Returns all updated output note records. That is, any output notes that are locally tracked
-    /// and have been updated.
+    /// Returns all updated output note records that have been updated.
     pub fn updated_output_notes(&self) -> impl Iterator<Item = &OutputNoteRecord> {
         self.updated_output_notes.values()
     }
@@ -339,14 +337,18 @@ impl NoteUpdates {
         }
     }
 
+    /// Returns a mutable reference to the input note record with the provided ID if it exists.
     pub fn get_input_note_by_id(&mut self, note_id: &NoteId) -> Option<&mut InputNoteRecord> {
         self.updated_input_notes.get_mut(note_id)
     }
 
+    /// Returns a mutable reference to the output note record with the provided ID if it exists.
     pub fn get_output_note_by_id(&mut self, note_id: &NoteId) -> Option<&mut OutputNoteRecord> {
         self.updated_output_notes.get_mut(note_id)
     }
 
+    /// Returns a mutable reference to the input note record with the provided nullifier if it
+    /// exists.
     pub fn get_input_note_by_nullifier(
         &mut self,
         nullifier: Nullifier,
@@ -354,6 +356,8 @@ impl NoteUpdates {
         self.updated_input_notes.values_mut().find(|note| note.nullifier() == nullifier)
     }
 
+    /// Returns a mutable reference to the output note record with the provided nullifier if it
+    /// exists.
     pub fn get_output_note_by_nullifier(
         &mut self,
         nullifier: Nullifier,

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -341,6 +341,16 @@ impl NoteUpdates {
         }
     }
 
+    /// Returns a mutable reference to the input note record with the provided ID if it exists.
+    pub fn get_input_note_by_id(&mut self, note_id: NoteId) -> Option<&mut InputNoteRecord> {
+        self.updated_input_notes.get_mut(&note_id)
+    }
+
+    /// Returns a mutable reference to the output note record with the provided ID if it exists.
+    pub fn get_output_note_by_id(&mut self, note_id: NoteId) -> Option<&mut OutputNoteRecord> {
+        self.updated_output_notes.get_mut(&note_id)
+    }
+
     /// Returns a mutable reference to the input note record with the provided nullifier if it
     /// exists.
     pub fn get_input_note_by_nullifier(
@@ -348,5 +358,16 @@ impl NoteUpdates {
         nullifier: Nullifier,
     ) -> Option<&mut InputNoteRecord> {
         self.updated_input_notes.values_mut().find(|note| note.nullifier() == nullifier)
+    }
+
+    /// Returns a mutable reference to the output note record with the provided nullifier if it
+    /// exists.
+    pub fn get_output_note_by_nullifier(
+        &mut self,
+        nullifier: Nullifier,
+    ) -> Option<&mut OutputNoteRecord> {
+        self.updated_output_notes
+            .values_mut()
+            .find(|note| note.nullifier() == Some(nullifier))
     }
 }

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -328,6 +328,19 @@ impl NoteUpdates {
         self.updated_output_notes.extend(other.updated_output_notes);
     }
 
+    pub fn insert_updates(
+        &mut self,
+        input_note: Option<InputNoteRecord>,
+        output_note: Option<OutputNoteRecord>,
+    ) {
+        if let Some(input_note) = input_note {
+            self.updated_input_notes.insert(input_note.id(), input_note);
+        }
+        if let Some(output_note) = output_note {
+            self.updated_output_notes.insert(output_note.id(), output_note);
+        }
+    }
+
     /// Returns a mutable reference to the input note record with the provided nullifier if it
     /// exists.
     pub fn get_input_note_by_nullifier(

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -325,8 +325,8 @@ impl NoteUpdates {
 
     pub fn insert_or_ignore_notes(
         &mut self,
-        input_notes: &Vec<InputNoteRecord>,
-        output_notes: &Vec<OutputNoteRecord>,
+        input_notes: &[InputNoteRecord],
+        output_notes: &[OutputNoteRecord],
     ) {
         for note in input_notes {
             self.updated_input_notes.entry(note.id()).or_insert(note.clone());

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -323,28 +323,9 @@ impl NoteUpdates {
         BTreeSet::from_iter(consumed_input_note_ids.chain(consumed_output_note_ids))
     }
 
-    pub fn insert_or_ignore_notes(
-        &mut self,
-        input_notes: &[InputNoteRecord],
-        output_notes: &[OutputNoteRecord],
-    ) {
-        for note in input_notes {
-            self.updated_input_notes.entry(note.id()).or_insert(note.clone());
-        }
-
-        for note in output_notes {
-            self.updated_output_notes.entry(note.id()).or_insert(note.clone());
-        }
-    }
-
-    /// Returns a mutable reference to the input note record with the provided ID if it exists.
-    pub fn get_input_note_by_id(&mut self, note_id: &NoteId) -> Option<&mut InputNoteRecord> {
-        self.updated_input_notes.get_mut(note_id)
-    }
-
-    /// Returns a mutable reference to the output note record with the provided ID if it exists.
-    pub fn get_output_note_by_id(&mut self, note_id: &NoteId) -> Option<&mut OutputNoteRecord> {
-        self.updated_output_notes.get_mut(note_id)
+    pub fn extend(&mut self, other: NoteUpdates) {
+        self.updated_input_notes.extend(other.updated_input_notes);
+        self.updated_output_notes.extend(other.updated_output_notes);
     }
 
     /// Returns a mutable reference to the input note record with the provided nullifier if it
@@ -354,16 +335,5 @@ impl NoteUpdates {
         nullifier: Nullifier,
     ) -> Option<&mut InputNoteRecord> {
         self.updated_input_notes.values_mut().find(|note| note.nullifier() == nullifier)
-    }
-
-    /// Returns a mutable reference to the output note record with the provided nullifier if it
-    /// exists.
-    pub fn get_output_note_by_nullifier(
-        &mut self,
-        nullifier: Nullifier,
-    ) -> Option<&mut OutputNoteRecord> {
-        self.updated_output_notes
-            .values_mut()
-            .find(|note| note.nullifier() == Some(nullifier))
     }
 }

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -56,8 +56,11 @@
 //! For more details on the API and error handling, see the documentation for the specific functions
 //! and types in this module.
 
-use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
-use std::collections::BTreeMap;
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::ToString,
+    vec::Vec,
+};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{account::AccountId, crypto::rand::FeltRng};

--- a/crates/rust-client/src/rpc/domain/nullifier.rs
+++ b/crates/rust-client/src/rpc/domain/nullifier.rs
@@ -6,6 +6,7 @@ use crate::rpc::{errors::RpcConversionError, generated::digest::Digest};
 // ================================================================================================
 
 /// Represents a note that was consumed in the node at a certain block.
+#[derive(Debug, Clone)]
 pub struct NullifierUpdate {
     /// The nullifier of the consumed note.
     pub nullifier: Nullifier,

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -327,15 +327,7 @@ pub trait Store: Send + Sync {
     ///     locally does not match the `StateSyncUpdate` information, the account may be locked.
     /// - Storing new MMR authentication nodes.
     /// - Updating the tracked public accounts.
-    ///
-    /// A [StateSyncUpdate] corresponds to an update from a single `SyncState` RPC call. For the
-    /// client to be up to date against the current chain tip, multiple calls may be performed, and
-    /// so multiple store updates could happen sequentially.
-    async fn apply_state_sync_step(
-        &self,
-        state_sync_update: StateSyncUpdate,
-        new_block_has_relevant_notes: bool,
-    ) -> Result<(), StoreError>;
+    async fn apply_state_sync(&self, state_sync_update: StateSyncUpdate) -> Result<(), StoreError>;
 }
 
 // CHAIN MMR NODE FILTER

--- a/crates/rust-client/src/store/sqlite_store/mod.rs
+++ b/crates/rust-client/src/store/sqlite_store/mod.rs
@@ -144,13 +144,9 @@ impl Store for SqliteStore {
         self.interact_with_connection(SqliteStore::get_sync_height).await
     }
 
-    async fn apply_state_sync_step(
-        &self,
-        state_sync_update: StateSyncUpdate,
-        block_has_relevant_notes: bool,
-    ) -> Result<(), StoreError> {
+    async fn apply_state_sync(&self, state_sync_update: StateSyncUpdate) -> Result<(), StoreError> {
         self.interact_with_connection(move |conn| {
-            SqliteStore::apply_state_sync_step(conn, state_sync_update, block_has_relevant_notes)
+            SqliteStore::apply_state_sync(conn, state_sync_update)
         })
         .await
     }

--- a/crates/rust-client/src/store/sqlite_store/note.rs
+++ b/crates/rust-client/src/store/sqlite_store/note.rs
@@ -587,17 +587,11 @@ pub(crate) fn apply_note_updates_tx(
     tx: &Transaction,
     note_updates: &NoteUpdates,
 ) -> Result<(), StoreError> {
-    for input_note in
-        note_updates.new_input_notes().iter().chain(note_updates.updated_input_notes())
-    {
+    for input_note in note_updates.updated_input_notes() {
         upsert_input_note_tx(tx, input_note)?;
     }
 
-    for output_note in note_updates
-        .new_output_notes()
-        .iter()
-        .chain(note_updates.updated_output_notes())
-    {
+    for output_note in note_updates.updated_output_notes() {
         upsert_output_note_tx(tx, output_note)?;
     }
 

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -101,7 +101,6 @@ impl SqliteStore {
             note_updates,
             transaction_updates,
             account_updates,
-            tags_to_remove,
         } = state_sync_update;
 
         let mut locked_accounts = vec![];
@@ -141,6 +140,12 @@ impl SqliteStore {
         apply_note_updates_tx(&tx, &note_updates)?;
 
         // Remove tags
+        let tags_to_remove = note_updates.committed_input_notes().map(|note| {
+            NoteTagRecord::with_note_source(
+                note.metadata().expect("Committed notes should have metadata").tag(),
+                note.id(),
+            )
+        });
         for tag in tags_to_remove {
             remove_note_tag_tx(&tx, tag)?;
         }

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -94,14 +94,12 @@ impl SqliteStore {
     pub(super) fn apply_state_sync_step(
         conn: &mut Connection,
         state_sync_update: StateSyncUpdate,
-        block_has_relevant_notes: bool,
+        _block_has_relevant_notes: bool,
     ) -> Result<(), StoreError> {
         let StateSyncUpdate {
-            block_header,
+            block_headers,
             note_updates,
             transaction_updates,
-            new_mmr_peaks,
-            new_authentication_nodes,
             account_updates,
             tags_to_remove,
         } = state_sync_update;
@@ -125,10 +123,25 @@ impl SqliteStore {
 
         // Update state sync block number
         const BLOCK_NUMBER_QUERY: &str = "UPDATE state_sync SET block_num = ?";
-        tx.execute(BLOCK_NUMBER_QUERY, params![block_header.block_num().as_u32() as i64])?;
+        if let Some(max_block_num) =
+            block_headers.iter().map(|(header, ..)| header.block_num().as_u32()).max()
+        {
+            tx.execute(BLOCK_NUMBER_QUERY, params![max_block_num as i64])?;
+        }
 
-        Self::insert_block_header_tx(&tx, block_header, new_mmr_peaks, block_has_relevant_notes)?;
+        for (block_header, block_has_relevant_notes, new_mmr_peaks, new_authentication_nodes) in
+            block_headers
+        {
+            Self::insert_block_header_tx(
+                &tx,
+                block_header,
+                new_mmr_peaks,
+                block_has_relevant_notes,
+            )?;
 
+            // Insert new authentication nodes (inner nodes of the PartialMmr)
+            Self::insert_chain_mmr_nodes_tx(&tx, &new_authentication_nodes)?;
+        }
         // Update notes
         apply_note_updates_tx(&tx, &note_updates)?;
 
@@ -136,9 +149,6 @@ impl SqliteStore {
         for tag in tags_to_remove {
             remove_note_tag_tx(&tx, tag)?;
         }
-
-        // Insert new authentication nodes (inner nodes of the PartialMmr)
-        Self::insert_chain_mmr_nodes_tx(&tx, &new_authentication_nodes)?;
 
         // Mark transactions as committed
         Self::mark_transactions_as_committed(&tx, transaction_updates.committed_transactions())?;

--- a/crates/rust-client/src/store/web_store/mod.rs
+++ b/crates/rust-client/src/store/web_store/mod.rs
@@ -79,12 +79,8 @@ impl Store for WebStore {
         self.get_sync_height().await
     }
 
-    async fn apply_state_sync_step(
-        &self,
-        state_sync_update: StateSyncUpdate,
-        block_has_relevant_notes: bool,
-    ) -> Result<(), StoreError> {
-        self.apply_state_sync_step(state_sync_update, block_has_relevant_notes).await
+    async fn apply_state_sync(&self, state_sync_update: StateSyncUpdate) -> Result<(), StoreError> {
+        self.apply_state_sync(state_sync_update).await
     }
 
     // TRANSACTIONS

--- a/crates/rust-client/src/store/web_store/note/utils.rs
+++ b/crates/rust-client/src/store/web_store/note/utils.rs
@@ -193,17 +193,11 @@ pub fn parse_output_note_idxdb_object(
 }
 
 pub(crate) async fn apply_note_updates_tx(note_updates: &NoteUpdates) -> Result<(), StoreError> {
-    for input_note in
-        note_updates.new_input_notes().iter().chain(note_updates.updated_input_notes())
-    {
+    for input_note in note_updates.updated_input_notes() {
         upsert_input_note_tx(input_note).await?;
     }
 
-    for output_note in note_updates
-        .new_output_notes()
-        .iter()
-        .chain(note_updates.updated_output_notes())
-    {
+    for output_note in note_updates.updated_output_notes() {
         upsert_output_note_tx(output_note).await?;
     }
 

--- a/crates/rust-client/src/store/web_store/sync/js_bindings.rs
+++ b/crates/rust-client/src/store/web_store/sync/js_bindings.rs
@@ -3,6 +3,8 @@ use alloc::{string::String, vec::Vec};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::*;
 
+use super::flattened_vec::FlattenedU8Vec;
+
 // Sync IndexedDB Operations
 #[wasm_bindgen(module = "/src/store/web_store/js/sync.js")]
 
@@ -29,9 +31,10 @@ extern "C" {
     #[wasm_bindgen(js_name = applyStateSync)]
     pub fn idxdb_apply_state_sync(
         block_num: String,
-        block_header: Vec<u8>,
-        chain_mmr_peaks: Vec<u8>,
-        has_client_notes: bool,
+        flattened_new_block_headers: FlattenedU8Vec,
+        new_block_nums: Vec<String>,
+        flattened_chain_mmr_peaks: FlattenedU8Vec,
+        has_client_notes: Vec<u8>,
         serialized_node_ids: Vec<String>,
         serialized_nodes: Vec<String>,
         note_tags_to_remove_as_str: Vec<String>,

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -111,7 +111,6 @@ impl WebStore {
             note_updates,
             transaction_updates, //TODO: Add support for discarded transactions in web store
             account_updates,
-            tags_to_remove,
         } = state_sync_update;
 
         // Serialize data for updating state sync and block header
@@ -144,16 +143,8 @@ impl WebStore {
         apply_note_updates_tx(&note_updates).await?;
 
         // Tags to remove
-        let note_tags_to_remove_as_str: Vec<String> = tags_to_remove
-            .iter()
-            .filter_map(|tag_record| {
-                if let NoteTagSource::Note(note_id) = tag_record.source {
-                    Some(note_id.to_hex())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let note_tags_to_remove_as_str: Vec<String> =
+            note_updates.committed_input_notes().map(|note| note.id().to_hex()).collect();
 
         // Serialize data for updating committed transactions
         let transactions_to_commit_block_nums_as_str = transaction_updates

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -29,6 +29,9 @@ use js_bindings::*;
 mod models;
 use models::*;
 
+mod flattened_vec;
+use flattened_vec::*;
+
 impl WebStore {
     pub(crate) async fn get_note_tags(&self) -> Result<Vec<NoteTagRecord>, StoreError> {
         let promise = idxdb_get_note_tags();
@@ -98,32 +101,39 @@ impl WebStore {
         Ok(removed_tags)
     }
 
-    pub(super) async fn apply_state_sync_step(
+    pub(super) async fn apply_state_sync(
         &self,
         state_sync_update: StateSyncUpdate,
-        block_has_relevant_notes: bool,
     ) -> Result<(), StoreError> {
         let StateSyncUpdate {
-            block_header,
+            block_num,
+            block_updates,
             note_updates,
             transaction_updates, //TODO: Add support for discarded transactions in web store
-            new_mmr_peaks,
-            new_authentication_nodes,
             account_updates,
             tags_to_remove,
         } = state_sync_update;
 
         // Serialize data for updating state sync and block header
-        let block_num_as_str = block_header.block_num().to_string();
+        let block_num_as_str = block_num.to_string();
 
         // Serialize data for updating block header
-        let block_header_as_bytes = block_header.to_bytes();
-        let new_mmr_peaks_as_bytes = new_mmr_peaks.peaks().to_vec().to_bytes();
+        let mut block_headers_as_bytes = vec![];
+        let mut new_mmr_peaks_as_bytes = vec![];
+        let mut block_nums_as_str = vec![];
+        let mut block_has_relevant_notes = vec![];
+
+        for (block_header, has_client_notes, mmr_peaks) in block_updates.block_headers.iter() {
+            block_headers_as_bytes.push(block_header.to_bytes());
+            new_mmr_peaks_as_bytes.push(mmr_peaks.peaks().to_vec().to_bytes());
+            block_nums_as_str.push(block_header.block_num().to_string());
+            block_has_relevant_notes.push(*has_client_notes as u8);
+        }
 
         // Serialize data for updating chain MMR nodes
         let mut serialized_node_ids = Vec::new();
         let mut serialized_nodes = Vec::new();
-        for (id, node) in new_authentication_nodes.iter() {
+        for (id, node) in block_updates.new_authentication_nodes.iter() {
             let serialized_data = serialize_chain_mmr_node(*id, *node)?;
             serialized_node_ids.push(serialized_data.id);
             serialized_nodes.push(serialized_data.node);
@@ -178,8 +188,9 @@ impl WebStore {
 
         let promise = idxdb_apply_state_sync(
             block_num_as_str,
-            block_header_as_bytes,
-            new_mmr_peaks_as_bytes,
+            flatten_nested_u8_vec(block_headers_as_bytes),
+            block_nums_as_str,
+            flatten_nested_u8_vec(new_mmr_peaks_as_bytes),
             block_has_relevant_notes,
             serialized_node_ids,
             serialized_nodes,

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -13,9 +13,15 @@ use crate::{
     Client, ClientError,
 };
 
+/// Contains all the block information that needs to be added in the client's store after a sync.
+
 #[derive(Debug, Clone, Default)]
 pub struct BlockUpdates {
+    /// New block headers to be stored, along with a flag indicating whether the block contains
+    /// notes that are relevant to the client and the MMR peaks for the block.
     pub block_headers: Vec<(BlockHeader, bool, MmrPeaks)>,
+    /// New authentication nodes that are meant to be stored in order to authenticate block
+    /// headers.
     pub new_authentication_nodes: Vec<(InOrderIndex, Digest)>,
 }
 

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -37,7 +37,7 @@ impl<R: FeltRng> Client<R> {
     /// Updates committed notes with no MMR data. These could be notes that were
     /// imported with an inclusion proof, but its block header isn't tracked.
     pub(crate) async fn update_mmr_data(&self) -> Result<(), ClientError> {
-        let mut current_partial_mmr = self.build_current_partial_mmr(true).await?;
+        let mut current_partial_mmr = self.build_current_partial_mmr().await?;
 
         let mut changed_notes = vec![];
         for mut note in self.store.get_input_notes(NoteFilter::Unverified).await? {
@@ -96,10 +96,7 @@ impl<R: FeltRng> Client<R> {
     ///
     /// As part of the syncing process, we add the current block number so we don't need to
     /// track it here.
-    pub(crate) async fn build_current_partial_mmr(
-        &self,
-        include_current_block: bool,
-    ) -> Result<PartialMmr, ClientError> {
+    pub(crate) async fn build_current_partial_mmr(&self) -> Result<PartialMmr, ClientError> {
         let current_block_num = self.store.get_sync_height().await?;
 
         let tracked_nodes = self.store.get_chain_mmr_nodes(ChainMmrNodeFilter::All).await?;
@@ -121,15 +118,13 @@ impl<R: FeltRng> Client<R> {
         let mut current_partial_mmr =
             PartialMmr::from_parts(current_peaks, tracked_nodes, track_latest);
 
-        if include_current_block {
-            let (current_block, has_client_notes) = self
-                .store
-                .get_block_header_by_num(current_block_num)
-                .await?
-                .expect("Current block should be in the store");
+        let (current_block, has_client_notes) = self
+            .store
+            .get_block_header_by_num(current_block_num)
+            .await?
+            .expect("Current block should be in the store");
 
-            current_partial_mmr.add(current_block.hash(), has_client_notes);
-        }
+        current_partial_mmr.add(current_block.hash(), has_client_notes);
 
         Ok(current_partial_mmr)
     }
@@ -197,7 +192,7 @@ impl<R: FeltRng> Client<R> {
             return self.ensure_genesis_in_place().await;
         }
 
-        let mut current_partial_mmr = self.build_current_partial_mmr(true).await?;
+        let mut current_partial_mmr = self.build_current_partial_mmr().await?;
         let anchor_block = self
             .get_and_store_authenticated_block(epoch_block_number, &mut current_partial_mmr)
             .await?;

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -188,13 +188,6 @@ impl<R: FeltRng> Client<R> {
         );
 
         // Get current state of the client
-        let current_block_num = self.store.get_sync_height().await?;
-        let (current_block, has_relevant_notes) = self
-            .store
-            .get_block_header_by_num(current_block_num)
-            .await?
-            .expect("Current block should be in the store");
-
         let accounts = self
             .store
             .get_account_headers()
@@ -212,9 +205,7 @@ impl<R: FeltRng> Client<R> {
         // Get the sync update from the network
         let state_sync_update = state_sync
             .sync_state(
-                current_block,
-                has_relevant_notes,
-                self.build_current_partial_mmr(false).await?,
+                self.build_current_partial_mmr().await?,
                 accounts,
                 note_tags,
                 unspent_input_notes,

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -182,10 +182,9 @@ impl<R: FeltRng> Client<R> {
             self.rpc_api.clone(),
             Box::new({
                 let store_clone = self.store.clone();
-                move |note_updates, committed_note, block_header, new_public_notes| {
+                move |committed_note, block_header, new_public_notes| {
                     Box::pin(on_note_received(
                         store_clone.clone(),
-                        note_updates,
                         committed_note,
                         block_header,
                         new_public_notes,
@@ -194,10 +193,9 @@ impl<R: FeltRng> Client<R> {
             }),
             Box::new({
                 let store_clone = self.store.clone();
-                move |note_updates, nullifier_update, committed_transactions| {
+                move |nullifier_update, committed_transactions| {
                     Box::pin(on_nullifier_received(
                         store_clone.clone(),
-                        note_updates,
                         nullifier_update,
                         committed_transactions,
                     ))

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -374,7 +374,7 @@ async fn test_sync_state_mmr() {
     );
 
     // Try reconstructing the chain_mmr from what's in the database
-    let partial_mmr = client.build_current_partial_mmr(true).await.unwrap();
+    let partial_mmr = client.build_current_partial_mmr().await.unwrap();
     assert_eq!(partial_mmr.forest(), 6);
     assert!(partial_mmr.open(0).unwrap().is_some()); // Account anchor block
     assert!(partial_mmr.open(1).unwrap().is_some());

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -155,6 +155,11 @@ impl TransactionUpdates {
     pub fn discarded_transactions(&self) -> &[TransactionId] {
         &self.discarded_transactions
     }
+
+    /// Inserts a committed transaction into the transaction updates.
+    pub fn discarded_transaction(&mut self, transaction_id: TransactionId) {
+        self.discarded_transactions.push(transaction_id);
+    }
 }
 
 // TRANSACTION RESULT

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -363,10 +363,8 @@ impl TransactionStoreUpdate {
             executed_transaction,
             updated_account,
             note_updates: NoteUpdates::new(
-                created_input_notes,
+                [created_input_notes, updated_input_notes].concat(),
                 created_output_notes,
-                updated_input_notes,
-                vec![],
             ),
             new_tags,
         }

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -913,7 +913,7 @@ impl<R: FeltRng> Client<R> {
             let summary = self.sync_state().await?;
 
             if summary.block_num != block_num {
-                let mut current_partial_mmr = self.build_current_partial_mmr(true).await?;
+                let mut current_partial_mmr = self.build_current_partial_mmr().await?;
                 self.get_and_store_authenticated_block(block_num, &mut current_partial_mmr)
                     .await?;
             }

--- a/crates/web-client/package-lock.json
+++ b/crates/web-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.6.1-next.3",
+  "version": "0.6.1-next.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@demox-labs/miden-sdk",
-      "version": "0.6.1-next.3",
+      "version": "0.6.1-next.4",
       "dependencies": {
         "chai-as-promised": "^8.0.0",
         "dexie": "^4.0.1",

--- a/crates/web-client/src/models/sync_summary.rs
+++ b/crates/web-client/src/models/sync_summary.rs
@@ -12,10 +12,6 @@ impl SyncSummary {
         self.0.block_num.as_u32()
     }
 
-    pub fn received_notes(&self) -> Vec<NoteId> {
-        self.0.received_notes.iter().map(|note_id| note_id.into()).collect()
-    }
-
     pub fn committed_notes(&self) -> Vec<NoteId> {
         self.0.committed_notes.iter().map(|note_id| note_id.into()).collect()
     }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -850,8 +850,7 @@ async fn test_sync_detail_values() {
 
     // Second client sync should have new note
     let new_details = client2.sync_state().await.unwrap();
-    assert_eq!(new_details.received_notes.len(), 1);
-    assert_eq!(new_details.committed_notes.len(), 0);
+    assert_eq!(new_details.committed_notes.len(), 1);
     assert_eq!(new_details.consumed_notes.len(), 0);
     assert_eq!(new_details.updated_accounts.len(), 0);
 
@@ -861,7 +860,6 @@ async fn test_sync_detail_values() {
 
     // First client sync should have a new nullifier as the note was consumed
     let new_details = client1.sync_state().await.unwrap();
-    assert_eq!(new_details.received_notes.len(), 0);
     assert_eq!(new_details.committed_notes.len(), 0);
     assert_eq!(new_details.consumed_notes.len(), 1);
 }

--- a/tests/integration/onchain_tests.rs
+++ b/tests/integration/onchain_tests.rs
@@ -87,7 +87,8 @@ async fn test_onchain_notes_flow() {
     client_3.add_note_tag(note.metadata().tag()).await.unwrap();
     client_3.sync_state().await.unwrap();
 
-    // client 3 should have two notes, the one directed to them and the one consumed by client 2 (which should come from the tag added)
+    // client 3 should have two notes, the one directed to them and the one consumed by client 2
+    // (which should come from the tag added)
     assert_eq!(client_3.get_input_notes(NoteFilter::Committed).await.unwrap().len(), 1);
     assert_eq!(client_3.get_input_notes(NoteFilter::Consumed).await.unwrap().len(), 1);
 

--- a/tests/integration/onchain_tests.rs
+++ b/tests/integration/onchain_tests.rs
@@ -84,8 +84,13 @@ async fn test_onchain_notes_flow() {
     execute_tx_and_sync(&mut client_2, basic_wallet_1.id(), tx_request).await;
 
     // sync client 3 (basic account 2)
+    client_3.add_note_tag(note.metadata().tag()).await.unwrap();
     client_3.sync_state().await.unwrap();
-    // client 3 should only have one note
+
+    // client 3 should have two notes, the one directed to them and the one consumed by client 2 (which should come from the tag added)
+    assert_eq!(client_3.get_input_notes(NoteFilter::Committed).await.unwrap().len(), 1);
+    assert_eq!(client_3.get_input_notes(NoteFilter::Consumed).await.unwrap().len(), 1);
+
     let note = client_3
         .get_input_notes(NoteFilter::Committed)
         .await


### PR DESCRIPTION
This version is still a WIP.

The idea is to remove the sync steps from the interface of the `StateSync` so that the user doesn't have to deal with them and the sync is shown as a single step process.

After some bug fixing, the rust tests are passing so this version works! It's a bit messy and the documentation is now outdated. Will be working on this next but the main changes can be discussed:

### Main changes
The main change with this new functionality is that we relied on store to persist the updates on each step but if we remove the steps, we need to store the intermediate states of notes on each step and update them accordingly without storing them. The changes made in `state_sync.rs` can be summarized as:
- `NoteUpdates`: Instead of being 4 vectors of notes, now it's 2 maps (one for input and another for output notes). This means that it is better for retrieving the state of a specific note. Additionally, a new `insert_or_ignore` is used to add the state in the store (before starting the sync process) to the note update, if the note is not tracked in the update it is inserted but if it's tracked (meaning that it was modified in a previous step) then it is ignored.
- Callbacks: Each callback now receives a `NoteUpdates` with the state of changed notes since the start of the sync process. The callbacks use the `insert_or_ignore` to add notes if needed and then apply the state changes to the `NoteUpdates` to update it with the new event. The updated `NoteUpdates` is returned.
    - Why not just give a mutable reference for the `NoteUpdates`? This was my first approach but there are problems with the lifetimes of the closures and the received references. In theory it wouldn't be a problem as both lifetimes are the same but the rust compiler can be sure of this and will doesn't like the references in the closure.
- `BlockUpdates`: Now a `SyncStateUpdate` represents an update after multiple steps, so it may contain multiple new block headers. All of the data related to each new block is stored in a new `BlockUpdates` struct.
- New `OnBlockReceived` callback: This callback was added to deal with the arrival of each new block. It is used to have a store access to check the relevance of each block received. The component in general still doesn't have access to the store so this callback is needed. 