### PR TITLE
chore: use miden-node's main, update miden-node-proto-build to 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* Added wallet generation from seed & import from seed on web SDK (#710).
+* Added import/export for web client db (#740).
 * Added Delegated Proving Support to All Transaction Types in Web Client (#792).
 * Added support to import public accounts to `Client` (#733).
 * [BREAKING] Merged `TonicRpcClient` with `WebTonicRpcClient` and added missing endpoints (#744).
@@ -14,11 +16,9 @@
 
 ### Changes
 
-* Added wallet generation from seed & import from seed on web SDK (#710).
-* Add check for empty pay to ID notes (#714).
+* Added check for empty pay to ID notes (#714).
 * [BREAKING] Refactored authentication out of the `Client` and added new separate authenticators (#718).
-* Added import/export for web client db (#740).
-* Re-exported RemoteTransactionProver in `rust-client` (#752).
+* Re-exported `RemoteTransactionProver` in `rust-client` (#752).
 * Moved error handling to the `TransactionRequestBuilder::build()` (#750).
 * [BREAKING] Added starting block number parameter to `CheckNullifiersByPrefix` and removed nullifiers from `SyncState` (#758).
 * Added `ClientBuilder` for client initialization (#741).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,8 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.8.0"
-source = "git+https://github.com/0xPolygonMiden/miden-node?branch=next#ac49ae324f3d9f4e425ebec6eda909274412630a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb1d9b312ec25b732b4d3f6f75d37dd6ff1b69dd483e89ec8001be482dcc5fb"
 dependencies = [
  "anyhow",
  "prost",

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 
 NODE_DIR="miden-node"
 NODE_REPO="https://github.com/0xPolygonMiden/miden-node.git"
-NODE_BRANCH="next"
+NODE_BRANCH="main"
 
 PROVER_DIR="miden-base"
 PROVER_REPO="https://github.com/0xPolygonMiden/miden-base.git"

--- a/crates/rust-client/Cargo.toml
+++ b/crates/rust-client/Cargo.toml
@@ -66,7 +66,7 @@ uuid = { version = "1.10", features = ["serde", "v4"] }
 web-sys = { version = "0.3", features = ["console"]}
 
 [build-dependencies]
-miden-node-proto-build = { git = "https://github.com/0xPolygonMiden/miden-node", branch = "next" }
+miden-node-proto-build = { version = "0.8.0", default-features = false }
 miden-lib = { workspace = true }
 miden-objects = { workspace = true }
 miette = { workspace = true }


### PR DESCRIPTION
- Updates the version of the node used in the CI and the Makefile.
- Updates the version of `miden-node-proto-build` to `0.8`.