### PR TITLE
feat: give interior mutability to rpc client

### DIFF
--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -112,7 +112,7 @@ impl Cli {
         let authenticator = StoreAuthenticator::new_with_rng(store.clone() as Arc<dyn Store>, rng);
 
         let client = Client::new(
-            Box::new(
+            Arc::new(
                 TonicRpcClient::new(
                     cli_config.rpc.endpoint.clone().into(),
                     cli_config.rpc.timeout_ms,

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -112,10 +112,14 @@ impl Cli {
         let authenticator = StoreAuthenticator::new_with_rng(store.clone() as Arc<dyn Store>, rng);
 
         let client = Client::new(
-            Box::new(TonicRpcClient::new(
-                &(cli_config.rpc.endpoint.clone().into()),
-                cli_config.rpc.timeout_ms,
-            )),
+            Box::new(
+                TonicRpcClient::new(
+                    cli_config.rpc.endpoint.clone().into(),
+                    cli_config.rpc.timeout_ms,
+                )
+                .await
+                .map_err(ClientError::RpcError)?,
+            ),
             rng,
             store as Arc<dyn Store>,
             Arc::new(authenticator),

--- a/bin/miden-cli/src/lib.rs
+++ b/bin/miden-cli/src/lib.rs
@@ -112,14 +112,10 @@ impl Cli {
         let authenticator = StoreAuthenticator::new_with_rng(store.clone() as Arc<dyn Store>, rng);
 
         let client = Client::new(
-            Arc::new(
-                TonicRpcClient::new(
-                    cli_config.rpc.endpoint.clone().into(),
-                    cli_config.rpc.timeout_ms,
-                )
-                .await
-                .map_err(ClientError::RpcError)?,
-            ),
+            Arc::new(TonicRpcClient::new(
+                &cli_config.rpc.endpoint.clone().into(),
+                cli_config.rpc.timeout_ms,
+            )),
             rng,
             store as Arc<dyn Store>,
             Arc::new(authenticator),

--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -710,11 +710,7 @@ async fn create_test_client_with_store_path(store_path: &Path) -> TestClient {
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
-        Arc::new(
-            TonicRpcClient::new(rpc_config.endpoint.into(), rpc_config.timeout_ms)
-                .await
-                .unwrap(),
-        ),
+        Arc::new(TonicRpcClient::new(&rpc_config.endpoint.into(), rpc_config.timeout_ms)),
         rng,
         store,
         Arc::new(authenticator),

--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -3,6 +3,7 @@ use std::{
     fs::File,
     io::{Read, Write},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use assert_cmd::Command;
@@ -699,7 +700,7 @@ async fn create_test_client_with_store_path(store_path: &Path) -> TestClient {
 
     let store = {
         let sqlite_store = SqliteStore::new(PathBuf::from(store_path)).await.unwrap();
-        std::sync::Arc::new(sqlite_store)
+        Arc::new(sqlite_store)
     };
 
     let mut rng = rand::thread_rng();
@@ -709,14 +710,14 @@ async fn create_test_client_with_store_path(store_path: &Path) -> TestClient {
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
-        Box::new(
+        Arc::new(
             TonicRpcClient::new(rpc_config.endpoint.into(), rpc_config.timeout_ms)
                 .await
                 .unwrap(),
         ),
         rng,
         store,
-        std::sync::Arc::new(authenticator),
+        Arc::new(authenticator),
         true,
     )
 }

--- a/bin/miden-cli/src/tests.rs
+++ b/bin/miden-cli/src/tests.rs
@@ -709,7 +709,11 @@ async fn create_test_client_with_store_path(store_path: &Path) -> TestClient {
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
-        Box::new(TonicRpcClient::new(&(rpc_config.endpoint.into()), rpc_config.timeout_ms)),
+        Box::new(
+            TonicRpcClient::new(rpc_config.endpoint.into(), rpc_config.timeout_ms)
+                .await
+                .unwrap(),
+        ),
         rng,
         store,
         std::sync::Arc::new(authenticator),

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -25,7 +25,7 @@ idxdb = ["dep:base64", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-b
 sqlite = ["dep:rusqlite", "dep:deadpool-sqlite", "std"]
 std = ["miden-objects/std"]
 testing = ["miden-objects/testing", "miden-lib/testing", "miden-tx/testing"]
-tonic = ["std", "tonic/transport", "tonic/tls", "tonic/tls-native-roots", "tokio"]
+tonic = ["std", "tonic/transport", "tonic/tls", "tonic/tls-native-roots", "dep:tokio"]
 web-tonic = ["dep:tonic-web-wasm-client"]
 
 [dependencies]

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -25,7 +25,7 @@ idxdb = ["dep:base64", "dep:serde-wasm-bindgen", "dep:wasm-bindgen", "dep:wasm-b
 sqlite = ["dep:rusqlite", "dep:deadpool-sqlite", "std"]
 std = ["miden-objects/std"]
 testing = ["miden-objects/testing", "miden-lib/testing", "miden-tx/testing"]
-tonic = ["std", "tonic/transport", "tonic/tls", "tonic/tls-native-roots"]
+tonic = ["std", "tonic/transport", "tonic/tls", "tonic/tls-native-roots", "tokio"]
 web-tonic = ["dep:tonic-web-wasm-client"]
 
 [dependencies]

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -99,8 +99,6 @@
 #[macro_use]
 extern crate alloc;
 
-use alloc::boxed::Box;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -210,7 +208,7 @@ pub struct Client<R: FeltRng> {
     rng: R,
     /// An instance of [`NodeRpcClient`] which provides a way for the client to connect to the
     /// Miden node.
-    rpc_api: Box<dyn NodeRpcClient + Send>,
+    rpc_api: Arc<dyn NodeRpcClient + Send>,
     /// An instance of a [`LocalTransactionProver`] which will be the default prover for the
     /// client.
     tx_prover: Arc<LocalTransactionProver>,
@@ -246,7 +244,7 @@ impl<R: FeltRng> Client<R> {
     ///
     /// Returns an error if the client couldn't be instantiated.
     pub fn new(
-        rpc_api: Box<dyn NodeRpcClient + Send>,
+        rpc_api: Arc<dyn NodeRpcClient + Send>,
         rng: R,
         store: Arc<dyn Store>,
         authenticator: Arc<dyn TransactionAuthenticator>,
@@ -287,7 +285,7 @@ impl<R: FeltRng> Client<R> {
     // --------------------------------------------------------------------------------------------
 
     #[cfg(any(test, feature = "testing"))]
-    pub fn test_rpc_api(&mut self) -> &mut Box<dyn NodeRpcClient + Send> {
+    pub fn test_rpc_api(&mut self) -> &mut Arc<dyn NodeRpcClient + Send> {
         &mut self.rpc_api
     }
 

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -80,7 +80,7 @@
 //! // Instantiate the client using a Tonic RPC client
 //! let endpoint = Endpoint::new("https".into(), "localhost".into(), Some(57291));
 //! let client: Client<RpoRandomCoin> = Client::new(
-//!     Arc::new(TonicRpcClient::new(endpoint, 10_000).await.unwrap()),
+//!     Arc::new(TonicRpcClient::new(&endpoint, 10_000)),
 //!     rng,
 //!     store,
 //!     Arc::new(authenticator),

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -80,7 +80,7 @@
 //! // Instantiate the client using a Tonic RPC client
 //! let endpoint = Endpoint::new("https".into(), "localhost".into(), Some(57291));
 //! let client: Client<RpoRandomCoin> = Client::new(
-//!     Box::new(TonicRpcClient::new(&endpoint, 10_000)),
+//!     Arc::new(TonicRpcClient::new(endpoint, 10_000).await.unwrap()),
 //!     rng,
 //!     store,
 //!     Arc::new(authenticator),

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -319,9 +319,9 @@ pub async fn create_test_client() -> (MockClient, MockRpcApi) {
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     let rpc_api = MockRpcApi::new();
-    let boxed_rpc_api = Box::new(rpc_api.clone());
+    let arc_rpc_api = Arc::new(rpc_api.clone());
 
-    let client = MockClient::new(boxed_rpc_api, rng, store, Arc::new(authenticator), true);
+    let client = MockClient::new(arc_rpc_api, rng, store, Arc::new(authenticator), true);
     (client, rpc_api)
 }
 

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -262,7 +262,7 @@ impl NodeRpcClient for MockRpcApi {
     }
 
     async fn get_notes_by_id(&self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError> {
-        // assume all off-chain notes for now
+        // assume all private notes for now
         let hit_notes = note_ids.iter().filter_map(|id| self.notes.get(id));
         let mut return_notes = vec![];
         for note in hit_notes {

--- a/crates/rust-client/src/mock.rs
+++ b/crates/rust-client/src/mock.rs
@@ -208,7 +208,7 @@ use alloc::boxed::Box;
 #[async_trait(?Send)]
 impl NodeRpcClient for MockRpcApi {
     async fn sync_notes(
-        &mut self,
+        &self,
         _block_num: BlockNumber,
         _note_tags: &[NoteTag],
     ) -> Result<NoteSyncInfo, RpcError> {
@@ -224,7 +224,7 @@ impl NodeRpcClient for MockRpcApi {
 
     /// Executes the specified sync state request and returns the response.
     async fn sync_state(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         _account_ids: &[AccountId],
         _note_tags: &[NoteTag],
@@ -239,7 +239,7 @@ impl NodeRpcClient for MockRpcApi {
     /// Creates and executes a [GetBlockHeaderByNumberRequest].
     /// Only used for retrieving genesis block right now so that's the only case we need to cover.
     async fn get_block_header_by_number(
-        &mut self,
+        &self,
         block_num: Option<BlockNumber>,
         include_mmr_proof: bool,
     ) -> Result<(BlockHeader, Option<MmrProof>), RpcError> {
@@ -261,8 +261,8 @@ impl NodeRpcClient for MockRpcApi {
         Ok((block.header(), mmr_proof))
     }
 
-    async fn get_notes_by_id(&mut self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError> {
-        // assume all private notes for now
+    async fn get_notes_by_id(&self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError> {
+        // assume all off-chain notes for now
         let hit_notes = note_ids.iter().filter_map(|id| self.notes.get(id));
         let mut return_notes = vec![];
         for note in hit_notes {
@@ -276,23 +276,20 @@ impl NodeRpcClient for MockRpcApi {
     }
 
     async fn submit_proven_transaction(
-        &mut self,
+        &self,
         _proven_transaction: ProvenTransaction,
     ) -> std::result::Result<(), RpcError> {
         // TODO: add some basic validations to test error cases
         Ok(())
     }
 
-    async fn get_account_update(
-        &mut self,
-        _account_id: AccountId,
-    ) -> Result<AccountDetails, RpcError> {
+    async fn get_account_update(&self, _account_id: AccountId) -> Result<AccountDetails, RpcError> {
         panic!("shouldn't be used for now")
     }
 
     async fn get_account_proofs(
-        &mut self,
-        _account_ids: &BTreeSet<ForeignAccount>,
+        &self,
+        _: &BTreeSet<ForeignAccount>,
         _code_commitments: Vec<AccountCode>,
     ) -> Result<AccountProofs, RpcError> {
         // TODO: Implement fully
@@ -300,7 +297,7 @@ impl NodeRpcClient for MockRpcApi {
     }
 
     async fn check_nullifiers_by_prefix(
-        &mut self,
+        &self,
         _prefix: &[u16],
     ) -> Result<Vec<(miden_objects::note::Nullifier, u32)>, RpcError> {
         // Always return an empty list for now since it's only used when importing

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -94,7 +94,7 @@ impl<R: FeltRng> Client<R> {
     /// - If the note doesn't exist on the node.
     /// - If the note exists but is private.
     async fn import_note_record_by_id(
-        &mut self,
+        &self,
         previous_note: Option<InputNoteRecord>,
         id: NoteId,
     ) -> Result<Option<InputNoteRecord>, ClientError> {
@@ -136,7 +136,7 @@ impl<R: FeltRng> Client<R> {
     /// If the note isn't consumed and it was committed in the past relative to the client, then
     /// the MMR for the relevant block is fetched from the node and stored.
     async fn import_note_record_by_proof(
-        &mut self,
+        &self,
         previous_note: Option<InputNoteRecord>,
         note: Note,
         inclusion_proof: NoteInclusionProof,

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -195,7 +195,7 @@ pub trait NodeRpcClient {
     ///
     /// The default implementation of this method uses [NodeRpcClient::get_notes_by_id].
     async fn get_public_note_records(
-        &mut self,
+        &self,
         note_ids: &[NoteId],
         current_timestamp: Option<u64>,
     ) -> Result<Vec<InputNoteRecord>, RpcError> {
@@ -226,7 +226,7 @@ pub trait NodeRpcClient {
     /// change, it is ignored and will not be included in the returned list.
     /// The default implementation of this method uses [NodeRpcClient::get_account_update].
     async fn get_updated_public_accounts(
-        &mut self,
+        &self,
         local_accounts: &[&AccountHeader],
     ) -> Result<Vec<Account>, RpcError> {
         let mut public_accounts = vec![];
@@ -250,7 +250,7 @@ pub trait NodeRpcClient {
     ///
     /// The default implementation of this method uses [NodeRpcClient::get_block_header_by_number].
     async fn get_block_header_with_proof(
-        &mut self,
+        &self,
         block_num: BlockNumber,
     ) -> Result<(BlockHeader, MmrProof), RpcError> {
         let (header, proof) = self.get_block_header_by_number(Some(block_num), true).await?;
@@ -263,7 +263,7 @@ pub trait NodeRpcClient {
     ///
     /// Errors:
     /// - [RpcError::NoteNotFound] if the note with the specified ID is not found.
-    async fn get_note_by_id(&mut self, note_id: NoteId) -> Result<NetworkNote, RpcError> {
+    async fn get_note_by_id(&self, note_id: NoteId) -> Result<NetworkNote, RpcError> {
         let notes = self.get_notes_by_id(&[note_id]).await?;
         notes.into_iter().next().ok_or(RpcError::NoteNotFound(note_id))
     }

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -22,7 +22,7 @@
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create a Tonic RPC client instance (assumes default endpoint configuration).
 //! let endpoint = Endpoint::new("https".into(), "localhost".into(), Some(57291));
-//! let mut rpc_client = TonicRpcClient::new(&endpoint, 1000);
+//! let mut rpc_client = TonicRpcClient::new(endpoint, 1000).await.unwrap();
 //!
 //! // Fetch the latest block header (by passing None).
 //! let (block_header, mmr_proof) = rpc_client.get_block_header_by_number(None, true).await?;
@@ -101,43 +101,43 @@ pub trait NodeRpcClient {
     /// Given a Proven Transaction, send it to the node for it to be included in a future block
     /// using the `/SubmitProvenTransaction` RPC endpoint.
     async fn submit_proven_transaction(
-        &mut self,
+        &self,
         proven_transaction: ProvenTransaction,
     ) -> Result<(), RpcError>;
 
     /// Given a block number, fetches the block header corresponding to that height from the node
     /// using the `/GetBlockHeaderByNumber` endpoint.
     /// If `include_mmr_proof` is set to true and the function returns an `Ok`, the second value
-    /// of the return tuple should always be Some(MmrProof).
+    /// of the return tuple should always be Some(MmrProof)   
     ///
     /// When `None` is provided, returns info regarding the latest block.
     async fn get_block_header_by_number(
-        &mut self,
+        &self,
         block_num: Option<BlockNumber>,
         include_mmr_proof: bool,
     ) -> Result<(BlockHeader, Option<MmrProof>), RpcError>;
 
-    /// Fetches note-related data for a list of [NoteId] using the `/GetNotesById` rpc endpoint.
+    /// Fetches note-related data for a list of [NoteId] using the `/GetNotesById` rpc endpoint
     ///
     /// For any NoteType::Private note, the return data is only the
     /// [miden_objects::note::NoteMetadata], whereas for NoteType::Onchain notes, the return
     /// data includes all details.
-    async fn get_notes_by_id(&mut self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError>;
+    async fn get_notes_by_id(&self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError>;
 
     /// Fetches info from the node necessary to perform a state sync using the
-    /// `/SyncState` RPC endpoint.
+    /// `/SyncState` RPC endpoint
     ///
     /// - `block_num` is the last block number known by the client. The returned [StateSyncInfo]
     ///   should contain data starting from the next block, until the first block which contains a
     ///   note of matching the requested tag, or the chain tip if there are no notes.
-    /// - `account_ids` is a list of account IDs and determines the accounts the client is
+    /// - `account_ids` is a list of account ids and determines the accounts the client is
     ///   interested in and should receive account updates of.
     /// - `note_tags` is a list of tags used to filter the notes the client is interested in, which
-    ///   serves as a "note group" filter. Notice that you can't filter by a specific note ID.
+    ///   serves as a "note group" filter. Notice that you can't filter by a specific note id
     /// - `nullifiers_tags` similar to `note_tags`, is a list of tags used to filter the nullifiers
     ///   corresponding to some notes the client is interested in.
     async fn sync_state(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         account_ids: &[AccountId],
         note_tags: &[NoteTag],
@@ -145,16 +145,13 @@ pub trait NodeRpcClient {
     ) -> Result<StateSyncInfo, RpcError>;
 
     /// Fetches the current state of an account from the node using the `/GetAccountDetails` RPC
-    /// endpoint.
+    /// endpoint
     ///
-    /// - `account_id` is the ID of the wanted account.
-    async fn get_account_update(
-        &mut self,
-        account_id: AccountId,
-    ) -> Result<AccountDetails, RpcError>;
+    /// - `account_id` is the id of the wanted account.
+    async fn get_account_update(&self, account_id: AccountId) -> Result<AccountDetails, RpcError>;
 
     async fn sync_notes(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         note_tags: &[NoteTag],
     ) -> Result<NoteSyncInfo, RpcError>;
@@ -162,7 +159,7 @@ pub trait NodeRpcClient {
     /// Fetches the nullifiers corresponding to a list of prefixes using the
     /// `/CheckNullifiersByPrefix` RPC endpoint.
     async fn check_nullifiers_by_prefix(
-        &mut self,
+        &self,
         prefix: &[u16],
     ) -> Result<Vec<(Nullifier, u32)>, RpcError>;
 
@@ -173,17 +170,17 @@ pub trait NodeRpcClient {
     /// to prevent unnecessary data fetching. Returns the block number and the FPI account data. If
     /// one of the tracked accounts is not found in the node, the method will return an error.
     async fn get_account_proofs(
-        &mut self,
+        &self,
         account_storage_requests: &BTreeSet<ForeignAccount>,
         known_account_codes: Vec<AccountCode>,
     ) -> Result<AccountProofs, RpcError>;
 
-    /// Fetches the commit height where the nullifier was consumed. If the nullifier isn't found,
+    /// Fetches the commit height where the nullifier was consumed. If the nullifier is not found,
     /// then `None` is returned.
     ///
     /// The default implementation of this method uses [NodeRpcClient::check_nullifiers_by_prefix].
     async fn get_nullifier_commit_height(
-        &mut self,
+        &self,
         nullifier: &Nullifier,
     ) -> Result<Option<u32>, RpcError> {
         let nullifiers =

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -22,7 +22,7 @@
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create a Tonic RPC client instance (assumes default endpoint configuration).
 //! let endpoint = Endpoint::new("https".into(), "localhost".into(), Some(57291));
-//! let mut rpc_client = TonicRpcClient::new(endpoint, 1000).await.unwrap();
+//! let mut rpc_client = TonicRpcClient::new(&endpoint, 1000);
 //!
 //! // Fetch the latest block header (by passing None).
 //! let (block_header, mmr_proof) = rpc_client.get_block_header_by_number(None, true).await?;
@@ -108,7 +108,7 @@ pub trait NodeRpcClient {
     /// Given a block number, fetches the block header corresponding to that height from the node
     /// using the `/GetBlockHeaderByNumber` endpoint.
     /// If `include_mmr_proof` is set to true and the function returns an `Ok`, the second value
-    /// of the return tuple should always be Some(MmrProof)   
+    /// of the return tuple should always be Some(MmrProof).
     ///
     /// When `None` is provided, returns info regarding the latest block.
     async fn get_block_header_by_number(
@@ -117,7 +117,7 @@ pub trait NodeRpcClient {
         include_mmr_proof: bool,
     ) -> Result<(BlockHeader, Option<MmrProof>), RpcError>;
 
-    /// Fetches note-related data for a list of [NoteId] using the `/GetNotesById` rpc endpoint
+    /// Fetches note-related data for a list of [NoteId] using the `/GetNotesById` rpc endpoint.
     ///
     /// For any NoteType::Private note, the return data is only the
     /// [miden_objects::note::NoteMetadata], whereas for NoteType::Onchain notes, the return
@@ -125,15 +125,15 @@ pub trait NodeRpcClient {
     async fn get_notes_by_id(&self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError>;
 
     /// Fetches info from the node necessary to perform a state sync using the
-    /// `/SyncState` RPC endpoint
+    /// `/SyncState` RPC endpoint.
     ///
     /// - `block_num` is the last block number known by the client. The returned [StateSyncInfo]
     ///   should contain data starting from the next block, until the first block which contains a
     ///   note of matching the requested tag, or the chain tip if there are no notes.
-    /// - `account_ids` is a list of account ids and determines the accounts the client is
+    /// - `account_ids` is a list of account IDs and determines the accounts the client is
     ///   interested in and should receive account updates of.
     /// - `note_tags` is a list of tags used to filter the notes the client is interested in, which
-    ///   serves as a "note group" filter. Notice that you can't filter by a specific note id
+    ///   serves as a "note group" filter. Notice that you can't filter by a specific note ID.
     /// - `nullifiers_tags` similar to `note_tags`, is a list of tags used to filter the nullifiers
     ///   corresponding to some notes the client is interested in.
     async fn sync_state(
@@ -145,9 +145,9 @@ pub trait NodeRpcClient {
     ) -> Result<StateSyncInfo, RpcError>;
 
     /// Fetches the current state of an account from the node using the `/GetAccountDetails` RPC
-    /// endpoint
+    /// endpoint.
     ///
-    /// - `account_id` is the id of the wanted account.
+    /// - `account_id` is the ID of the wanted account.
     async fn get_account_update(&self, account_id: AccountId) -> Result<AccountDetails, RpcError>;
 
     async fn sync_notes(
@@ -175,7 +175,7 @@ pub trait NodeRpcClient {
         known_account_codes: Vec<AccountCode>,
     ) -> Result<AccountProofs, RpcError>;
 
-    /// Fetches the commit height where the nullifier was consumed. If the nullifier is not found,
+    /// Fetches the commit height where the nullifier was consumed. If the nullifier isn't found,
     /// then `None` is returned.
     ///
     /// The default implementation of this method uses [NodeRpcClient::check_nullifiers_by_prefix].

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -62,7 +62,8 @@ impl TonicRpcClient {
         }
     }
 
-    /// Takes care of establishing the RPC connection if not connected yet.
+    /// Takes care of establishing the RPC connection if not connected yet. It ensures that the
+    /// `rpc_api` field is initialized and returns a write guard to it.
     async fn ensure_connected(
         &self,
     ) -> Result<RwLockWriteGuard<Option<ApiClient<Channel>>>, RpcError> {

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -1,9 +1,4 @@
-use alloc::{
-    boxed::Box,
-    collections::BTreeSet,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, collections::BTreeSet, string::ToString, vec::Vec};
 use std::{collections::BTreeMap, time::Duration};
 
 use async_trait::async_trait;
@@ -17,6 +12,7 @@ use miden_objects::{
     Digest,
 };
 use miden_tx::utils::Serializable;
+use tokio::sync::RwLock;
 use tonic::transport::Channel;
 use tracing::info;
 
@@ -42,52 +38,35 @@ use crate::{rpc::generated::requests::GetBlockHeaderByNumberRequest, transaction
 // ================================================================================================
 
 /// Client for the Node RPC API using tonic.
-///
-/// Wraps the `ApiClient` which defers establishing a connection with a node until necessary.
 pub struct TonicRpcClient {
-    rpc_api: Option<ApiClient<Channel>>,
-    endpoint: String,
-    timeout_ms: u64,
+    rpc_api: RwLock<ApiClient<Channel>>,
 }
 
 impl TonicRpcClient {
-    /// Returns a new instance of [`TonicRpcClient`] that'll do calls to the provided [`Endpoint`]
-    /// with the given timeout in milliseconds.
-    pub fn new(endpoint: &Endpoint, timeout_ms: u64) -> TonicRpcClient {
-        TonicRpcClient {
-            rpc_api: None,
-            endpoint: endpoint.to_string(),
-            timeout_ms,
-        }
-    }
+    /// Returns a new instance of [`TonicRpcClien`] that'll do calls to the provided [`Endpoint`]
+    /// with the given timeout in milliseconds
+    pub async fn new(endpoint: Endpoint, timeout_ms: u64) -> Result<TonicRpcClient, RpcError> {
+        let endpoint = tonic::transport::Endpoint::try_from(endpoint.to_string())
+            .map_err(|err| RpcError::ConnectionError(err.to_string()))?
+            .timeout(Duration::from_millis(timeout_ms));
+        let rpc_api = ApiClient::connect(endpoint)
+            .await
+            .map_err(|err| RpcError::ConnectionError(err.to_string()))?;
 
-    /// Takes care of establishing the RPC connection if not connected yet and returns a reference
-    /// to the inner `ApiClient`.
-    async fn rpc_api(&mut self) -> Result<&mut ApiClient<Channel>, RpcError> {
-        if self.rpc_api.is_some() {
-            Ok(self.rpc_api.as_mut().unwrap())
-        } else {
-            let endpoint = tonic::transport::Endpoint::try_from(self.endpoint.clone())
-                .map_err(|err| RpcError::ConnectionError(err.to_string()))?
-                .timeout(Duration::from_millis(self.timeout_ms));
-            let rpc_api = ApiClient::connect(endpoint)
-                .await
-                .map_err(|err| RpcError::ConnectionError(err.to_string()))?;
-            Ok(self.rpc_api.insert(rpc_api))
-        }
+        Ok(TonicRpcClient { rpc_api: RwLock::new(rpc_api) })
     }
 }
 
 #[async_trait(?Send)]
 impl NodeRpcClient for TonicRpcClient {
     async fn submit_proven_transaction(
-        &mut self,
+        &self,
         proven_transaction: ProvenTransaction,
     ) -> Result<(), RpcError> {
         let request = SubmitProvenTransactionRequest {
             transaction: proven_transaction.to_bytes(),
         };
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
         rpc_api.submit_proven_transaction(request).await.map_err(|err| {
             RpcError::RequestError(
                 NodeRpcClientEndpoint::SubmitProvenTx.to_string(),
@@ -99,7 +78,7 @@ impl NodeRpcClient for TonicRpcClient {
     }
 
     async fn get_block_header_by_number(
-        &mut self,
+        &self,
         block_num: Option<BlockNumber>,
         include_mmr_proof: bool,
     ) -> Result<(BlockHeader, Option<MmrProof>), RpcError> {
@@ -110,7 +89,7 @@ impl NodeRpcClient for TonicRpcClient {
 
         info!("Calling GetBlockHeaderByNumber: {:?}", request);
 
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
         let api_response = rpc_api.get_block_header_by_number(request).await.map_err(|err| {
             RpcError::RequestError(
                 NodeRpcClientEndpoint::GetBlockHeaderByNumber.to_string(),
@@ -146,11 +125,11 @@ impl NodeRpcClient for TonicRpcClient {
         Ok((block_header, mmr_proof))
     }
 
-    async fn get_notes_by_id(&mut self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError> {
+    async fn get_notes_by_id(&self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError> {
         let request = GetNotesByIdRequest {
             note_ids: note_ids.iter().map(|id| id.inner().into()).collect(),
         };
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
         let api_response = rpc_api.get_notes_by_id(request).await.map_err(|err| {
             RpcError::RequestError(
                 NodeRpcClientEndpoint::GetBlockHeaderByNumber.to_string(),
@@ -199,7 +178,7 @@ impl NodeRpcClient for TonicRpcClient {
     /// Sends a sync state request to the Miden node, validates and converts the response
     /// into a [StateSyncInfo] struct.
     async fn sync_state(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         account_ids: &[AccountId],
         note_tags: &[NoteTag],
@@ -218,7 +197,7 @@ impl NodeRpcClient for TonicRpcClient {
             nullifiers,
         };
 
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
         let response = rpc_api.sync_state(request).await.map_err(|err| {
             RpcError::RequestError(NodeRpcClientEndpoint::SyncState.to_string(), err.to_string())
         })?;
@@ -232,17 +211,14 @@ impl NodeRpcClient for TonicRpcClient {
     ///
     /// This function will return an error if:
     ///
-    /// - There was an error sending the request to the node.
+    /// - There was an error sending the request to the node
     /// - The answer had a `None` for one of the expected fields (account, summary, account_hash,
     ///   details).
-    /// - There is an error during [Account] deserialization.
-    async fn get_account_update(
-        &mut self,
-        account_id: AccountId,
-    ) -> Result<AccountDetails, RpcError> {
+    /// - There is an error during [Account] deserialization
+    async fn get_account_update(&self, account_id: AccountId) -> Result<AccountDetails, RpcError> {
         let request = GetAccountDetailsRequest { account_id: Some(account_id.into()) };
 
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
 
         let response = rpc_api.get_account_details(request).await.map_err(|err| {
             RpcError::RequestError(
@@ -291,7 +267,7 @@ impl NodeRpcClient for TonicRpcClient {
     /// - The answer had a `None` for one of the expected fields.
     /// - There is an error during storage deserialization.
     async fn get_account_proofs(
-        &mut self,
+        &self,
         account_requests: &BTreeSet<ForeignAccount>,
         known_account_codes: Vec<AccountCode>,
     ) -> Result<AccountProofs, RpcError> {
@@ -315,7 +291,7 @@ impl NodeRpcClient for TonicRpcClient {
             code_commitments: known_account_codes.keys().map(Into::into).collect(),
         };
 
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
         let response = rpc_api
             .get_account_proofs(request)
             .await
@@ -375,7 +351,7 @@ impl NodeRpcClient for TonicRpcClient {
     }
 
     async fn sync_notes(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         note_tags: &[NoteTag],
     ) -> Result<NoteSyncInfo, RpcError> {
@@ -383,7 +359,7 @@ impl NodeRpcClient for TonicRpcClient {
 
         let request = SyncNoteRequest { block_num: block_num.as_u32(), note_tags };
 
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
 
         let response = rpc_api.sync_notes(request).await.map_err(|err| {
             RpcError::RequestError(NodeRpcClientEndpoint::SyncNotes.to_string(), err.to_string())
@@ -393,14 +369,14 @@ impl NodeRpcClient for TonicRpcClient {
     }
 
     async fn check_nullifiers_by_prefix(
-        &mut self,
+        &self,
         prefixes: &[u16],
     ) -> Result<Vec<(Nullifier, u32)>, RpcError> {
         let request = CheckNullifiersByPrefixRequest {
             nullifiers: prefixes.iter().map(|&x| u32::from(x)).collect(),
             prefix_len: 16,
         };
-        let rpc_api = self.rpc_api().await?;
+        let mut rpc_api = self.rpc_api.write().await;
         let response = rpc_api.check_nullifiers_by_prefix(request).await.map_err(|err| {
             RpcError::RequestError(
                 NodeRpcClientEndpoint::CheckNullifiersByPrefix.to_string(),

--- a/crates/rust-client/src/rpc/web_tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/web_tonic_client/mod.rs
@@ -54,7 +54,7 @@ impl WebTonicRpcClient {
 #[async_trait(?Send)]
 impl NodeRpcClient for WebTonicRpcClient {
     async fn submit_proven_transaction(
-        &mut self,
+        &self,
         proven_transaction: ProvenTransaction,
     ) -> Result<(), RpcError> {
         let mut query_client = self.build_api_client();
@@ -74,7 +74,7 @@ impl NodeRpcClient for WebTonicRpcClient {
     }
 
     async fn get_block_header_by_number(
-        &mut self,
+        &self,
         block_num: Option<BlockNumber>,
         include_mmr_proof: bool,
     ) -> Result<(BlockHeader, Option<MmrProof>), RpcError> {
@@ -123,7 +123,7 @@ impl NodeRpcClient for WebTonicRpcClient {
         Ok((block_header, mmr_proof))
     }
 
-    async fn get_notes_by_id(&mut self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError> {
+    async fn get_notes_by_id(&self, note_ids: &[NoteId]) -> Result<Vec<NetworkNote>, RpcError> {
         let mut query_client = self.build_api_client();
 
         let request = GetNotesByIdRequest {
@@ -177,7 +177,7 @@ impl NodeRpcClient for WebTonicRpcClient {
     /// Sends a sync state request to the Miden node, validates and converts the response
     /// into a [StateSyncInfo] struct.
     async fn sync_state(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         account_ids: &[AccountId],
         note_tags: &[NoteTag],
@@ -203,7 +203,7 @@ impl NodeRpcClient for WebTonicRpcClient {
     }
 
     async fn sync_notes(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         note_tags: &[NoteTag],
     ) -> Result<NoteSyncInfo, RpcError> {
@@ -231,7 +231,7 @@ impl NodeRpcClient for WebTonicRpcClient {
     /// - The answer had a `None` for one of the expected fields.
     /// - There is an error during storage deserialization.
     async fn get_account_proofs(
-        &mut self,
+        &self,
         account_requests: &BTreeSet<ForeignAccount>,
         known_account_codes: Vec<AccountCode>,
     ) -> Result<AccountProofs, RpcError> {
@@ -326,10 +326,7 @@ impl NodeRpcClient for WebTonicRpcClient {
     /// - The answer had a `None` for its account, or the account had a `None` at the `details`
     ///   field.
     /// - There is an error during [Account] deserialization.
-    async fn get_account_update(
-        &mut self,
-        account_id: AccountId,
-    ) -> Result<AccountDetails, RpcError> {
+    async fn get_account_update(&self, account_id: AccountId) -> Result<AccountDetails, RpcError> {
         let mut query_client = self.build_api_client();
 
         let request = GetAccountDetailsRequest { account_id: Some(account_id.into()) };
@@ -371,7 +368,7 @@ impl NodeRpcClient for WebTonicRpcClient {
     }
 
     async fn check_nullifiers_by_prefix(
-        &mut self,
+        &self,
         prefixes: &[u16],
     ) -> Result<Vec<(Nullifier, u32)>, RpcError> {
         let mut query_client = self.build_api_client();

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -152,7 +152,7 @@ impl<R: FeltRng> Client<R> {
     /// If the store already contains MMR data for the requested block number, the request isn't
     /// done and the stored block header is returned.
     pub(crate) async fn get_and_store_authenticated_block(
-        &mut self,
+        &self,
         block_num: BlockNumber,
         current_partial_mmr: &mut PartialMmr,
     ) -> Result<BlockHeader, ClientError> {

--- a/crates/rust-client/src/tests.rs
+++ b/crates/rust-client/src/tests.rs
@@ -343,7 +343,7 @@ async fn test_sync_state() {
 #[tokio::test]
 async fn test_sync_state_mmr() {
     // generate test client with a random store name
-    let (mut client, mut rpc_api) = create_test_client().await;
+    let (mut client, rpc_api) = create_test_client().await;
     // Import note and create wallet so that synced notes do not get discarded (due to being
     // irrelevant)
     insert_new_wallet(&mut client, AccountStorageMode::Private).await.unwrap();

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -78,7 +78,7 @@ impl WebClient {
             .map_err(|_| JsValue::from_str("Failed to initialize WebStore"))?;
         let web_store = Arc::new(web_store);
         let authenticator = Arc::new(StoreAuthenticator::new_with_rng(web_store.clone(), rng));
-        let web_rpc_client = Box::new(WebTonicRpcClient::new(
+        let web_rpc_client = Arc::new(WebTonicRpcClient::new(
             &node_url.unwrap_or_else(|| miden_client::rpc::Endpoint::testnet().to_string()),
         ));
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -37,7 +37,7 @@ let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
 // Instantiate the client using a Tonic RPC client
 let endpoint = Endpoint::new("https".into(), "localhost".into(), Some(57291));
 let client: Client<RpoRandomCoin> = Client::new(
-    Box::new(TonicRpcClient::new(&endpoint, 10_000)),
+    Arc::new(TonicRpcClient::new(&endpoint, 10_000)),
     rng,
     store,
     Arc::new(authenticator),

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -58,7 +58,7 @@ pub async fn create_test_client() -> TestClient {
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
-        Box::new(TonicRpcClient::new(&rpc_endpoint, rpc_timeout)),
+        Box::new(TonicRpcClient::new(rpc_endpoint, rpc_timeout).await.unwrap()),
         rng,
         store,
         Arc::new(authenticator),

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -58,7 +58,7 @@ pub async fn create_test_client() -> TestClient {
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
-        Arc::new(TonicRpcClient::new(rpc_endpoint, rpc_timeout).await.unwrap()),
+        Arc::new(TonicRpcClient::new(&rpc_endpoint, rpc_timeout)),
         rng,
         store,
         Arc::new(authenticator),

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -58,7 +58,7 @@ pub async fn create_test_client() -> TestClient {
 
     let authenticator = StoreAuthenticator::new_with_rng(store.clone(), rng);
     TestClient::new(
-        Box::new(TonicRpcClient::new(rpc_endpoint, rpc_timeout).await.unwrap()),
+        Arc::new(TonicRpcClient::new(rpc_endpoint, rpc_timeout).await.unwrap()),
         rng,
         store,
         Arc::new(authenticator),

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -800,7 +800,7 @@ async fn test_get_account_update() {
     // [`AccountDetails`] should be received.
     // TODO: should we expose the `get_account_update` endpoint from the Client?
     let (endpoint, timeout, _) = get_client_config();
-    let rpc_api = TonicRpcClient::new(endpoint, timeout).await.unwrap();
+    let rpc_api = TonicRpcClient::new(&endpoint, timeout);
     let details1 = rpc_api.get_account_update(basic_wallet_1.id()).await.unwrap();
     let details2 = rpc_api.get_account_update(basic_wallet_2.id()).await.unwrap();
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -800,7 +800,7 @@ async fn test_get_account_update() {
     // [`AccountDetails`] should be received.
     // TODO: should we expose the `get_account_update` endpoint from the Client?
     let (endpoint, timeout, _) = get_client_config();
-    let mut rpc_api = TonicRpcClient::new(&endpoint, timeout);
+    let rpc_api = TonicRpcClient::new(endpoint, timeout).await.unwrap();
     let details1 = rpc_api.get_account_update(basic_wallet_1.id()).await.unwrap();
     let details2 = rpc_api.get_account_update(basic_wallet_2.id()).await.unwrap();
 


### PR DESCRIPTION
This is an auxiliary PR to reduce the review changes in #650 

The rpc_api in the client was changed from Box to Arc so it can be shared with the component. This also means that I had to change the base struct to give it interior mutability.