### PR TITLE
Convert NoteType class to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8.2 (TBD)
 
-* Converted Web Client `NoteType` class to `enum` (#830)
+* Converted Web Client `NoteType` class to `enum` (#831)
 
 ## 0.8.1 (2025-03-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.2 (TBD)
+
+* Converted Web Client `NoteType` class to `enum` (#830)
+
 ## 0.8.1 (2025-03-28)
 
 ### Features

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -74,7 +74,7 @@ pub enum ClientError {
     NoteScreenerError(#[from] NoteScreenerError),
     #[error("store error")]
     StoreError(#[from] StoreError),
-    #[error("transaction executor error")]
+    #[error("transaction executor error: {0}")]
     TransactionExecutorError(#[from] TransactionExecutorError),
     #[error("transaction prover error")]
     TransactionProvingError(#[from] TransactionProverError),

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.8.1-next.0",
+  "version": "0.8.2",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",

--- a/crates/web-client/package.json
+++ b/crates/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-sdk",
-  "version": "0.7.5-next.0",
+  "version": "0.8.1-next.0",
   "description": "Polygon Miden Wasm SDK",
   "collaborators": [
     "Polygon Miden",

--- a/crates/web-client/src/models/note.rs
+++ b/crates/web-client/src/models/note.rs
@@ -48,7 +48,7 @@ impl Note {
         sender: &AccountId,
         target: &AccountId,
         assets: &NoteAssets,
-        note_type: &NoteType,
+        note_type: NoteType,
         serial_num: &Word,
         aux: &Felt,
     ) -> Self {
@@ -76,7 +76,7 @@ impl Note {
         sender: &AccountId,
         target: &AccountId,
         assets: &NoteAssets,
-        note_type: &NoteType,
+        note_type: NoteType,
         serial_num: &Word,
         recall_height: u32,
         aux: &Felt,

--- a/crates/web-client/src/models/note_metadata.rs
+++ b/crates/web-client/src/models/note_metadata.rs
@@ -41,11 +41,7 @@ impl NoteMetadata {
 
     #[wasm_bindgen(js_name = "noteType")]
     pub fn note_type(&self) -> NoteType {
-        match self.0.note_type() {
-            NativeNoteType::Private => NoteType::Private,
-            NativeNoteType::Public => NoteType::Public,
-            NativeNoteType::Encrypted => NoteType::Encrypted,
-        }
+        self.0.note_type().into()
     }
 }
 

--- a/crates/web-client/src/models/note_metadata.rs
+++ b/crates/web-client/src/models/note_metadata.rs
@@ -1,4 +1,4 @@
-use miden_objects::note::NoteMetadata as NativeNoteMetadata;
+use miden_objects::note::{NoteMetadata as NativeNoteMetadata, NoteType as NativeNoteType};
 use wasm_bindgen::prelude::*;
 
 use super::{
@@ -15,7 +15,7 @@ impl NoteMetadata {
     #[wasm_bindgen(constructor)]
     pub fn new(
         sender: &AccountId,
-        note_type: &NoteType,
+        note_type: NoteType,
         note_tag: &NoteTag,
         note_execution_hint: &NoteExecutionHint,
         aux: Option<Felt>, // Create an OptionFelt type so user has choice to consume or not
@@ -41,7 +41,11 @@ impl NoteMetadata {
 
     #[wasm_bindgen(js_name = "noteType")]
     pub fn note_type(&self) -> NoteType {
-        self.0.note_type().into()
+        match self.0.note_type() {
+            NativeNoteType::Private => NoteType::Private,
+            NativeNoteType::Public => NoteType::Public,
+            NativeNoteType::Encrypted => NoteType::Encrypted,
+        }
     }
 }
 

--- a/crates/web-client/src/models/note_metadata.rs
+++ b/crates/web-client/src/models/note_metadata.rs
@@ -1,4 +1,4 @@
-use miden_objects::note::{NoteMetadata as NativeNoteMetadata, NoteType as NativeNoteType};
+use miden_objects::note::NoteMetadata as NativeNoteMetadata;
 use wasm_bindgen::prelude::*;
 
 use super::{

--- a/crates/web-client/src/models/note_type.rs
+++ b/crates/web-client/src/models/note_type.rs
@@ -1,59 +1,60 @@
 use miden_objects::note::NoteType as NativeNoteType;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::js_sys::Uint8Array;
+//use wasm_bindgen_futures::js_sys::Uint8Array;
 
-use crate::utils::{deserialize_from_uint8array, serialize_to_uint8array};
+//use crate::utils::{deserialize_from_uint8array, serialize_to_uint8array};
 
-#[derive(Clone, Copy)]
+// Keep these masks in sync with `miden-lib/asm/miden/kernels/tx/tx.masm`
 #[wasm_bindgen]
-pub struct NoteType(NativeNoteType);
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NoteType {
+    /// Notes with this type have only their hash published to the network.
+    Private = 0b10,
 
-#[wasm_bindgen]
-impl NoteType {
-    pub fn private() -> NoteType {
-        NoteType(NativeNoteType::Private)
-    }
+    /// Notes with this type are shared with the network encrypted.
+    Encrypted = 0b11,
 
-    pub fn public() -> NoteType {
-        NoteType(NativeNoteType::Public)
-    }
-
-    pub fn encrypted() -> NoteType {
-        NoteType(NativeNoteType::Encrypted)
-    }
-
-    pub fn serialize(&self) -> Uint8Array {
-        serialize_to_uint8array(&self.0)
-    }
-
-    pub fn deserialize(bytes: &Uint8Array) -> Result<NoteType, JsValue> {
-        deserialize_from_uint8array::<NativeNoteType>(bytes).map(NoteType)
-    }
+    /// Notes with this type are fully shared with the network.
+    Public = 0b01,
 }
 
-// CONVERSIONS
-// ================================================================================================
-
 impl From<NativeNoteType> for NoteType {
-    fn from(native_note_type: NativeNoteType) -> Self {
-        NoteType(native_note_type)
+    fn from(value: NativeNoteType) -> Self {
+        match value {
+            NativeNoteType::Private => NoteType::Private,
+            NativeNoteType::Public => NoteType::Public,
+            NativeNoteType::Encrypted => NoteType::Encrypted,
+        }
     }
 }
 
 impl From<&NativeNoteType> for NoteType {
-    fn from(native_note_type: &NativeNoteType) -> Self {
-        NoteType(*native_note_type)
+    fn from(value: &NativeNoteType) -> Self {
+        match *value {
+            NativeNoteType::Private => NoteType::Private,
+            NativeNoteType::Public => NoteType::Public,
+            NativeNoteType::Encrypted => NoteType::Encrypted,
+        }
     }
 }
 
 impl From<NoteType> for NativeNoteType {
-    fn from(note_type: NoteType) -> Self {
-        note_type.0
+    fn from(value: NoteType) -> Self {
+        match value {
+            NoteType::Private => NativeNoteType::Private,
+            NoteType::Public => NativeNoteType::Public,
+            NoteType::Encrypted => NativeNoteType::Encrypted,
+        }
     }
 }
 
 impl From<&NoteType> for NativeNoteType {
-    fn from(note_type: &NoteType) -> Self {
-        note_type.0
+    fn from(value: &NoteType) -> Self {
+        match *value {
+            NoteType::Private => NativeNoteType::Private,
+            NoteType::Public => NativeNoteType::Public,
+            NoteType::Encrypted => NativeNoteType::Encrypted,
+        }
     }
 }

--- a/crates/web-client/src/models/note_type.rs
+++ b/crates/web-client/src/models/note_type.rs
@@ -1,8 +1,5 @@
 use miden_objects::note::NoteType as NativeNoteType;
 use wasm_bindgen::prelude::*;
-//use wasm_bindgen_futures::js_sys::Uint8Array;
-
-//use crate::utils::{deserialize_from_uint8array, serialize_to_uint8array};
 
 // Keep these masks in sync with `miden-lib/asm/miden/kernels/tx/tx.masm`
 #[wasm_bindgen]
@@ -29,29 +26,9 @@ impl From<NativeNoteType> for NoteType {
     }
 }
 
-impl From<&NativeNoteType> for NoteType {
-    fn from(value: &NativeNoteType) -> Self {
-        match *value {
-            NativeNoteType::Private => NoteType::Private,
-            NativeNoteType::Public => NoteType::Public,
-            NativeNoteType::Encrypted => NoteType::Encrypted,
-        }
-    }
-}
-
 impl From<NoteType> for NativeNoteType {
     fn from(value: NoteType) -> Self {
         match value {
-            NoteType::Private => NativeNoteType::Private,
-            NoteType::Public => NativeNoteType::Public,
-            NoteType::Encrypted => NativeNoteType::Encrypted,
-        }
-    }
-}
-
-impl From<&NoteType> for NativeNoteType {
-    fn from(value: &NoteType) -> Self {
-        match *value {
             NoteType::Private => NativeNoteType::Private,
             NoteType::Public => NativeNoteType::Public,
             NoteType::Encrypted => NativeNoteType::Encrypted,

--- a/crates/web-client/src/new_transactions.rs
+++ b/crates/web-client/src/new_transactions.rs
@@ -78,7 +78,7 @@ impl WebClient {
         &mut self,
         target_account_id: &AccountId,
         faucet_id: &AccountId,
-        note_type: &NoteType,
+        note_type: NoteType,
         amount: u64,
     ) -> Result<TransactionRequest, JsValue> {
         let fungible_asset = FungibleAsset::new(faucet_id.into(), amount)
@@ -110,7 +110,7 @@ impl WebClient {
         sender_account_id: &AccountId,
         target_account_id: &AccountId,
         faucet_id: &AccountId,
-        note_type: &NoteType,
+        note_type: NoteType,
         amount: u64,
         recall_height: Option<u32>,
     ) -> Result<TransactionRequest, JsValue> {
@@ -196,7 +196,7 @@ impl WebClient {
         offered_asset_amount: String,
         requested_asset_faucet_id: String,
         requested_asset_amount: String,
-        note_type: &NoteType,
+        note_type: NoteType,
     ) -> Result<NewSwapTransactionResult, JsValue> {
         let sender_account_id =
             NativeAccountId::from_hex(&sender_account_id).map_err(|err| err.to_string())?;

--- a/crates/web-client/test/new_transactions.test.ts
+++ b/crates/web-client/test/new_transactions.test.ts
@@ -102,7 +102,7 @@ export const sendTransaction = async (
     let mintTransactionRequest = client.newMintTransactionRequest(
       senderAccount.id(),
       faucetAccount.id(),
-      window.NoteType.private(),
+      window.NoteType.Private,
       BigInt(1000)
     );
     let mintTransactionResult = await client.newTransaction(
@@ -145,7 +145,7 @@ export const sendTransaction = async (
       senderAccount.id(),
       targetAccount.id(),
       faucetAccount.id(),
-      window.NoteType.private(),
+      window.NoteType.Private,
       BigInt(100)
     );
     let sendTransactionResult = await client.newTransaction(
@@ -270,7 +270,7 @@ export const customTransaction = async (
 
       let noteMetadata = new window.NoteMetadata(
         faucetAccount.id(),
-        window.NoteType.private(),
+        window.NoteType.Private,
         window.NoteTag.fromAccountId(
           walletAccount.id(),
           window.NoteExecutionMode.newLocal()
@@ -287,12 +287,12 @@ export const customTransaction = async (
       let noteScript = `
             # Custom P2ID note script
             #
-            # This note script asserts that the note args are exactly the same as passed 
+            # This note script asserts that the note args are exactly the same as passed
             # (currently defined as {expected_note_arg_1} and {expected_note_arg_2}).
-            # Since the args are too big to fit in a single note arg, we provide them via advice inputs and 
+            # Since the args are too big to fit in a single note arg, we provide them via advice inputs and
             # address them via their commitment (noted as NOTE_ARG)
-            # This note script is based off of the P2ID note script because notes currently need to have 
-            # assets, otherwise it could have been boiled down to the assert. 
+            # This note script is based off of the P2ID note script because notes currently need to have
+            # assets, otherwise it could have been boiled down to the assert.
 
             use.miden::account
             use.miden::note
@@ -351,7 +351,7 @@ export const customTransaction = async (
             begin
                 # push data from the advice map into the advice stack
                 adv.push_mapval
-                # => [NOTE_ARG] 
+                # => [NOTE_ARG]
 
                 # memory address where to write the data
                 push.${memAddress}
@@ -363,13 +363,13 @@ export const customTransaction = async (
                 # => [target_mem_addr']
                 dropw
                 # => []
-                
+
                 # read first word
                 push.${memAddress}
                 # => [data_mem_address]
                 mem_loadw
                 # => [NOTE_ARG_1]
-                
+
                 push.${expectedNoteArg1} assert_eqw.err=101
                 # => []
 
@@ -541,7 +541,7 @@ const customTxWithMultipleNotes = async (
 
       let noteMetadata = new window.NoteMetadata(
         senderAccountId,
-        window.NoteType.public(),
+        window.NoteType.Public,
         window.NoteTag.fromAccountId(
           targetAccountId,
           window.NoteExecutionMode.newLocal()
@@ -681,7 +681,7 @@ export const discardedTransaction =
       let mintTransactionRequest = client.newMintTransactionRequest(
         senderAccount.id(),
         faucetAccount.id(),
-        window.NoteType.private(),
+        window.NoteType.Private,
         BigInt(1000)
       );
       let mintTransactionResult = await client.newTransaction(
@@ -710,7 +710,7 @@ export const discardedTransaction =
         senderAccount.id(),
         targetAccount.id(),
         faucetAccount.id(),
-        window.NoteType.private(),
+        window.NoteType.Private,
         BigInt(100),
         1
       );

--- a/crates/web-client/test/webClientTestUtils.ts
+++ b/crates/web-client/test/webClientTestUtils.ts
@@ -34,7 +34,7 @@ export const mintTransaction = async (
       const mintTransactionRequest = client.newMintTransactionRequest(
         targetAccountId,
         faucetAccountId,
-        window.NoteType.private(),
+        window.NoteType.Private,
         BigInt(1000)
       );
       const mintTransactionResult = await client.newTransaction(
@@ -100,7 +100,7 @@ export const sendTransaction = async (
       let mintTransactionRequest = client.newMintTransactionRequest(
         senderAccountId,
         window.AccountId.fromHex(_faucetAccountId),
-        window.NoteType.private(),
+        window.NoteType.Private,
         BigInt(_amount)
       );
       let mintTransactionResult = await client.newTransaction(
@@ -143,7 +143,7 @@ export const sendTransaction = async (
         senderAccountId,
         targetAccountId,
         faucetAccountId,
-        window.NoteType.public(),
+        window.NoteType.Public,
         BigInt(_amount),
         _recallHeight
       );

--- a/crates/web-client/yarn.lock
+++ b/crates/web-client/yarn.lock
@@ -82,7 +82,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -407,11 +407,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-binaryen@^121.0.0:
-  version "121.0.0"
-  resolved "https://registry.npmjs.org/binaryen/-/binaryen-121.0.0.tgz"
-  integrity sha512-St5LX+CmVdDQMf+DDHWdne7eDK+8tH9TE4Kc+Xk3s5+CzVYIKeJbWuXgsKVbkdLJXGUc2eflFqjThQy555mBag==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
@@ -485,7 +480,7 @@ chai-as-promised@^8.0.0:
   dependencies:
     check-error "^2.0.0"
 
-chai@^5.1.1, "chai@>= 2.1.2 < 6":
+chai@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz"
   integrity sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==
@@ -584,15 +579,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colorette@^1.1.0:
   version "1.4.0"
@@ -665,19 +660,19 @@ data-uri-to-buffer@^6.0.2:
   resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz"
   integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
 
+debug@4, debug@^4.1.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"
+  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.1.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@4:
-  version "4.3.6"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz"
-  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
-  dependencies:
-    ms "2.1.2"
 
 decamelize@^4.0.0:
   version "4.0.0"
@@ -712,7 +707,7 @@ degenerator@^5.0.0:
     escodegen "^2.1.0"
     esprima "^4.0.1"
 
-devtools-protocol@*, devtools-protocol@0.0.1330662:
+devtools-protocol@0.0.1330662:
   version "0.0.1330662"
   resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1330662.tgz"
   integrity sha512-pzh6YQ8zZfz3iKlCvgzVCu22NdpZ8hNmwU6WnQjNVquh0A9iVosPtNLWDwaWVGyrntQlltPFztTMK5Cg6lfCuw==
@@ -1044,18 +1039,7 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.3:
-  version "8.1.0"
-  resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
-glob@^8.1.0:
+glob@^8.0.3, glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -1530,15 +1514,15 @@ mocha@^10.7.3:
     yargs-parser "^20.2.9"
     yargs-unparser "^2.0.0"
 
-ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 netmask@^2.0.2:
   version "2.0.2"
@@ -1863,7 +1847,7 @@ rollup-plugin-copy@^3.5.0:
     globby "10.0.1"
     is-plain-object "^3.0.0"
 
-rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0, rollup@^2.68.0||^3.0.0||^4.0.0, rollup@^2.78.0||^3.0.0||^4.0.0, rollup@^3.27.2:
+rollup@^3.27.2:
   version "3.29.4"
   resolved "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz"
   integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
@@ -1877,7 +1861,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.1.0, safe-buffer@5.1.2:
+safe-buffer@5.1.2, safe-buffer@^5.1.0:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -2150,7 +2134,7 @@ typed-query-selector@^2.12.0:
   resolved "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz"
   integrity sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==
 
-typescript@^5.5.4, typescript@>=2.7, typescript@>=4.9.5:
+typescript@^5.5.4:
   version "5.5.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz"
   integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==


### PR DESCRIPTION
This PR changes the web client's NoteType implementation to be an enum for easier consumption in TypeScript, as the static methods didn't work with type-checking e.g. NoteType.public() == NoteType.public() evaluates to false.

The main downside to this approach is that wasm enums can only have literal values, so we have to keep the underlying u8 values in line with the values defined in miden-lib