### PR TITLE
feat: rollback uncommitted tx

### DIFF
--- a/crates/rust-client/src/store/account.rs
+++ b/crates/rust-client/src/store/account.rs
@@ -13,6 +13,7 @@ use miden_objects::{
 /// The account should be stored in the database with its parts normalized. Meaning that the
 /// account header, vault, storage and code are stored separately. This is done to avoid data
 /// duplication as the header can reference the same elements if they have equal roots.
+#[derive(Debug)]
 pub struct AccountRecord {
     /// Full account object.
     account: Account,
@@ -54,6 +55,7 @@ impl From<AccountRecord> for Account {
 /// Represents the status of an account tracked by the client.
 ///
 /// The status of an account may change by local or external factors.
+#[derive(Debug)]
 pub enum AccountStatus {
     /// The account is new and hasn't been used yet. The seed used to create the account is
     /// stored in this state.

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -345,6 +345,8 @@ pub enum TransactionFilter {
     /// Filter by transactions that haven't yet been committed to the blockchain as per the last
     /// sync.
     Uncomitted,
+    /// Return a list of the transaction that matches the provided [`TransactionId`]s.
+    Ids(Vec<TransactionId>),
 }
 
 // NOTE FILTER

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -207,10 +207,10 @@ impl SqliteStore {
 
     pub fn delete_accounts(
         tx: &Transaction<'_>,
-        account_ids: &[AccountId],
+        account_hashes: &[Digest],
     ) -> Result<(), StoreError> {
-        const QUERY: &str = "DELETE FROM accounts WHERE id = ?";
-        for account_id in account_ids {
+        const QUERY: &str = "DELETE FROM accounts WHERE account_hash = ?";
+        for account_id in account_hashes {
             tx.execute(QUERY, params![account_id.to_hex()])?;
         }
         Ok(())

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -210,7 +210,7 @@ impl SqliteStore {
     /// This is used to rollback account changes when a transaction is discarded,
     /// effectively undoing the account state changes that were applied by the transaction.
     ///
-    /// Note: This is not part of the Store trait and is only used internally by the SQLite store
+    /// Note: This is not part of the Store trait and is only used internally by the `SQLite` store
     /// implementation to handle transaction rollbacks.
     pub fn undo_account_state(
         tx: &Transaction<'_>,

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -204,6 +204,17 @@ impl SqliteStore {
             })
             .collect::<Result<BTreeMap<AccountId, AccountCode>, _>>()
     }
+
+    pub fn delete_accounts(
+        tx: &Transaction<'_>,
+        account_ids: &[AccountId],
+    ) -> Result<(), StoreError> {
+        const QUERY: &str = "DELETE FROM accounts WHERE id = ?";
+        for account_id in account_ids {
+            tx.execute(QUERY, params![account_id.to_hex()])?;
+        }
+        Ok(())
+    }
 }
 
 // HELPERS

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -417,7 +417,7 @@ pub(crate) fn undo_account_state(
     tx: &Transaction<'_>,
     account_hashes: &[Digest],
 ) -> Result<(), StoreError> {
-    const QUERY: &str = "DELETE FROM accounts WHERE account_hash = ?";
+    const QUERY: &str = "DELETE FROM accounts WHERE account_commitment = ?";
     for account_id in account_hashes {
         tx.execute(QUERY, params![account_id.to_hex()])?;
     }

--- a/crates/rust-client/src/store/sqlite_store/account.rs
+++ b/crates/rust-client/src/store/sqlite_store/account.rs
@@ -205,7 +205,14 @@ impl SqliteStore {
             .collect::<Result<BTreeMap<AccountId, AccountCode>, _>>()
     }
 
-    pub fn delete_accounts(
+    /// Removes account states with the specified hashes from the database.
+    ///
+    /// This is used to rollback account changes when a transaction is discarded,
+    /// effectively undoing the account state changes that were applied by the transaction.
+    ///
+    /// Note: This is not part of the Store trait and is only used internally by the SQLite store
+    /// implementation to handle transaction rollbacks.
+    pub fn undo_account_state(
         tx: &Transaction<'_>,
         account_hashes: &[Digest],
     ) -> Result<(), StoreError> {

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -201,7 +201,7 @@ impl SqliteStore {
         }
 
         // Remove the accounts that are originated from the discarded transactions
-        Self::delete_accounts(&tx, &accounts_to_remove)?;
+        Self::undo_account_state(&tx, &accounts_to_remove)?;
 
         tx.commit()?;
 

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -188,7 +188,7 @@ impl SqliteStore {
         // the final state after the transaction is applied. We can use this field to
         // identify the accounts that are originated from the discarded transactions.
 
-        let mut accounts_to_remove = Vec::new();
+        let mut account_states_to_remove = Vec::new();
         for tx_record in &transactions_records_to_discard {
             let final_account_state = tx_record.final_account_state;
             let account = outdated_accounts
@@ -202,11 +202,11 @@ impl SqliteStore {
                     }
                 })?;
 
-            accounts_to_remove.push(account.account().commitment());
+            account_states_to_remove.push(account.account().commitment());
         }
 
         // Remove the accounts that are originated from the discarded transactions
-        Self::undo_account_state(&tx, &accounts_to_remove)?;
+        Self::undo_account_state(&tx, &account_states_to_remove)?;
 
         tx.commit()?;
 

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -12,10 +12,11 @@ use super::SqliteStore;
 use crate::{
     note::NoteUpdates,
     store::{
+        StoreError, TransactionFilter,
         sqlite_store::{
             account::{lock_account, update_account},
             note::apply_note_updates_tx,
-        }, StoreError, TransactionFilter
+        },
     },
     sync::{NoteTagRecord, NoteTagSource, StateSyncUpdate},
 };

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -181,9 +181,6 @@ impl SqliteStore {
 
         Self::mark_transactions_as_discarded(&tx, transactions_to_discard)?;
 
-        // TODO: here we need to remove the `accounts` table entries that are originated from the
-        // discarded transactions
-
         // Transaction records have a final_account_state field, which is the hash of the account in
         // the final state after the transaction is applied. We can use this field to
         // identify the accounts that are originated from the discarded transactions.

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -8,7 +8,7 @@ use miden_objects::{
 use miden_tx::utils::{Deserializable, Serializable};
 use rusqlite::{Connection, Transaction, params};
 
-use super::SqliteStore;
+use super::{SqliteStore, account::undo_account_state};
 use crate::{
     note::NoteUpdates,
     store::{
@@ -206,7 +206,7 @@ impl SqliteStore {
         }
 
         // Remove the accounts that are originated from the discarded transactions
-        Self::undo_account_state(&tx, &account_states_to_remove)?;
+        undo_account_state(&tx, &account_states_to_remove)?;
 
         tx.commit()?;
 

--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -139,6 +139,41 @@ impl SqliteStore {
         // Marc transactions as discarded
         Self::mark_transactions_as_discarded(&tx, &discarded_transactions)?;
 
+        // TODO: here we need to remove the `accounts` table entries that are originated from the
+        // discarded transactions
+
+        // First we need the `transaction` entries from the `transactions` table that matches the
+        // `transactions_to_discard`
+        let transactions_to_discard =
+            Self::get_transactions(conn, &TransactionFilter::Ids(discarded_transactions.clone()))?;
+
+        let outdated_accounts = transactions_to_discard
+            .iter()
+            .map(|transaction_record| {
+                Self::get_account(conn, transaction_record.account_id).unwrap().unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        // Transaction records have a final_account_state field, which is the hash of the account in
+        // the final state after the transaction is applied. We can use this field to
+        // identify the accounts that are originated from the discarded transactions.
+
+        let accounts_to_remove = transactions_to_discard
+            .iter()
+            .map(|tx| {
+                let final_account_state = tx.final_account_state;
+
+                let account = outdated_accounts
+                    .iter()
+                    .find(|account| account.account().hash() == final_account_state)?;
+
+                account.account().id()
+            })
+            .collect::<Vec<AccountId>>();
+
+        // Remove the accounts that are originated from the discarded transactions
+        Self::delete_accounts(&tx, &accounts_to_remove)?;
+
         // Update public accounts on the db that have been updated onchain
         for account in updated_accounts.updated_public_accounts() {
             update_account(&tx, account)?;

--- a/crates/rust-client/src/store/sqlite_store/transaction.rs
+++ b/crates/rust-client/src/store/sqlite_store/transaction.rs
@@ -48,12 +48,8 @@ impl TransactionFilter {
             TransactionFilter::All => QUERY.to_string(),
             TransactionFilter::Uncomitted => format!("{QUERY} WHERE tx.commit_height IS NULL"),
             TransactionFilter::Ids(ids) => {
-                let ids = ids
-                    .iter()
-                    .map(|id| format!("'{}'", id.to_string()))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{QUERY} WHERE tx.id IN ({})", ids)
+                let ids = ids.iter().map(|id| format!("'{id}'")).collect::<Vec<_>>().join(", ");
+                format!("{QUERY} WHERE tx.id IN ({ids})")
             },
         }
     }

--- a/crates/rust-client/src/store/sqlite_store/transaction.rs
+++ b/crates/rust-client/src/store/sqlite_store/transaction.rs
@@ -11,7 +11,6 @@ use miden_objects::{
     account::AccountId,
     block::BlockNumber,
     crypto::utils::{Deserializable, Serializable},
-    testing::account_id,
     transaction::{
         ExecutedTransaction, OutputNotes, ToInputNoteCommitments, TransactionId, TransactionScript,
     },

--- a/crates/rust-client/src/store/sqlite_store/transaction.rs
+++ b/crates/rust-client/src/store/sqlite_store/transaction.rs
@@ -11,6 +11,7 @@ use miden_objects::{
     account::AccountId,
     block::BlockNumber,
     crypto::utils::{Deserializable, Serializable},
+    testing::account_id,
     transaction::{
         ExecutedTransaction, OutputNotes, ToInputNoteCommitments, TransactionId, TransactionScript,
     },
@@ -47,6 +48,14 @@ impl TransactionFilter {
         match self {
             TransactionFilter::All => QUERY.to_string(),
             TransactionFilter::Uncomitted => format!("{QUERY} WHERE tx.commit_height IS NULL"),
+            TransactionFilter::Ids(ids) => {
+                let ids = ids
+                    .iter()
+                    .map(|id| format!("'{}'", id.to_string()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{QUERY} WHERE tx.id IN ({})", ids)
+            },
         }
     }
 }

--- a/crates/rust-client/src/store/web_store/account/js_bindings.rs
+++ b/crates/rust-client/src/store/web_store/account/js_bindings.rs
@@ -81,4 +81,10 @@ extern "C" {
 
     #[wasm_bindgen(js_name = lockAccount)]
     pub fn idxdb_lock_account(account_id: String) -> js_sys::Promise;
+
+    // DELETES
+    // ================================================================================================
+
+    #[wasm_bindgen(js_name = undoAccountStates)]
+    pub fn idxdb_undo_account_states(account_hashes: Vec<String>) -> js_sys::Promise;
 }

--- a/crates/rust-client/src/store/web_store/account/mod.rs
+++ b/crates/rust-client/src/store/web_store/account/mod.rs
@@ -296,7 +296,7 @@ impl WebStore {
         account_states: &[Digest],
     ) -> Result<(), StoreError> {
         let account_commitments =
-            account_states.iter().map(|account| account.to_string()).collect::<Vec<_>>();
+            account_states.iter().map(ToString::to_string).collect::<Vec<_>>();
         let promise = idxdb_undo_account_states(account_commitments);
         let _ = JsFuture::from(promise).await.map_err(|js_error| {
             StoreError::DatabaseError(format!("Failed to undo account states: {js_error:?}"))

--- a/crates/rust-client/src/store/web_store/account/mod.rs
+++ b/crates/rust-client/src/store/web_store/account/mod.rs
@@ -21,7 +21,8 @@ use js_bindings::{
     idxdb_fetch_and_cache_account_auth_by_pub_key, idxdb_get_account_asset_vault,
     idxdb_get_account_code, idxdb_get_account_header, idxdb_get_account_header_by_commitment,
     idxdb_get_account_headers, idxdb_get_account_ids, idxdb_get_account_storage,
-    idxdb_get_foreign_account_code, idxdb_lock_account, idxdb_upsert_foreign_account_code,
+    idxdb_get_foreign_account_code, idxdb_lock_account, idxdb_undo_account_states,
+    idxdb_upsert_foreign_account_code,
 };
 
 mod models;
@@ -288,6 +289,20 @@ impl WebStore {
             .collect::<Result<BTreeMap<AccountId, AccountCode>, StoreError>>()?;
 
         Ok(foreign_account_code)
+    }
+
+    pub(crate) async fn undo_account_states(
+        &self,
+        account_states: &[Digest],
+    ) -> Result<(), StoreError> {
+        let account_commitments =
+            account_states.iter().map(|account| account.to_string()).collect::<Vec<_>>();
+        let promise = idxdb_undo_account_states(account_commitments);
+        let _ = JsFuture::from(promise).await.map_err(|js_error| {
+            StoreError::DatabaseError(format!("Failed to undo account states: {js_error:?}"))
+        })?;
+
+        Ok(())
     }
 }
 

--- a/crates/rust-client/src/store/web_store/js/accounts.js
+++ b/crates/rust-client/src/store/web_store/js/accounts.js
@@ -474,9 +474,15 @@ export async function lockAccount(accountId) {
 
 export async function undoAccountStates(accountCommitments) {
   try {
-    await accounts.where("accountCommitment").anyOf(accountCommitments).delete();
+    await accounts
+      .where("accountCommitment")
+      .anyOf(accountCommitments)
+      .delete();
   } catch (error) {
-    console.error(`Error undoing account states: ${accountCommitments}:`, error);
+    console.error(
+      `Error undoing account states: ${accountCommitments}:`,
+      error
+    );
     throw error; // Rethrow the error to handle it further up the call chain if needed
   }
 }

--- a/crates/rust-client/src/store/web_store/js/accounts.js
+++ b/crates/rust-client/src/store/web_store/js/accounts.js
@@ -472,11 +472,11 @@ export async function lockAccount(accountId) {
 
 // Delete functions
 
-export async function undoAccountStates(accountHashes) {
+export async function undoAccountStates(accountCommitments) {
   try {
-    await accounts.where("accountCommitment").anyOf(accountHashes).delete();
+    await accounts.where("accountCommitment").anyOf(accountCommitments).delete();
   } catch (error) {
-    console.error(`Error undoing account states: ${accountIds}:`, error);
+    console.error(`Error undoing account states: ${accountCommitments}:`, error);
     throw error; // Rethrow the error to handle it further up the call chain if needed
   }
 }

--- a/crates/rust-client/src/store/web_store/js/accounts.js
+++ b/crates/rust-client/src/store/web_store/js/accounts.js
@@ -470,6 +470,17 @@ export async function lockAccount(accountId) {
   }
 }
 
+// Delete functions
+
+export async function undoAccountStates(accountHashes) {
+  try {
+    await accounts.where("accountCommitment").anyOf(accountHashes).delete();
+  } catch (error) {
+    console.error(`Error undoing account states: ${accountIds}:`, error);
+    throw error; // Rethrow the error to handle it further up the call chain if needed
+  }
+}
+
 function uint8ArrayToBase64(bytes) {
   const binary = bytes.reduce(
     (acc, byte) => acc + String.fromCharCode(byte),

--- a/crates/rust-client/src/store/web_store/js/transactions.js
+++ b/crates/rust-client/src/store/web_store/js/transactions.js
@@ -1,5 +1,6 @@
 import { transactions, transactionScripts } from "./schema.js";
 
+const IDS_FILTER_PREFIX = "Ids:";
 export async function getTransactions(filter) {
   let transactionRecords;
 
@@ -10,8 +11,8 @@ export async function getTransactions(filter) {
           (tx) => tx.commitHeight === undefined || tx.commitHeight === null
         )
         .toArray();
-    } else if (filter.startsWith("Ids:")) {
-      const idsString = filter.substring(4); // Remove "Ids:" prefix
+    } else if (filter.startsWith(IDS_FILTER_PREFIX)) {
+      const idsString = filter.substring(IDS_FILTER_PREFIX.length);
       const ids = idsString.split(",");
 
       if (ids.length > 0) {

--- a/crates/rust-client/src/store/web_store/js/transactions.js
+++ b/crates/rust-client/src/store/web_store/js/transactions.js
@@ -10,6 +10,18 @@ export async function getTransactions(filter) {
           (tx) => tx.commitHeight === undefined || tx.commitHeight === null
         )
         .toArray();
+    } else if (filter.startsWith("Ids:")) {
+      const idsString = filter.substring(4); // Remove "Ids:" prefix
+      const ids = idsString.split(",");
+
+      if (ids.length > 0) {
+        transactionRecords = await transactions
+          .where("id")
+          .anyOf(ids)
+          .toArray();
+      } else {
+        transactionRecords = [];
+      }
     } else {
       transactionRecords = await transactions.toArray();
     }
@@ -82,7 +94,7 @@ export async function getTransactions(filter) {
     );
 
     return processedTransactions;
-  } catch {
+  } catch (err) {
     console.error("Failed to get transactions: ", err);
     throw err;
   }

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -198,7 +198,7 @@ impl WebStore {
         // First we need the `transaction` entries from the `transactions` table that matches the
         // `transactions_to_discard`
         let transactions_records_to_discard = self
-            .get_transactions(TransactionFilter::Ids(transactions_to_discard.to_vec()))
+            .get_transactions(TransactionFilter::Ids(transactions_to_discard.clone()))
             .await?;
 
         apply_note_updates_tx(&note_updates).await?;

--- a/crates/rust-client/src/store/web_store/sync/mod.rs
+++ b/crates/rust-client/src/store/web_store/sync/mod.rs
@@ -21,7 +21,7 @@ use super::{
 };
 use crate::{
     note::NoteUpdates,
-    store::StoreError,
+    store::{StoreError, TransactionFilter},
     sync::{NoteTagRecord, NoteTagSource, StateSyncUpdate},
 };
 
@@ -195,11 +195,26 @@ impl WebStore {
         note_updates: NoteUpdates,
         transactions_to_discard: Vec<TransactionId>,
     ) -> Result<(), StoreError> {
+        // First we need the `transaction` entries from the `transactions` table that matches the
+        // `transactions_to_discard`
+        let transactions_records_to_discard = self
+            .get_transactions(TransactionFilter::Ids(transactions_to_discard.to_vec()))
+            .await?;
+
         apply_note_updates_tx(&note_updates).await?;
         let transactions_ids_as_str: Vec<String> =
             transactions_to_discard.iter().map(ToString::to_string).collect();
 
         let promise = idxdb_discard_transactions(transactions_ids_as_str);
+
+        let final_account_states = transactions_records_to_discard
+            .iter()
+            .map(|tx_record| tx_record.final_account_state)
+            .collect::<Vec<_>>();
+
+        // Remove the account states that are originated from the discarded transactions
+        self.undo_account_states(&final_account_states).await?;
+
         JsFuture::from(promise).await.unwrap();
 
         Ok(())

--- a/crates/rust-client/src/store/web_store/transaction/mod.rs
+++ b/crates/rust-client/src/store/web_store/transaction/mod.rs
@@ -1,4 +1,7 @@
-use alloc::{string::ToString, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use miden_objects::{
     Digest,
@@ -33,6 +36,11 @@ impl WebStore {
         let filter_as_str = match filter {
             TransactionFilter::All => "All",
             TransactionFilter::Uncomitted => "Uncomitted",
+            TransactionFilter::Ids(ids) => &{
+                let ids_str =
+                    ids.iter().map(ToString::to_string).collect::<Vec<String>>().join(",");
+                format!("Ids:{ids_str}")
+            },
         };
 
         let promise = idxdb_get_transactions(filter_as_str.to_string());

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./webClientTestUtils";
 import { TransactionProver } from "../dist";
 import { setupConsumedNote } from "./notes.test";
-import { TransactionRecord } from "../dist/crates/miden_client_web";
+import { Account, TransactionRecord } from "../dist/crates/miden_client_web";
 
 // NEW_MINT_TRANSACTION TESTS
 // =======================================================================================================
@@ -577,6 +577,9 @@ describe("use custom transaction prover per request", () => {
 
 interface DiscardedTransactionResult {
   discardedTransactions: TransactionRecord[];
+  accountStateBeforeTx: Account | undefined;
+  accountStateAfterTx: Account | undefined;
+  accountStateAfterDiscardedTx: Account | undefined;
 }
 
 export const discardedTransaction =
@@ -703,11 +706,11 @@ describe("discarded_transaction tests", () => {
     const result = await discardedTransaction();
 
     expect(result.discardedTransactions.length).to.equal(1);
-    expect(result.accountStateBeforeTx.commitment()).to.equal(
-      result.accountStateAfterDiscardedTx.commitment()
+    expect(result.accountStateBeforeTx?.commitment()).to.equal(
+      result.accountStateAfterDiscardedTx?.commitment()
     );
-    expect(result.accountStateAfterTx.commitment()).to.not.equal(
-      result.accountStateAfterDiscardedTx.commitment()
+    expect(result.accountStateAfterTx?.commitment()).to.not.equal(
+      result.accountStateAfterDiscardedTx?.commitment()
     );
   });
 });

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -665,7 +665,9 @@ export const discardedTransaction =
       await client.forceImportStore(preConsumeStore);
 
       // Get the account state before the transaction is applied
-      const accountStateBeforeTx = await client.getAccount(targetAccount.id()) as Account;
+      const accountStateBeforeTx = (await client.getAccount(
+        targetAccount.id()
+      )) as Account;
       if (!accountStateBeforeTx) {
         throw new Error("Failed to get account state before transaction");
       }
@@ -678,7 +680,9 @@ export const discardedTransaction =
 
       await client.testingApplyTransaction(targetTxResult);
       // Get the account state after the transaction is applied
-      const accountStateAfterTx = await client.getAccount(targetAccount.id()) as Account;
+      const accountStateAfterTx = (await client.getAccount(
+        targetAccount.id()
+      )) as Account;
       if (!accountStateAfterTx) {
         throw new Error("Failed to get account state after transaction");
       }
@@ -694,17 +698,21 @@ export const discardedTransaction =
       );
 
       // Get the account state after the discarded transactions are applied
-      const accountStateAfterDiscardedTx = await client.getAccount(
+      const accountStateAfterDiscardedTx = (await client.getAccount(
         targetAccount.id()
-      ) as Account;
+      )) as Account;
       if (!accountStateAfterDiscardedTx) {
-        throw new Error("Failed to get account state after discarded transaction");
+        throw new Error(
+          "Failed to get account state after discarded transaction"
+        );
       }
 
       // Perform a `.commitment()` check on each account
       const commitmentBeforeTx = accountStateBeforeTx.commitment().toHex();
       const commitmentAfterTx = accountStateAfterTx.commitment().toHex();
-      const commitmentAfterDiscardedTx = accountStateAfterDiscardedTx.commitment().toHex();
+      const commitmentAfterDiscardedTx = accountStateAfterDiscardedTx
+        .commitment()
+        .toHex();
 
       return {
         discardedTransactions: discardedTransactions,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1378,14 +1378,14 @@ async fn test_discarded_transaction() {
 
     // Store the account state before applying the transaction
     let account_before_tx = client_1.get_account(from_account_id).await.unwrap().unwrap();
-    let account_hash_before_tx = account_before_tx.account().hash();
+    let account_hash_before_tx = account_before_tx.account().commitment();
 
     // Apply the transaction
     client_1.testing_apply_transaction(tx_result).await.unwrap();
 
     // Check that the account state has changed after applying the transaction
     let account_after_tx = client_1.get_account(from_account_id).await.unwrap().unwrap();
-    let account_hash_after_tx = account_after_tx.account().hash();
+    let account_hash_after_tx = account_after_tx.account().commitment();
 
     assert_ne!(
         account_hash_before_tx, account_hash_after_tx,
@@ -1416,7 +1416,7 @@ async fn test_discarded_transaction() {
 
     // Check that the account state has been rolled back after the transaction was discarded
     let account_after_sync = client_1.get_account(from_account_id).await.unwrap().unwrap();
-    let account_hash_after_sync = account_after_sync.account().hash();
+    let account_hash_after_sync = account_after_sync.account().commitment();
 
     assert_ne!(
         account_hash_after_sync, account_hash_after_tx,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1375,7 +1375,22 @@ async fn test_discarded_transaction() {
     let tx_result = client_1.new_transaction(from_account_id, tx_request.clone()).await.unwrap();
     let tx_id = tx_result.executed_transaction().id();
     client_1.testing_prove_transaction(&tx_result).await.unwrap();
+
+    // Store the account state before applying the transaction
+    let account_before_tx = client_1.get_account(from_account_id).await.unwrap().unwrap();
+    let account_hash_before_tx = account_before_tx.account().hash();
+
+    // Apply the transaction
     client_1.testing_apply_transaction(tx_result).await.unwrap();
+
+    // Check that the account state has changed after applying the transaction
+    let account_after_tx = client_1.get_account(from_account_id).await.unwrap().unwrap();
+    let account_hash_after_tx = account_after_tx.account().hash();
+
+    assert_ne!(
+        account_hash_before_tx, account_hash_after_tx,
+        "Account hash should change after applying the transaction"
+    );
 
     let note_record = client_1.get_input_note(note.id()).await.unwrap().unwrap();
     assert!(matches!(note_record.state(), InputNoteState::ProcessingAuthenticated(_)));
@@ -1398,6 +1413,19 @@ async fn test_discarded_transaction() {
         .find(|tx| tx.id == tx_id)
         .unwrap();
     assert!(matches!(tx_record.transaction_status, TransactionStatus::Discarded));
+
+    // Check that the account state has been rolled back after the transaction was discarded
+    let account_after_sync = client_1.get_account(from_account_id).await.unwrap().unwrap();
+    let account_hash_after_sync = account_after_sync.account().hash();
+
+    assert_ne!(
+        account_hash_after_sync, account_hash_after_tx,
+        "Account hash should change after transaction was discarded"
+    );
+    assert_eq!(
+        account_hash_after_sync, account_hash_before_tx,
+        "Account hash should be rolled back to the value before the transaction"
+    );
 }
 
 struct AlwaysFailingProver;


### PR DESCRIPTION
If a transaction gets discarded, delete. the corresponding account entry.  Due to the sync_nullifiers method from the web client store not supporting discarded transactions yet, this PR introduces the rollback only for the sqlite store.

part of #607 