### PR TITLE
Export `import_account_by_id` to WebClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.2 (TBD)
 
 * Converted Web Client `NoteType` class to `enum` (#831)
+* Exported `import_account_by_id` function to Web Client (#858)
 
 ## 0.8.1 (2025-03-28)
 

--- a/crates/web-client/src/import.rs
+++ b/crates/web-client/src/import.rs
@@ -87,7 +87,7 @@ impl WebClient {
             .get_mut_inner()
             .ok_or_else(|| JsValue::from_str("Client not initialized"))?;
 
-        let native_id: NativeAccountId = NativeAccountId::from(account_id);
+        let native_id: NativeAccountId = account_id.into();
 
         client
             .import_account_by_id(native_id)

--- a/crates/web-client/test/import.test.ts
+++ b/crates/web-client/test/import.test.ts
@@ -33,6 +33,20 @@ const importWalletFromSeed = async (
   );
 };
 
+const importAccountById = async (accountId: string) => {
+  return await testingPage.evaluate(
+    async (id) => {
+      const client = window.client;
+      const account = await client.importAccountById(id);
+      return {
+        accountId: account.id().toString(),
+        accountCommitment: account.commitment().toHex(),
+      };
+    },
+    accountId
+  );
+};
+
 describe("import from seed", () => {
   it("should import same public account from seed", async () => {
     const walletSeed = new Uint8Array(32);
@@ -70,6 +84,48 @@ describe("import from seed", () => {
       initialWallet.id
     );
 
+    const restoredBalance = await getAccountBalance(
+      initialWallet.id,
+      faucet.id
+    );
+
+    expect(restoredBalance.toString()).to.equal(initialBalance);
+    expect(restoredAccountCommitment).to.equal(initialCommitment);
+  });
+});
+
+describe("import public account by id", () => {
+  it("should import public account from id", async () => {
+    const walletSeed = new Uint8Array(32);
+    crypto.getRandomValues(walletSeed);
+
+    const mutable = false;
+    const storageMode = StorageMode.PUBLIC;
+
+    const initialWallet = await createNewWallet({
+      storageMode,
+      mutable,
+      walletSeed,
+    });
+    const faucet = await createNewFaucet();
+    const { targetAccountBalanace: initialBalance } = await fundAccountFromFaucet(
+      initialWallet.id,
+      faucet.id
+    );
+    const { commitment: initialCommitment } = await getAccount(
+      initialWallet.id
+    );
+
+    await clearStore();
+
+    const { accountId: restoredAccountId } = await importAccountById(
+      initialWallet.id
+    );
+    expect(restoredAccountId).to.equal(initialWallet.id);
+
+    const { commitment: restoredAccountCommitment } = await getAccount(
+      initialWallet.id
+    );
     const restoredBalance = await getAccountBalance(
       initialWallet.id,
       faucet.id

--- a/crates/web-client/test/import.test.ts
+++ b/crates/web-client/test/import.test.ts
@@ -34,17 +34,16 @@ const importWalletFromSeed = async (
 };
 
 const importAccountById = async (accountId: string) => {
-  return await testingPage.evaluate(
-    async (id) => {
-      const client = window.client;
-      const account = await client.importAccountById(id);
-      return {
-        accountId: account.id().toString(),
-        accountCommitment: account.commitment().toHex(),
-      };
-    },
-    accountId
-  );
+  return await testingPage.evaluate(async (id) => {
+    const client = window.client;
+    const _accountId = window.AccountId.fromHex(id);
+    await client.importAccountById(_accountId);
+    const account = await client.getAccount(_accountId);
+    return {
+      accountId: account?.id().toString(),
+      accountCommitment: account?.commitment().toHex(),
+    };
+  }, accountId);
 };
 
 describe("import from seed", () => {
@@ -108,10 +107,8 @@ describe("import public account by id", () => {
       walletSeed,
     });
     const faucet = await createNewFaucet();
-    const { targetAccountBalanace: initialBalance } = await fundAccountFromFaucet(
-      initialWallet.id,
-      faucet.id
-    );
+    const { targetAccountBalanace: initialBalance } =
+      await fundAccountFromFaucet(initialWallet.id, faucet.id);
     const { commitment: initialCommitment } = await getAccount(
       initialWallet.id
     );


### PR DESCRIPTION
This PR adds the `import_account_by_id` functionality that was added in PR #733 to the WebClient. This resolves issue #855.

This PR makes it possible to import a public account on the WebClient:
```ts
const account = await client.importAccountById("0xb584c3769ab90b000004c780363668");
```
This function only works if the Account is public. Obviously this would only be used for public accounts that do not require authentication when submitting state changing transactions, i.e. a counter contract.

I added a test that deploys a public account, then deletes the store, then reimports it via the `importAccountById` method.

To run the tests:

1) Run the node locally by cloning the node repository, then run the following:
```
miden-node bundled bootstrap \
  --data-directory data \
  --accounts-directory accounts \
  --config genesis.toml
```
Start the node:
```
miden-node bundled start \
  --data-directory data \
  --rpc.url http://0.0.0.0:57291
```

2) Checkout this branch and run
```
cd crates/web-client
npm i
npm test -- --grep "import public account by id" --invert=false
```

If all looks good, since this is a non breaking change, would it be possible to merge it to main and publish an updated version of the WebClient-SDK? 