### PR TITLE
Web Client Submit Transaction Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Changelog
 
-## 0.7.2 (TBD)
-
-* Web Client: Exposed `InputNotes` iterator and `Note` `assets` property
-
-## 0.7.1 (2025-02-19)
+## 0.7.1 (TBD)
 
 * [BREAKING] Added Initial Web Workers Implementation to Web Client (#720).
 * Web Client Fix: Handled Case Where Web Workers are Not Available (#743).
+* Web Client: Exposed `InputNotes` iterator and `Note` `assets` property (#757).
+* Web Client Submit Transaction Fix: Typescript Typings Now Match Underlying Client Call (#760).
 
 ## 0.7.0 (2025-01-28)
 

--- a/crates/web-client/js/index.js
+++ b/crates/web-client/js/index.js
@@ -421,7 +421,7 @@ export class WebClient {
     }
   }
 
-  async submit_transaction(transactionResult, prover = null) {
+  async submit_transaction(transactionResult, prover = undefined) {
     try {
       if (!this.worker) {
         return await this.wasmWebClient.submit_transaction(

--- a/crates/web-client/js/workers/web-client-methods-worker.js
+++ b/crates/web-client/js/workers/web-client-methods-worker.js
@@ -148,9 +148,8 @@ const methodHandlers = {
       new Uint8Array(serializedTransactionResult)
     );
 
+    let prover = undefined;
     if (serializedProver) {
-      // A prover was provided, so determine which one it is.
-      let prover;
       if (serializedProver.startsWith("remote:")) {
         // For a remote prover, extract the endpoint.
         // For example, "remote:https://my-custom-endpoint.com" becomes "https://my-custom-endpoint.com"
@@ -161,14 +160,10 @@ const methodHandlers = {
       } else {
         throw new Error("Invalid prover tag received in worker");
       }
-      await wasmWebClient.submit_transaction_with_prover(
-        transactionResult,
-        prover
-      );
-    } else {
-      // No prover was passed, so submit the transaction without one.
-      await wasmWebClient.submit_transaction(transactionResult);
     }
+
+    // Call the unified submit_transaction method with an optional prover.
+    await wasmWebClient.submit_transaction(transactionResult, prover);
     return;
   },
   [MethodName.SYNC_STATE]: async () => {

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",


### PR DESCRIPTION
# Summary
This PR consolidates the `submit_transaction` and `submit_transaction_with_prover` calls exposed via WASM in the web client to just `submit_transaction`. 

I made this change because in https://github.com/0xPolygonMiden/miden-client/pull/720, I tried making it so that the top-level `WebClient` wrapper that I introduced to allow the web workers work only exposed one `submit_transaction` call with an optional prover. Then, depending on whether a `prover` was passed, it would call into `submit_transaction` or `submit_transaction_with_prover` as both of these calls were exposed from the rust side. The result of this could be confusing for consumers of the SDK because despite trying to consolidate the calls at the top level, the Typescript typings would still indicate that `submit_transaction_with_prover` is callable directly.

As a result, I decided to consolidate the calls at the rust level, and fix the JS accordingly. Now there should be no confusion when calling `submit_transaction` as the it's the only call to make and the parameters are very clear. 