### PR TITLE
fix: downgrade node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="next"
+NODE_BRANCH="399888dfea24322604f0ce5a720628dc368edbbc"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"


### PR DESCRIPTION
This change is meant to be temporary. The objective is to fix the CI checks while the node gets fixed and #793 gets merged. 