### PR TITLE
fix: flaky tests

### DIFF
--- a/crates/rust-client/src/store/sqlite_store/sync.rs
+++ b/crates/rust-client/src/store/sqlite_store/sync.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::items_after_statements)]
 
 use alloc::{collections::BTreeSet, vec::Vec};
-use std::println;
 
 use miden_objects::{Digest, block::BlockNumber, note::NoteTag};
 use miden_tx::utils::{Deserializable, Serializable};
@@ -173,7 +172,6 @@ impl SqliteStore {
         undo_account_state(&tx, &account_hashes_to_delete)?;
 
         // Combine discarded transactions from sync and old pending transactions
-        println!("Stale transactions: {:?}", transaction_updates.stale_transactions());
         let mut discarded_transactions = transaction_updates.discarded_transactions().to_vec();
         discarded_transactions
             .extend(transaction_updates.stale_transactions().iter().map(|tx| tx.id));

--- a/crates/rust-client/src/sync/mod.rs
+++ b/crates/rust-client/src/sync/mod.rs
@@ -85,7 +85,7 @@ pub use state_sync_update::{AccountUpdates, BlockUpdates, StateSyncUpdate, Trans
 // ================================================================================================
 
 /// The number of blocks that are considered old enough to discard pending transactions.
-pub const TX_GRACEFUL_BLOCKS: u32 = 10;
+pub const TX_GRACEFUL_BLOCKS: u32 = 20;
 
 /// Client synchronization methods.
 impl Client {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -224,15 +224,19 @@ pub async fn wait_for_tx(client: &mut TestClient, transaction_id: TransactionId)
             .unwrap()
             .pop()
             .unwrap();
-        let is_tx_committed =
-            matches!(tracked_transaction.transaction_status, TransactionStatus::Committed(_));
 
-        if is_tx_committed {
-            break;
+        match tracked_transaction.transaction_status {
+            TransactionStatus::Committed(_) => {
+                break;
+            },
+            TransactionStatus::Pending => {
+                // 500_000_000 ns = 0.5s
+                std::thread::sleep(std::time::Duration::new(0, 500_000_000));
+            },
+            TransactionStatus::Discarded => {
+                panic!("Transaction discarded");
+            },
         }
-
-        // 500_000_000 ns = 0.5s
-        std::thread::sleep(std::time::Duration::new(0, 500_000_000));
     }
 }
 


### PR DESCRIPTION
The component PR had some flaky tests due to a value I modified while debugging and never returned to normal. I also removed some debug prints and changed the `wait_for_tx` to better catch these cases in the future.