### PR TITLE
chore: node version downgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="next"
+NODE_BRANCH="cf87d340f394d03bf376abff06a4b36149d63b24"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"


### PR DESCRIPTION
The last commit on the node changed the `StateSync` endpoint. The fix for this is still a WIP, in the meantime we can downgrade the node used in the CI so that the integration tests work again.