### PR TITLE
chore: make non-default option lowercase when asking for confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Updated Web Client README and Documentation (#808).
 * [BREAKING] Removed `script_roots` mod in favor of `WellKnownNote` (#834).
+* Made non-default options lowercase when prompting for transaction confirmation (#843)
 
 ## 0.8.1 (2025-03-28)
 

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -351,7 +351,7 @@ async fn execute_transaction(
     print_transaction_details(&transaction_execution_result)?;
     if !force {
         println!(
-            "\nContinue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (Y/N)"
+            "\nContinue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (y/N)"
         );
         let mut proceed_str: String = String::new();
         io::stdin().read_line(&mut proceed_str).expect("Should read line");

--- a/bin/miden-cli/src/commands/new_transactions.rs
+++ b/bin/miden-cli/src/commands/new_transactions.rs
@@ -351,7 +351,7 @@ async fn execute_transaction(
     print_transaction_details(&transaction_execution_result)?;
     if !force {
         println!(
-            "\nContinue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (y/N)"
+            "\nContinue with proving and submission? Changes will be irreversible once the proof is finalized on the network (y/N)"
         );
         let mut proceed_str: String = String::new();
         io::stdin().read_line(&mut proceed_str).expect("Should read line");

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -263,7 +263,7 @@ TX Summary:
 
 ...
 
-Continue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (Y/N)
+Continue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (y/N)
 ```
 
 This confirmation can be skipped in non-interactive environments by providing the `--force` flag (`miden send --force ...`):

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -263,7 +263,7 @@ TX Summary:
 
 ...
 
-Continue with proving and submission? Changes will be irreversible once the proof is finalized on the rollup (y/N)
+Continue with proving and submission? Changes will be irreversible once the proof is finalized on the network (y/N)
 ```
 
 This confirmation can be skipped in non-interactive environments by providing the `--force` flag (`miden send --force ...`):


### PR DESCRIPTION
Currently, when prompting for transaction confirmation, both options are in uppercase; even though only one of them is the default. 

This PR underscores the "yes" option to indicate that it's not the default; thus making the CLI more aligned with other CLI tools.

