### PR TITLE
chore: Use `miden-base`'s next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,9 +1477,8 @@ dependencies = [
 
 [[package]]
 name = "miden-lib"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee8babd17ea380c6c5b948761ca63208b633b7130379ee2a57c6d3732d2f8bc"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "miden-assembly",
  "miden-objects",
@@ -1533,9 +1532,8 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe3f10d0e3787176f0803be2ecb4646f3a17fe10af45a50736c8d079a3c94d8"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "getrandom 0.2.15",
  "miden-assembly",
@@ -1580,9 +1578,8 @@ dependencies = [
 
 [[package]]
 name = "miden-proving-service-client"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8bb57ec4864fe7b128a24fcf8872ba18c3229e6cea5aea6194c6b2e2d814a8"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "async-trait",
  "miden-objects",
@@ -1599,9 +1596,8 @@ dependencies = [
 
 [[package]]
 name = "miden-rpc-proto"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68f00e0e97ba6bc65896e5ca2bb0995d59b14fd8f0389916dc2ee792f353f50"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#ebef2151f5883f76f8c36c5c835634e94d0aa8bf"
 
 [[package]]
 name = "miden-stdlib"
@@ -1614,9 +1610,8 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4371509f1e4c25dfe26b7ffcffbb34aaa152c6eaad400f2624240a941baed2d0"
+version = "0.8.0"
+source = "git+https://github.com/0xPolygonMiden/miden-base?branch=next#66cf1bc8744cf739aa3ef726300c389796047394"
 dependencies = [
  "async-trait",
  "miden-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ repository = "https://github.com/0xPolygonMiden/miden-client"
 
 [workspace.dependencies]
 async-trait = "0.1"
-miden-lib = { version = "0.7", default-features = false }
-miden-objects = { version = "0.7", default-features = false }
-miden-tx = { version = "0.7", default-features = false, features = ["async"] }
-miden-proving-service-client = { version = "0.7", default-features = false, features = ["tx-prover"] }
+miden-lib = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
+miden-objects = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false }
+miden-tx = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false, features = ["async"] }
+miden-proving-service-client = { git = "https://github.com/0xPolygonMiden/miden-base", branch = "next", default-features = false, features = ["tx-prover"] }
 miette = { version = "7.2", features = ["fancy"] }
 rand = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="main"
+NODE_BRANCH="igamigo-next-base"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"
-PROVER_BRANCH="main"
+PROVER_BRANCH="next"
 PROVER_FEATURES_TESTING=--features "testing"
 PROVER_PORT=50051
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="igamigo-next-base"
+NODE_BRANCH="next"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"

--- a/bin/miden-cli/src/commands/export.rs
+++ b/bin/miden-cli/src/commands/export.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
 use miden_client::{
-    account::AccountData, crypto::FeltRng, store::NoteExportType, utils::Serializable, Client,
+    account::AccountFile, crypto::FeltRng, store::NoteExportType, utils::Serializable, Client,
 };
 use tracing::info;
 
@@ -84,7 +84,7 @@ async fn export_account<R: FeltRng>(
         .await?
         .ok_or(CliError::Export(format!("Account with ID {account_id} not found")))?;
 
-    let account_data = AccountData::new(account.into(), account_seed, auth);
+    let account_data = AccountFile::new(account.into(), account_seed, auth);
 
     let file_path = if let Some(filename) = filename {
         filename

--- a/bin/miden-cli/src/commands/import.rs
+++ b/bin/miden-cli/src/commands/import.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use miden_client::{
-    account::{AccountData, AccountId},
+    account::{AccountFile, AccountId},
     crypto::FeltRng,
     note::NoteFile,
     utils::Deserializable,
@@ -68,7 +68,7 @@ async fn import_account(
     account_data_file_contents: &[u8],
     overwrite: bool,
 ) -> Result<AccountId, CliError> {
-    let account_data = AccountData::read_from_bytes(account_data_file_contents)
+    let account_data = AccountFile::read_from_bytes(account_data_file_contents)
         .map_err(ClientError::DataDeserializationError)?;
     let account_id = account_data.account.id();
 

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -13,7 +13,7 @@ use miden_client::{
     },
     Client,
 };
-use miden_proving_service_client::RemoteTransactionProver;
+use miden_proving_service_client::tx_prover::RemoteTransactionProver;
 use tracing::info;
 
 use crate::{

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -60,7 +60,7 @@ uuid = { version = "1.10", features = ["serde", "v4"] }
 web-sys = { version = "0.3", features = ["console"]}
 
 [build-dependencies]
-miden-rpc-proto = { version = "0.7" }
+miden-rpc-proto = { git = "https://github.com/0xPolygonMiden/miden-node", branch = "next" }
 miden-lib = { workspace = true }
 miette = { workspace = true }
 prost = { version = "0.13", default-features = false, features = ["derive"] }

--- a/crates/rust-client/src/account.rs
+++ b/crates/rust-client/src/account.rs
@@ -42,7 +42,7 @@
 use alloc::vec::Vec;
 
 pub use miden_objects::account::{
-    Account, AccountBuilder, AccountCode, AccountData, AccountHeader, AccountId, AccountStorage,
+    Account, AccountBuilder, AccountCode, AccountFile, AccountHeader, AccountId, AccountStorage,
     AccountStorageMode, AccountType, StorageSlot,
 };
 use miden_objects::{account::AuthSecretKey, crypto::rand::FeltRng, Word};
@@ -262,7 +262,7 @@ pub mod tests {
 
     use miden_lib::transaction::TransactionKernel;
     use miden_objects::{
-        account::{Account, AccountData, AuthSecretKey},
+        account::{Account, AccountFile, AuthSecretKey},
         crypto::dsa::rpo_falcon512::SecretKey,
         testing::account_id::{
             ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN, ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN,
@@ -272,18 +272,18 @@ pub mod tests {
 
     use crate::mock::create_test_client;
 
-    fn create_account_data(account_id: u128) -> AccountData {
+    fn create_account_data(account_id: u128) -> AccountFile {
         let account =
             Account::mock(account_id, Felt::new(2), TransactionKernel::testing_assembler());
 
-        AccountData::new(
+        AccountFile::new(
             account.clone(),
             Some(Word::default()),
             AuthSecretKey::RpoFalcon512(SecretKey::new()),
         )
     }
 
-    pub fn create_initial_accounts_data() -> Vec<AccountData> {
+    pub fn create_initial_accounts_data() -> Vec<AccountFile> {
         let account = create_account_data(ACCOUNT_ID_FUNGIBLE_FAUCET_OFF_CHAIN);
 
         let faucet_account = create_account_data(ACCOUNT_ID_FUNGIBLE_FAUCET_ON_CHAIN);

--- a/crates/rust-client/src/rpc/generated/nostd/requests.rs
+++ b/crates/rust-client/src/rpc/generated/nostd/requests.rs
@@ -92,6 +92,16 @@ pub struct GetBlockInputsRequest {
     #[prost(message, repeated, tag = "3")]
     pub unauthenticated_notes: ::prost::alloc::vec::Vec<super::digest::Digest>,
 }
+/// Returns the inputs for a transaction batch.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBatchInputsRequest {
+    /// List of unauthenticated notes to be queried from the database.
+    #[prost(message, repeated, tag = "1")]
+    pub note_ids: ::prost::alloc::vec::Vec<super::digest::Digest>,
+    /// Set of block numbers referenced by transactions.
+    #[prost(fixed32, repeated, tag = "2")]
+    pub reference_blocks: ::prost::alloc::vec::Vec<u32>,
+}
 /// Returns data required to validate a new transaction.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTransactionInputsRequest {
@@ -119,13 +129,6 @@ pub struct SubmitProvenTransactionRequest {
 /// Returns a list of notes matching the provided note IDs.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNotesByIdRequest {
-    /// List of notes to be queried from the database.
-    #[prost(message, repeated, tag = "1")]
-    pub note_ids: ::prost::alloc::vec::Vec<super::digest::Digest>,
-}
-/// Returns a list of Note inclusion proofs for the specified Note IDs.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetNoteAuthenticationInfoRequest {
     /// List of notes to be queried from the database.
     #[prost(message, repeated, tag = "1")]
     pub note_ids: ::prost::alloc::vec::Vec<super::digest::Digest>,

--- a/crates/rust-client/src/rpc/generated/nostd/responses.rs
+++ b/crates/rust-client/src/rpc/generated/nostd/responses.rs
@@ -128,6 +128,21 @@ pub struct GetBlockInputsResponse {
         super::note::NoteAuthenticationInfo,
     >,
 }
+/// Represents the result of getting batch inputs.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBatchInputsResponse {
+    /// The block header that the transaction batch should reference.
+    #[prost(message, optional, tag = "1")]
+    pub batch_reference_block_header: ::core::option::Option<super::block::BlockHeader>,
+    /// Proof of each _found_ unauthenticated note's inclusion in a block.
+    #[prost(message, repeated, tag = "2")]
+    pub note_proofs: ::prost::alloc::vec::Vec<super::note::NoteInclusionInBlockProof>,
+    /// The serialized chain MMR which includes proofs for all blocks referenced by the
+    /// above note inclusion proofs as well as proofs for inclusion of the blocks referenced
+    /// by the transactions in the batch.
+    #[prost(bytes = "vec", tag = "3")]
+    pub chain_mmr: ::prost::alloc::vec::Vec<u8>,
+}
 /// An account returned as a response to the `GetTransactionInputs`.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionInputRecord {
@@ -177,13 +192,6 @@ pub struct GetNotesByIdResponse {
     /// Lists Note's returned by the database.
     #[prost(message, repeated, tag = "1")]
     pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
-}
-/// Represents the result of getting note authentication info.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetNoteAuthenticationInfoResponse {
-    /// Proofs of note inclusions in blocks and block inclusions in chain.
-    #[prost(message, optional, tag = "1")]
-    pub proofs: ::core::option::Option<super::note::NoteAuthenticationInfo>,
 }
 /// Represents the result of getting account details.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/rust-client/src/rpc/generated/std/requests.rs
+++ b/crates/rust-client/src/rpc/generated/std/requests.rs
@@ -92,6 +92,16 @@ pub struct GetBlockInputsRequest {
     #[prost(message, repeated, tag = "3")]
     pub unauthenticated_notes: ::prost::alloc::vec::Vec<super::digest::Digest>,
 }
+/// Returns the inputs for a transaction batch.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBatchInputsRequest {
+    /// List of unauthenticated notes to be queried from the database.
+    #[prost(message, repeated, tag = "1")]
+    pub note_ids: ::prost::alloc::vec::Vec<super::digest::Digest>,
+    /// Set of block numbers referenced by transactions.
+    #[prost(fixed32, repeated, tag = "2")]
+    pub reference_blocks: ::prost::alloc::vec::Vec<u32>,
+}
 /// Returns data required to validate a new transaction.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTransactionInputsRequest {
@@ -119,13 +129,6 @@ pub struct SubmitProvenTransactionRequest {
 /// Returns a list of notes matching the provided note IDs.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNotesByIdRequest {
-    /// List of notes to be queried from the database.
-    #[prost(message, repeated, tag = "1")]
-    pub note_ids: ::prost::alloc::vec::Vec<super::digest::Digest>,
-}
-/// Returns a list of Note inclusion proofs for the specified Note IDs.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetNoteAuthenticationInfoRequest {
     /// List of notes to be queried from the database.
     #[prost(message, repeated, tag = "1")]
     pub note_ids: ::prost::alloc::vec::Vec<super::digest::Digest>,

--- a/crates/rust-client/src/rpc/generated/std/responses.rs
+++ b/crates/rust-client/src/rpc/generated/std/responses.rs
@@ -128,6 +128,21 @@ pub struct GetBlockInputsResponse {
         super::note::NoteAuthenticationInfo,
     >,
 }
+/// Represents the result of getting batch inputs.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBatchInputsResponse {
+    /// The block header that the transaction batch should reference.
+    #[prost(message, optional, tag = "1")]
+    pub batch_reference_block_header: ::core::option::Option<super::block::BlockHeader>,
+    /// Proof of each _found_ unauthenticated note's inclusion in a block.
+    #[prost(message, repeated, tag = "2")]
+    pub note_proofs: ::prost::alloc::vec::Vec<super::note::NoteInclusionInBlockProof>,
+    /// The serialized chain MMR which includes proofs for all blocks referenced by the
+    /// above note inclusion proofs as well as proofs for inclusion of the blocks referenced
+    /// by the transactions in the batch.
+    #[prost(bytes = "vec", tag = "3")]
+    pub chain_mmr: ::prost::alloc::vec::Vec<u8>,
+}
 /// An account returned as a response to the `GetTransactionInputs`.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AccountTransactionInputRecord {
@@ -177,13 +192,6 @@ pub struct GetNotesByIdResponse {
     /// Lists Note's returned by the database.
     #[prost(message, repeated, tag = "1")]
     pub notes: ::prost::alloc::vec::Vec<super::note::Note>,
-}
-/// Represents the result of getting note authentication info.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetNoteAuthenticationInfoResponse {
-    /// Proofs of note inclusions in blocks and block inclusions in chain.
-    #[prost(message, optional, tag = "1")]
-    pub proofs: ::core::option::Option<super::note::NoteAuthenticationInfo>,
 }
 /// Represents the result of getting account details.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/web-client/src/import.rs
+++ b/crates/web-client/src/import.rs
@@ -1,4 +1,4 @@
-use miden_objects::{account::AccountData, note::NoteFile, utils::Deserializable};
+use miden_objects::{account::AccountFile, note::NoteFile, utils::Deserializable};
 use serde_wasm_bindgen::from_value;
 use wasm_bindgen::prelude::*;
 
@@ -9,7 +9,7 @@ impl WebClient {
     pub async fn import_account(&mut self, account_bytes: JsValue) -> Result<JsValue, JsValue> {
         if let Some(client) = self.get_mut_inner() {
             let account_bytes_result: Vec<u8> = from_value(account_bytes).unwrap();
-            let account_data = AccountData::read_from_bytes(&account_bytes_result)
+            let account_data = AccountFile::read_from_bytes(&account_bytes_result)
                 .map_err(|err| err.to_string())?;
             let account_id = account_data.account.id().to_string();
 

--- a/crates/web-client/src/lib.rs
+++ b/crates/web-client/src/lib.rs
@@ -8,7 +8,7 @@ use miden_client::{
     Client,
 };
 use miden_objects::{crypto::rand::RpoRandomCoin, Felt};
-use miden_proving_service_client::RemoteTransactionProver;
+use miden_proving_service_client::tx_prover::RemoteTransactionProver;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use wasm_bindgen::prelude::*;
 

--- a/crates/web-client/src/models/provers.rs
+++ b/crates/web-client/src/models/provers.rs
@@ -3,7 +3,7 @@ use alloc::sync::Arc;
 use miden_client::transaction::{
     LocalTransactionProver, TransactionProver as TransactionProverTrait,
 };
-use miden_proving_service_client::RemoteTransactionProver;
+use miden_proving_service_client::tx_prover::RemoteTransactionProver;
 use miden_tx::ProvingOptions;
 use wasm_bindgen::prelude::*;
 

--- a/tests/config/miden-node.toml
+++ b/tests/config/miden-node.toml
@@ -1,4 +1,5 @@
-# This is an example configuration file for the Miden node.
+# Configuration settings for running integration tests.
+# Adjust these values to modify how the tests are executed, such as using a remote RPC endpoint instead of a local one.
 
 [block_producer]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16

--- a/tests/config/miden-node.toml
+++ b/tests/config/miden-node.toml
@@ -1,20 +1,19 @@
-# Configuration settings for running integration tests.
-# Adjust these values to modify how the tests are executed, such as using a remote RPC endpoint instead of a local one.
+# This is an example configuration file for the Miden node.
 
 [block_producer]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-block-producer', 1)) % 2**16
-endpoint = { host = "localhost", port = 48046 }
+endpoint = "http://127.0.0.1:48046"
 # enables or disables the verification of transaction proofs before they are accepted into the
 # transaction queue.
 verify_tx_proofs = true
 
 [rpc]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-rpc', 1)) % 2**16
-endpoint = { host = "0.0.0.0", port = 57291 }
+endpoint = "http://0.0.0.0:57291"
 
 [store]
 # port defined as: sum(ord(c)**p for (p, c) in enumerate('miden-store', 1)) % 2**16
-endpoint = { host = "localhost", port = 28943 }
+blockstore_dir    = "./blocks"
 database_filepath = "./miden-store.sqlite3"
-genesis_filepath = "./genesis.dat"
-blockstore_dir = "./blocks"
+endpoint          = "http://127.0.0.1:28943"
+genesis_filepath  = "./genesis.dat"


### PR DESCRIPTION
This also requires a [specific branch](https://github.com/0xPolygonMiden/miden-node/pull/689) from the node for now, because the node was also still using 0.7.