### PR TITLE
refactor: update structs for `StateSync` component

### DIFF
--- a/bin/miden-cli/src/commands/sync.rs
+++ b/bin/miden-cli/src/commands/sync.rs
@@ -12,8 +12,7 @@ impl SyncCmd {
         let new_details = client.sync_state().await?;
 
         println!("State synced to block {}", new_details.block_num);
-        println!("New public notes: {}", new_details.received_notes.len());
-        println!("Tracked notes updated: {}", new_details.committed_notes.len());
+        println!("Committed notes: {}", new_details.committed_notes.len());
         println!("Tracked notes consumed: {}", new_details.consumed_notes.len());
         println!("Tracked accounts updated: {}", new_details.updated_accounts.len());
         println!("Locked accounts: {}", new_details.locked_accounts.len());

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -56,7 +56,11 @@
 //! For more details on the API and error handling, see the documentation for the specific functions
 //! and types in this module.
 
-use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::ToString,
+    vec::Vec,
+};
 
 use miden_lib::transaction::TransactionKernel;
 use miden_objects::{account::AccountId, crypto::rand::FeltRng};
@@ -240,84 +244,63 @@ pub async fn get_input_note_with_id_prefix<R: FeltRng>(
 // ------------------------------------------------------------------------------------------------
 
 /// Contains note changes to apply to the store.
+#[derive(Clone, Debug, Default)]
 pub struct NoteUpdates {
-    /// A list of new input notes.
-    new_input_notes: Vec<InputNoteRecord>,
-    /// A list of new output notes.
-    new_output_notes: Vec<OutputNoteRecord>,
-    /// A list of updated input note records corresponding to locally-tracked input notes.
-    updated_input_notes: Vec<InputNoteRecord>,
-    /// A list of updated output note records corresponding to locally-tracked output notes.
-    updated_output_notes: Vec<OutputNoteRecord>,
+    /// A map of new and updated input note records to be upserted in the store.
+    updated_input_notes: BTreeMap<NoteId, InputNoteRecord>,
+    /// A map of updated output note records to be upserted in the store.
+    updated_output_notes: BTreeMap<NoteId, OutputNoteRecord>,
 }
 
 impl NoteUpdates {
     /// Creates a [`NoteUpdates`].
     pub fn new(
-        new_input_notes: Vec<InputNoteRecord>,
-        new_output_notes: Vec<OutputNoteRecord>,
         updated_input_notes: Vec<InputNoteRecord>,
         updated_output_notes: Vec<OutputNoteRecord>,
     ) -> Self {
         Self {
-            new_input_notes,
-            new_output_notes,
-            updated_input_notes,
-            updated_output_notes,
+            updated_input_notes: updated_input_notes
+                .into_iter()
+                .map(|note| (note.id(), note))
+                .collect(),
+            updated_output_notes: updated_output_notes
+                .into_iter()
+                .map(|note| (note.id(), note))
+                .collect(),
         }
     }
 
-    /// Combines two [`NoteUpdates`] into a single one.
-    #[must_use]
-    pub fn combine_with(mut self, other: Self) -> Self {
-        self.new_input_notes.extend(other.new_input_notes);
-        self.new_output_notes.extend(other.new_output_notes);
-        self.updated_input_notes.extend(other.updated_input_notes);
-        self.updated_output_notes.extend(other.updated_output_notes);
-
-        self
+    /// Returns all input note records that have been updated.
+    pub fn updated_input_notes(&self) -> impl Iterator<Item = &InputNoteRecord> {
+        self.updated_input_notes.values()
     }
 
-    /// Returns all new input note records, meant to be tracked by the client.
-    pub fn new_input_notes(&self) -> &[InputNoteRecord] {
-        &self.new_input_notes
-    }
-
-    /// Returns all new output note records, meant to be tracked by the client.
-    pub fn new_output_notes(&self) -> &[OutputNoteRecord] {
-        &self.new_output_notes
-    }
-
-    /// Returns all updated input note records. That is, any input notes that are locally tracked
-    /// and have been updated.
-    pub fn updated_input_notes(&self) -> &[InputNoteRecord] {
-        &self.updated_input_notes
-    }
-
-    /// Returns all updated output note records. That is, any output notes that are locally tracked
-    /// and have been updated.
-    pub fn updated_output_notes(&self) -> &[OutputNoteRecord] {
-        &self.updated_output_notes
+    /// Returns all updated output note records that have been updated.
+    pub fn updated_output_notes(&self) -> impl Iterator<Item = &OutputNoteRecord> {
+        self.updated_output_notes.values()
     }
 
     /// Returns whether no new note-related information has been retrieved.
     pub fn is_empty(&self) -> bool {
-        self.updated_input_notes.is_empty()
-            && self.updated_output_notes.is_empty()
-            && self.new_input_notes.is_empty()
-            && self.new_output_notes.is_empty()
+        self.updated_input_notes.is_empty() && self.updated_output_notes.is_empty()
     }
 
-    /// Returns the IDs of all notes that have been committed.
+    /// Returns any note that has been committed into the chain in this update (either new or
+    /// already locally tracked)
+    pub fn committed_input_notes(&self) -> impl Iterator<Item = &InputNoteRecord> {
+        self.updated_input_notes.values().filter(|note| note.is_committed())
+    }
+
+    /// Returns the IDs of all notes that have been committed (previously locally tracked).
     pub fn committed_note_ids(&self) -> BTreeSet<NoteId> {
         let committed_output_note_ids = self
             .updated_output_notes
-            .iter()
+            .values()
             .filter_map(|note_record| note_record.is_committed().then_some(note_record.id()));
 
         let committed_input_note_ids = self
             .updated_input_notes
-            .iter()
+            .values()
             .filter_map(|note_record| note_record.is_committed().then_some(note_record.id()));
 
         committed_input_note_ids
@@ -325,18 +308,23 @@ impl NoteUpdates {
             .collect::<BTreeSet<_>>()
     }
 
-    /// Returns the IDs of all notes that have been consumed
+    /// Returns the IDs of all notes that have been consumed.
     pub fn consumed_note_ids(&self) -> BTreeSet<NoteId> {
         let consumed_output_note_ids = self
             .updated_output_notes
-            .iter()
+            .values()
             .filter_map(|note_record| note_record.is_consumed().then_some(note_record.id()));
 
         let consumed_input_note_ids = self
             .updated_input_notes
-            .iter()
+            .values()
             .filter_map(|note_record| note_record.is_consumed().then_some(note_record.id()));
 
         consumed_input_note_ids.chain(consumed_output_note_ids).collect::<BTreeSet<_>>()
+    }
+
+    pub fn extend(&mut self, other: NoteUpdates) {
+        self.updated_input_notes.extend(other.updated_input_notes);
+        self.updated_output_notes.extend(other.updated_output_notes);
     }
 }

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -331,8 +331,9 @@ impl NoteUpdates {
         consumed_input_note_ids.chain(consumed_output_note_ids).collect::<BTreeSet<_>>()
     }
 
-    /// Extends this note update information with `other`. If the two contain updates to the same note (i.e. their IDs match),
-    /// the updates from `other` will overwrite the updates in `self`.
+    /// Extends this note update information with `other`. If the two contain updates to the same
+    /// note (i.e. their IDs match), the updates from `other` will overwrite the updates in
+    /// `self`.
     pub(crate) fn extend(&mut self, other: NoteUpdates) {
         self.updated_input_notes.extend(other.updated_input_notes);
         self.updated_output_notes.extend(other.updated_output_notes);

--- a/crates/rust-client/src/store/sqlite_store/note.rs
+++ b/crates/rust-client/src/store/sqlite_store/note.rs
@@ -589,17 +589,11 @@ pub(crate) fn apply_note_updates_tx(
     tx: &Transaction,
     note_updates: &NoteUpdates,
 ) -> Result<(), StoreError> {
-    for input_note in
-        note_updates.new_input_notes().iter().chain(note_updates.updated_input_notes())
-    {
+    for input_note in note_updates.updated_input_notes() {
         upsert_input_note_tx(tx, input_note)?;
     }
 
-    for output_note in note_updates
-        .new_output_notes()
-        .iter()
-        .chain(note_updates.updated_output_notes())
-    {
+    for output_note in note_updates.updated_output_notes() {
         upsert_output_note_tx(tx, output_note)?;
     }
 

--- a/crates/rust-client/src/store/web_store/note/utils.rs
+++ b/crates/rust-client/src/store/web_store/note/utils.rs
@@ -192,17 +192,11 @@ pub fn parse_output_note_idxdb_object(
 }
 
 pub(crate) async fn apply_note_updates_tx(note_updates: &NoteUpdates) -> Result<(), StoreError> {
-    for input_note in
-        note_updates.new_input_notes().iter().chain(note_updates.updated_input_notes())
-    {
+    for input_note in note_updates.updated_input_notes() {
         upsert_input_note_tx(input_note).await?;
     }
 
-    for output_note in note_updates
-        .new_output_notes()
-        .iter()
-        .chain(note_updates.updated_output_notes())
-    {
+    for output_note in note_updates.updated_output_notes() {
         upsert_output_note_tx(output_note).await?;
     }
 

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -107,14 +107,12 @@ impl WebStore {
     ) -> Result<(), StoreError> {
         let StateSyncUpdate {
             block_header,
-            note_updates,
-            transactions_to_commit: committed_transactions,
+            block_has_relevant_notes,
             new_mmr_peaks,
             new_authentication_nodes,
-            updated_accounts,
-            block_has_relevant_notes,
-            transactions_to_discard: _transactions_to_discard, /* TODO: Add support for discarded
-                                                                * transactions in web store */
+            note_updates,
+            transaction_updates,
+            account_updates,
             tags_to_remove,
         } = state_sync_update;
 
@@ -151,22 +149,24 @@ impl WebStore {
             .collect();
 
         // Serialize data for updating committed transactions
-        let transactions_to_commit_block_nums_as_str = committed_transactions
+        let transactions_to_commit_block_nums_as_str = transaction_updates
+            .committed_transactions()
             .iter()
             .map(|tx_update| tx_update.block_num.to_string())
             .collect();
-        let transactions_to_commit_as_str: Vec<String> = committed_transactions
+        let transactions_to_commit_as_str: Vec<String> = transaction_updates
+            .committed_transactions()
             .iter()
             .map(|tx_update| tx_update.transaction_id.to_string())
             .collect();
 
         // TODO: LOP INTO idxdb_apply_state_sync call
         // Update public accounts on the db that have been updated onchain
-        for account in updated_accounts.updated_public_accounts() {
+        for account in account_updates.updated_public_accounts() {
             update_account(&account.clone()).await.unwrap();
         }
 
-        for (account_id, _) in updated_accounts.mismatched_private_accounts() {
+        for (account_id, _) in account_updates.mismatched_private_accounts() {
             lock_account(account_id).await.unwrap();
         }
 

--- a/crates/rust-client/src/sync/block_header.rs
+++ b/crates/rust-client/src/sync/block_header.rs
@@ -85,11 +85,7 @@ impl<R: FeltRng> Client<R> {
         let note_screener = NoteScreener::new(self.store.clone());
 
         // Find all relevant Input Notes using the note checker
-        for input_note in committed_notes
-            .updated_input_notes()
-            .iter()
-            .chain(committed_notes.new_input_notes().iter())
-        {
+        for input_note in committed_notes.updated_input_notes() {
             if !note_screener
                 .check_relevance(&input_note.try_into().map_err(ClientError::NoteRecordError)?)
                 .await?

--- a/crates/rust-client/src/sync/state_sync_update.rs
+++ b/crates/rust-client/src/sync/state_sync_update.rs
@@ -1,0 +1,64 @@
+use alloc::vec::Vec;
+
+use miden_objects::{
+    account::Account,
+    block::BlockHeader,
+    crypto::merkle::{InOrderIndex, MmrPeaks},
+    Digest,
+};
+
+use super::{NoteTagRecord, SyncSummary};
+use crate::{note::NoteUpdates, store::AccountUpdates, transaction::TransactionUpdates};
+
+// STATE SYNC UPDATE
+// ================================================================================================
+
+/// Contains all information needed to apply the update in the store after syncing with the node.
+pub struct StateSyncUpdate {
+    /// The new block header, returned as part of the
+    /// [`StateSyncInfo`](crate::rpc::domain::sync::StateSyncInfo)
+    pub block_header: BlockHeader,
+    /// Whether the block header has notes relevant to the client.
+    pub block_has_relevant_notes: bool,
+    /// New MMR peaks for the locally tracked MMR of the blockchain.
+    pub new_mmr_peaks: MmrPeaks,
+    /// New authentications nodes that are meant to be stored in order to authenticate block
+    /// headers.
+    pub new_authentication_nodes: Vec<(InOrderIndex, Digest)>,
+    /// New and updated notes to be upserted in the store.
+    pub note_updates: NoteUpdates,
+    /// Committed and discarded transactions after the sync.
+    pub transaction_updates: TransactionUpdates,
+    /// Public account updates and mismatched private accounts after the sync.
+    pub account_updates: AccountUpdates,
+    /// Tag records that are no longer relevant.
+    pub tags_to_remove: Vec<NoteTagRecord>,
+}
+
+impl From<&StateSyncUpdate> for SyncSummary {
+    fn from(value: &StateSyncUpdate) -> Self {
+        SyncSummary::new(
+            value.block_header.block_num(),
+            value.note_updates.committed_note_ids().into_iter().collect(),
+            value.note_updates.consumed_note_ids().into_iter().collect(),
+            value
+                .account_updates
+                .updated_public_accounts()
+                .iter()
+                .map(Account::id)
+                .collect(),
+            value
+                .account_updates
+                .mismatched_private_accounts()
+                .iter()
+                .map(|(id, _)| *id)
+                .collect(),
+            value
+                .transaction_updates
+                .committed_transactions()
+                .iter()
+                .map(|t| t.transaction_id)
+                .collect(),
+        )
+    }
+}

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -340,10 +340,8 @@ impl TransactionStoreUpdate {
             executed_transaction,
             updated_account,
             note_updates: NoteUpdates::new(
-                created_input_notes,
+                [created_input_notes, updated_input_notes].concat(),
                 created_output_notes,
-                updated_input_notes,
-                vec![],
             ),
             new_tags,
         }

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -94,7 +94,7 @@ use tracing::info;
 use super::{Client, FeltRng};
 use crate::{
     note::{NoteScreener, NoteUpdates},
-    rpc::domain::account::AccountProof,
+    rpc::domain::{account::AccountProof, transaction::TransactionUpdate},
     store::{
         input_note_states::ExpectedNoteState, InputNoteRecord, InputNoteState, NoteFilter,
         OutputNoteRecord, StoreError, TransactionFilter,
@@ -119,7 +119,7 @@ pub use miden_tx::{DataStoreError, TransactionExecutorError};
 pub use script_builder::TransactionScriptBuilderError;
 
 // TRANSACTION RESULT
-// --------------------------------------------------------------------------------------------
+// ================================================================================================
 
 /// Represents the result of executing a transaction by the client.
 ///
@@ -241,7 +241,7 @@ impl Deserializable for TransactionResult {
 }
 
 // TRANSACTION RECORD
-// --------------------------------------------------------------------------------------------
+// ================================================================================================
 
 /// Describes a transaction that has been executed and is being tracked on the Client.
 ///
@@ -311,7 +311,7 @@ impl fmt::Display for TransactionStatus {
 }
 
 // TRANSACTION STORE UPDATE
-// --------------------------------------------------------------------------------------------
+// ================================================================================================
 
 /// Represents the changes that need to be applied to the client store as a result of a
 /// transaction execution.
@@ -365,6 +365,50 @@ impl TransactionStoreUpdate {
     /// Returns the new tags that were created as part of the transaction.
     pub fn new_tags(&self) -> &[NoteTagRecord] {
         &self.new_tags
+    }
+}
+
+/// Contains transaction changes to apply to the store.
+#[derive(Default)]
+pub struct TransactionUpdates {
+    /// Transaction updates for any transaction that was committed between the sync request's block
+    /// number and the response's block number.
+    committed_transactions: Vec<TransactionUpdate>,
+    /// Transaction IDs for any transactions that were discarded in the sync.
+    discarded_transactions: Vec<TransactionId>,
+}
+
+impl TransactionUpdates {
+    /// Creates a new [`TransactionUpdate`]
+    pub fn new(
+        committed_transactions: Vec<TransactionUpdate>,
+        discarded_transactions: Vec<TransactionId>,
+    ) -> Self {
+        Self {
+            committed_transactions,
+            discarded_transactions,
+        }
+    }
+
+    /// Extends the transaction update information with `other`.
+    pub fn extend(&mut self, other: Self) {
+        self.committed_transactions.extend(other.committed_transactions);
+        self.discarded_transactions.extend(other.discarded_transactions);
+    }
+
+    /// Returns a reference to committed transactions.
+    pub fn committed_transactions(&self) -> &[TransactionUpdate] {
+        &self.committed_transactions
+    }
+
+    /// Returns a reference to discarded transactions.
+    pub fn discarded_transactions(&self) -> &[TransactionId] {
+        &self.discarded_transactions
+    }
+
+    /// Inserts a committed transaction into the transaction updates.
+    pub fn discarded_transaction(&mut self, transaction_id: TransactionId) {
+        self.discarded_transactions.push(transaction_id);
     }
 }
 

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -406,8 +406,8 @@ impl TransactionUpdates {
         &self.discarded_transactions
     }
 
-    /// Inserts a committed transaction into the transaction updates.
-    pub fn discarded_transaction(&mut self, transaction_id: TransactionId) {
+    /// Inserts a discarded transaction into the transaction updates.
+    pub fn insert_discarded_transaction(&mut self, transaction_id: TransactionId) {
         self.discarded_transactions.push(transaction_id);
     }
 }

--- a/crates/web-client/src/models/sync_summary.rs
+++ b/crates/web-client/src/models/sync_summary.rs
@@ -12,10 +12,6 @@ impl SyncSummary {
         self.0.block_num.as_u32()
     }
 
-    pub fn received_notes(&self) -> Vec<NoteId> {
-        self.0.received_notes.iter().map(Into::into).collect()
-    }
-
     pub fn committed_notes(&self) -> Vec<NoteId> {
         self.0.committed_notes.iter().map(Into::into).collect()
     }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -850,7 +850,6 @@ async fn test_sync_detail_values() {
 
     // Second client sync should have new note
     let new_details = client2.sync_state().await.unwrap();
-    assert_eq!(new_details.received_notes.len(), 1);
     assert_eq!(new_details.committed_notes.len(), 0);
     assert_eq!(new_details.consumed_notes.len(), 0);
     assert_eq!(new_details.updated_accounts.len(), 0);
@@ -861,7 +860,6 @@ async fn test_sync_detail_values() {
 
     // First client sync should have a new nullifier as the note was consumed
     let new_details = client1.sync_state().await.unwrap();
-    assert_eq!(new_details.received_notes.len(), 0);
     assert_eq!(new_details.committed_notes.len(), 0);
     assert_eq!(new_details.consumed_notes.len(), 1);
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -850,7 +850,7 @@ async fn test_sync_detail_values() {
 
     // Second client sync should have new note
     let new_details = client2.sync_state().await.unwrap();
-    assert_eq!(new_details.committed_notes.len(), 0);
+    assert_eq!(new_details.committed_notes.len(), 1);
     assert_eq!(new_details.consumed_notes.len(), 0);
     assert_eq!(new_details.updated_accounts.len(), 0);
 


### PR DESCRIPTION
This is an auxiliary PR to reduce the review changes in https://github.com/0xPolygonMiden/miden-client/pull/650

These are mostly struct field refactors that are used in the `StateSync` component PR but can be reviewed separately.